### PR TITLE
[SCB-1134] change default verticle instance count

### DIFF
--- a/core/src/test/resources/microservice.yaml
+++ b/core/src/test/resources/microservice.yaml
@@ -23,19 +23,7 @@ servicecomb:
   service:
     registry:
       address: http://127.0.0.1:30100
-  rest:
-    client:
-      thread-count: 10
-      connection-pool-per-thread: 1
-    server:
-      thread-count: 10
-  highway:
-    thread-count: 1
-    connection-pool-per-thread: 10
   handler:
     chain:
       Consumer:
         default: simpleLB
-  metrics:
-    cycle:
-      ms: 1000

--- a/coverage-reports/pom.xml
+++ b/coverage-reports/pom.xml
@@ -92,6 +92,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.servicecomb</groupId>
+      <artifactId>transport-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.servicecomb</groupId>
       <artifactId>transport-rest-client</artifactId>
     </dependency>
     <dependency>

--- a/demo/demo-edge/authentication/src/main/resources/microservice.yaml
+++ b/demo/demo-edge/authentication/src/main/resources/microservice.yaml
@@ -26,4 +26,4 @@ servicecomb:
   rest:
     address: 127.0.0.1:7070
     server:
-      thread-count: 10
+      verticle-count: 10

--- a/demo/demo-edge/business-1-1-0/src/main/resources/microservice.yaml
+++ b/demo/demo-edge/business-1-1-0/src/main/resources/microservice.yaml
@@ -26,4 +26,4 @@ servicecomb:
   rest:
     address: 127.0.0.1:8090
     server:
-      thread-count: 1
+      verticle-count: 1

--- a/demo/demo-edge/business-1.0.0/src/main/resources/microservice.yaml
+++ b/demo/demo-edge/business-1.0.0/src/main/resources/microservice.yaml
@@ -26,4 +26,4 @@ servicecomb:
   rest:
     address: 127.0.0.1:8080
     server:
-      thread-count: 1
+      verticle-count: 1

--- a/demo/demo-edge/business-2.0.0/src/main/resources/microservice.yaml
+++ b/demo/demo-edge/business-2.0.0/src/main/resources/microservice.yaml
@@ -26,4 +26,4 @@ servicecomb:
   rest:
     address: 127.0.0.1:8091
     server:
-      thread-count: 1
+      verticle-count: 1

--- a/demo/demo-edge/edge-service/src/main/resources/microservice.yaml
+++ b/demo/demo-edge/edge-service/src/main/resources/microservice.yaml
@@ -26,9 +26,9 @@ servicecomb:
   rest:
     address: 127.0.0.1:18080
     server:
-      thread-count: 8
+      verticle-count: 8
     client:
-      thread-count: 8
+      verticle-count: 8
   handler:
     chain:
       Consumer:

--- a/demo/perf/src/main/resources/microservice.yaml
+++ b/demo/perf/src/main/resources/microservice.yaml
@@ -26,17 +26,21 @@ servicecomb:
   rest:
     address: 0.0.0.0:8080?sslEnabled=false
     server:
-      thread-count: 8
+      verticle-count: 8
     client:
-      thread-count: 8
+      verticle-count: 8
       connection:
         maxPoolSize: 30
   highway:
     address: 0.0.0.0:7070?sslEnabled=false
     server:
-      thread-count: 8
+      verticle-count: 8
     client:
-      thread-count: 8
+      verticle-count: 8
+  executor:
+    default:
+      group: 4
+      thread-per-group: 4
   references:
     transport: highway
   metrics:

--- a/foundations/foundation-test-scaffolding/src/main/java/org/apache/servicecomb/foundation/test/scaffolding/log/LogCollector.java
+++ b/foundations/foundation-test-scaffolding/src/main/java/org/apache/servicecomb/foundation/test/scaffolding/log/LogCollector.java
@@ -58,6 +58,10 @@ public class LogCollector {
     return events;
   }
 
+  public LoggingEvent getLastEvents() {
+    return events.get(events.size() - 1);
+  }
+
   public void teardown() {
     Logger.getRootLogger().removeAppender(appender);
   }

--- a/integration-tests/it-common/src/main/resources/microservice.yaml
+++ b/integration-tests/it-common/src/main/resources/microservice.yaml
@@ -36,16 +36,16 @@ servicecomb:
   rest:
     address: 0.0.0.0:0
     server:
-      thread-count: 8
+      verticle-count: 8
     client:
-      thread-count: 8
+      verticle-count: 8
       connection:
         maxPoolSize: 30
   highway:
     address: 0.0.0.0:0
     server:
-      thread-count: 8
+      verticle-count: 8
     client:
-      thread-count: 8
+      verticle-count: 8
   uploads:
     directory: target

--- a/java-chassis-dependencies/pom.xml
+++ b/java-chassis-dependencies/pom.xml
@@ -1073,6 +1073,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.servicecomb</groupId>
+        <artifactId>transport-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.servicecomb</groupId>
         <artifactId>transport-highway</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/transports/transport-common/pom.xml
+++ b/transports/transport-common/pom.xml
@@ -15,21 +15,38 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
   <parent>
+    <artifactId>transports</artifactId>
     <groupId>org.apache.servicecomb</groupId>
-    <artifactId>java-chassis-parent</artifactId>
     <version>1.2.0-SNAPSHOT</version>
-    <relativePath>../parent</relativePath>
   </parent>
-  <artifactId>transports</artifactId>
-  <name>Java Chassis::Transports</name>
-  <packaging>pom</packaging>
-  <modules>
-    <module>transport-highway</module>
-    <module>transport-rest</module>
-    <module>transport-common</module>
-  </modules>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>transport-common</artifactId>
+  <name>Java Chassis::Transports::common</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.servicecomb</groupId>
+      <artifactId>foundation-config</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.servicecomb</groupId>
+      <artifactId>foundation-test-scaffolding</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 </project>

--- a/transports/transport-common/src/main/java/org/apache/servicecomb/transport/common/TransportConfigUtils.java
+++ b/transports/transport-common/src/main/java/org/apache/servicecomb/transport/common/TransportConfigUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.transport.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.config.DynamicPropertyFactory;
+
+public final class TransportConfigUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TransportConfigUtils.class);
+
+  private TransportConfigUtils() {
+  }
+
+  // old verticle count key is ambiguous
+  // suggest to use new name
+  public static int readVerticleCount(String key, String deprecatedKey) {
+    int count = DynamicPropertyFactory.getInstance().getIntProperty(key, -1).get();
+    if (count > 0) {
+      return count;
+    }
+
+    count = DynamicPropertyFactory.getInstance().getIntProperty(deprecatedKey, -1).get();
+    if (count > 0) {
+      LOGGER.warn("{} is ambiguous, and deprecated, suggest to use {}.", deprecatedKey, key);
+      return count;
+    }
+
+    // default value
+    count = Runtime.getRuntime().availableProcessors() > 8 ? 8 : Runtime.getRuntime().availableProcessors();
+    LOGGER.info("{} not defined, set to {}.", key, count);
+    return count;
+  }
+}

--- a/transports/transport-common/src/test/java/org/apache/servicecomb/transport/common/TestTransportConfigUtils.java
+++ b/transports/transport-common/src/test/java/org/apache/servicecomb/transport/common/TestTransportConfigUtils.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.transport.common;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
+import org.apache.servicecomb.foundation.test.scaffolding.log.LogCollector;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import mockit.Mock;
+import mockit.MockUp;
+
+public class TestTransportConfigUtils {
+  @Before
+  public void setup() {
+    ArchaiusUtils.resetConfig();
+  }
+
+  @AfterClass
+  public static void teardown() {
+    ArchaiusUtils.resetConfig();
+  }
+
+  static String key = "verticle-count";
+
+  static String deprecatedKey = "thread-count";
+
+  @Test
+  public void readVerticleCount_new_exist() {
+    ArchaiusUtils.setProperty(key, 10);
+
+    Assert.assertEquals(10, TransportConfigUtils.readVerticleCount(key, deprecatedKey));
+  }
+
+  @Test
+  public void readVerticleCount_old_exist() {
+    ArchaiusUtils.setProperty(deprecatedKey, 10);
+
+    LogCollector collector = new LogCollector();
+    Assert.assertEquals(10, TransportConfigUtils.readVerticleCount(key, deprecatedKey));
+    Assert.assertEquals("thread-count is ambiguous, and deprecated, suggest to use verticle-count.",
+        collector.getEvents().get(0).getMessage());
+    collector.teardown();
+  }
+
+  @Test
+  public void readVerticleCount_default_smallCpu() {
+    new MockUp<Runtime>() {
+      @Mock
+      int availableProcessors() {
+        return 7;
+      }
+    };
+
+    LogCollector collector = new LogCollector();
+    Assert.assertEquals(7, TransportConfigUtils.readVerticleCount(key, deprecatedKey));
+    Assert.assertEquals("verticle-count not defined, set to 7.",
+        collector.getLastEvents().getMessage());
+    collector.teardown();
+  }
+
+  @Test
+  public void readVerticleCount_default_bigCpu() {
+    AtomicInteger count = new AtomicInteger(8);
+    new MockUp<Runtime>() {
+      @Mock
+      int availableProcessors() {
+        return count.get();
+      }
+    };
+
+    LogCollector collector = new LogCollector();
+    Assert.assertEquals(8, TransportConfigUtils.readVerticleCount(key, deprecatedKey));
+    Assert.assertEquals("verticle-count not defined, set to 8.",
+        collector.getLastEvents().getMessage());
+
+    count.set(9);
+    collector.clear();
+    Assert.assertEquals(8, TransportConfigUtils.readVerticleCount(key, deprecatedKey));
+    Assert.assertEquals("verticle-count not defined, set to 8.",
+        collector.getLastEvents().getMessage());
+
+    collector.teardown();
+  }
+}

--- a/transports/transport-highway/pom.xml
+++ b/transports/transport-highway/pom.xml
@@ -38,6 +38,10 @@
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>common-protobuf</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.servicecomb</groupId>
+      <artifactId>transport-common</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.vertx</groupId>

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayConfig.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayConfig.java
@@ -17,7 +17,8 @@
 
 package org.apache.servicecomb.transport.highway;
 
-import com.netflix.config.DynamicIntProperty;
+import org.apache.servicecomb.transport.common.TransportConfigUtils;
+
 import com.netflix.config.DynamicLongProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.config.DynamicStringProperty;
@@ -45,14 +46,14 @@ public final class HighwayConfig {
   }
 
   public static int getServerThreadCount() {
-    DynamicIntProperty address =
-        DynamicPropertyFactory.getInstance().getIntProperty("servicecomb.highway.server.thread-count", 1);
-    return address.get();
+    return TransportConfigUtils.readVerticleCount(
+        "servicecomb.highway.server.verticle-count",
+        "servicecomb.highway.server.thread-count");
   }
 
   public static int getClientThreadCount() {
-    DynamicIntProperty address =
-        DynamicPropertyFactory.getInstance().getIntProperty("servicecomb.highway.client.thread-count", 1);
-    return address.get();
+    return TransportConfigUtils.readVerticleCount(
+        "servicecomb.highway.client.verticle-count",
+        "servicecomb.highway.client.thread-count");
   }
 }

--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayConfig.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayConfig.java
@@ -27,13 +27,16 @@ public class TestHighwayConfig {
   public void tearDown() {
     ArchaiusUtils.resetConfig();
   }
+
   @Test
   public void getServerThreadCount() {
+    ArchaiusUtils.setProperty("servicecomb.highway.server.verticle-count", 1);
     Assert.assertEquals(HighwayConfig.getServerThreadCount(), 1);
   }
 
   @Test
   public void getClientThreadCount() {
+    ArchaiusUtils.setProperty("servicecomb.highway.client.verticle-count", 1);
     Assert.assertEquals(HighwayConfig.getClientThreadCount(), 1);
   }
 

--- a/transports/transport-rest/transport-rest-client/pom.xml
+++ b/transports/transport-rest/transport-rest-client/pom.xml
@@ -34,6 +34,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.servicecomb</groupId>
+      <artifactId>transport-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.servicecomb</groupId>
       <artifactId>common-rest</artifactId>
     </dependency>
 
@@ -42,7 +46,7 @@
       <artifactId>vertx-codegen</artifactId>
       <scope>provided</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>

--- a/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/TransportClientConfig.java
+++ b/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/TransportClientConfig.java
@@ -17,6 +17,8 @@
 
 package org.apache.servicecomb.transport.rest.client;
 
+import org.apache.servicecomb.transport.common.TransportConfigUtils;
+
 import com.netflix.config.DynamicPropertyFactory;
 
 import io.vertx.core.http.HttpClientOptions;
@@ -37,7 +39,9 @@ public final class TransportClientConfig {
   }
 
   public static int getThreadCount() {
-    return DynamicPropertyFactory.getInstance().getIntProperty("servicecomb.rest.client.thread-count", 1).get();
+    return TransportConfigUtils.readVerticleCount(
+        "servicecomb.rest.client.verticle-count",
+        "servicecomb.rest.client.thread-count");
   }
 
   public static int getHttp2ConnectionMaxPoolSize() {
@@ -57,7 +61,6 @@ public final class TransportClientConfig {
         .getIntProperty("servicecomb.rest.client.http2.idleTimeoutInSeconds", TCPSSLOptions.DEFAULT_IDLE_TIMEOUT)
         .get();
   }
-
 
   public static boolean getUseAlpn() {
     return DynamicPropertyFactory.getInstance()
@@ -82,7 +85,6 @@ public final class TransportClientConfig {
         .getBooleanProperty("servicecomb.rest.client.connection.keepAlive", HttpClientOptions.DEFAULT_KEEP_ALIVE)
         .get();
   }
-
 
   public static boolean getConnectionCompression() {
     return DynamicPropertyFactory.getInstance()

--- a/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/TestTransportClientConfig.java
+++ b/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/TestTransportClientConfig.java
@@ -17,12 +17,14 @@
 
 package org.apache.servicecomb.transport.rest.client;
 
+import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TestTransportClientConfig {
   @Test
   public void getThreadCount() {
+    ArchaiusUtils.setProperty("servicecomb.rest.client.verticle-count", 1);
     Assert.assertEquals(1, TransportClientConfig.getThreadCount());
   }
 
@@ -60,7 +62,6 @@ public class TestTransportClientConfig {
   public void getConnectionKeepAlive() {
     Assert.assertTrue(TransportClientConfig.getConnectionKeepAlive());
   }
-
 
   @Test
   public void getConnectionCompression() {

--- a/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/TransportConfig.java
+++ b/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/TransportConfig.java
@@ -21,9 +21,9 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.apache.servicecomb.transport.common.TransportConfigUtils;
 import org.springframework.util.StringUtils;
 
-import com.netflix.config.DynamicIntProperty;
 import com.netflix.config.DynamicPropertyFactory;
 import com.netflix.config.DynamicStringProperty;
 
@@ -31,9 +31,6 @@ import io.vertx.core.Verticle;
 import io.vertx.core.http.HttpServerOptions;
 
 public final class TransportConfig {
-
-  public static final int DEFAULT_SERVER_THREAD_COUNT = 1;
-
   public static final int DEFAULT_SERVER_CONNECTION_IDLE_TIMEOUT_SECOND = 60;
 
   public static final boolean DEFAULT_SERVER_COMPRESSION_SUPPORT = false;
@@ -63,10 +60,9 @@ public final class TransportConfig {
   }
 
   public static int getThreadCount() {
-    DynamicIntProperty address =
-        DynamicPropertyFactory.getInstance()
-            .getIntProperty("servicecomb.rest.server.thread-count", DEFAULT_SERVER_THREAD_COUNT);
-    return address.get();
+    return TransportConfigUtils.readVerticleCount(
+        "servicecomb.rest.server.verticle-count",
+        "servicecomb.rest.server.thread-count");
   }
 
   public static int getConnectionIdleTimeoutInSeconds() {

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestTransportConfig.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestTransportConfig.java
@@ -24,6 +24,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import mockit.Mock;
+import mockit.MockUp;
+
 public class TestTransportConfig {
 
   @Before
@@ -49,6 +52,12 @@ public class TestTransportConfig {
 
   @Test
   public void testGetThreadCountNull() {
+    new MockUp<Runtime>() {
+      @Mock
+      int availableProcessors() {
+        return 1;
+      }
+    };
     Assert.assertEquals(1, TransportConfig.getThreadCount());
   }
 
@@ -154,7 +163,6 @@ public class TestTransportConfig {
     ArchaiusUtils.setProperty("servicecomb.rest.server.http2.useAlpnEnabled", false);
     Assert.assertFalse(TransportConfig.getUseAlpn());
   }
-
 
   @Test
   public void testGetMaxInitialLineLength() {


### PR DESCRIPTION
include:
 - servicecomb.rest.server.thread-count
 - servicecomb.rest.client.thread-count
 - servicecomb.highway.server.thread-count
 - servicecomb. highway.client.thread-count

change to:
 - all thread-count change to verticle-count
 - if use thread-count, print log to suggest to use new name
 - if not present configuration, then will use default setting
   - if cpu count less than 8, then verticle-count set to cpu count
   - if cpu count equals or big than 8, then verticle-count set to 8