### PR TITLE
upgrade zipkin 2.4.2 to zipkin 2.9.3

### DIFF
--- a/java-chassis-dependencies/pom.xml
+++ b/java-chassis-dependencies/pom.xml
@@ -51,9 +51,9 @@
     <narayana.version>5.3.2.Final</narayana.version>
     <cxf.version>3.1.6</cxf.version>
     <logback.version>1.1.7</logback.version>
-    <brave.version>4.13.1</brave.version>
-    <zipkin.version>2.4.2</zipkin.version>
-    <zipkin-reporter.version>2.2.2</zipkin-reporter.version>
+    <brave.version>5.1.0</brave.version>
+    <zipkin.version>2.9.3</zipkin.version>
+    <zipkin-reporter.version>2.7.13</zipkin-reporter.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Upgrade the version of  zipkin kit, Brave from 4.13.1 to 5.1.0, zipkin from 2.4.2 to 2.9.3, zipkin-reporter from 2.2.2 to 2.7.13. 

 In the new zipkin kit ,  APIs  are not changed and we have keep compatible with new version and older version.

After upgrading new version,  java chassis compiled successfully .And bmi program running result and zipkin function is OK. 