### PR TITLE
Add "import package" message in README.

### DIFF
--- a/tracing/README.md
+++ b/tracing/README.md
@@ -11,6 +11,14 @@ interest.
     </dependency>
 ```
 2. Enable tracing with annotation `@EnableZipkinTracing` on your application entry or configuration
+
+Import `tracing.zipkin.EnableZipkinTracing` package
+
+```
+import org.apache.servicecomb.tracing.zipkin.EnableZipkinTracing;
+```
+Add annotation `@EnableZipkinTracing`
+
 ```
 @SpringBootApplication
 @EnableZipkinTracing
@@ -21,6 +29,14 @@ public class ZipkinSpanTestApplication {
 }
 ```
 3. Add new span to the point of interest with annotation `@Span`
+
+Import `tracing.Span` package
+
+```
+import org.apache.servicecomb.tracing.Span;
+```
+Add annotation `@Span`
+
 ```
 @Component
 public class SlowRepoImpl implements SlowRepo {


### PR DESCRIPTION
In README, we should describe the steps of use in more detailed. I'd prefer to add "import package" message in README, because it may be helpful for new hand.