### PR TITLE
[SCB-1266] Log4j2 marker leak

### DIFF
--- a/core/src/main/java/org/apache/servicecomb/core/SCBEngine.java
+++ b/core/src/main/java/org/apache/servicecomb/core/SCBEngine.java
@@ -42,6 +42,7 @@ import org.apache.servicecomb.core.provider.consumer.ReferenceConfig;
 import org.apache.servicecomb.core.provider.producer.ProducerProviderManager;
 import org.apache.servicecomb.core.transport.TransportManager;
 import org.apache.servicecomb.foundation.common.event.EventManager;
+import org.apache.servicecomb.foundation.common.log.LogMarkerLeakFixUtils;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.foundation.vertx.VertxUtils;
 import org.apache.servicecomb.serviceregistry.RegistryUtils;
@@ -228,6 +229,9 @@ public class SCBEngine {
 
   private void doInit() throws Exception {
     status = SCBStatus.STARTING;
+
+    // fix log4j2 leak marker problem
+    LogMarkerLeakFixUtils.fix();
 
     eventBus.register(this);
 

--- a/core/src/main/java/org/apache/servicecomb/core/tracing/ScbMarker.java
+++ b/core/src/main/java/org/apache/servicecomb/core/tracing/ScbMarker.java
@@ -16,13 +16,11 @@
  */
 package org.apache.servicecomb.core.tracing;
 
-import java.util.Collections;
-import java.util.Iterator;
-
 import org.apache.servicecomb.core.Invocation;
-import org.slf4j.Marker;
+import org.apache.servicecomb.foundation.common.log.AbstractMarker;
+import org.apache.servicecomb.foundation.common.log.NoCacheMarker;
 
-public class ScbMarker implements Marker {
+public class ScbMarker extends AbstractMarker implements NoCacheMarker {
   private static final long serialVersionUID = -1L;
 
   private final Invocation invocation;
@@ -43,47 +41,5 @@ public class ScbMarker implements Marker {
       name = invocation.getTraceId() + "-" + invocation.getInvocationId();
     }
     return name;
-  }
-
-  @Override
-  public void add(Marker reference) {
-
-  }
-
-  @Override
-  public boolean remove(Marker reference) {
-    return false;
-  }
-
-  @Deprecated
-  @Override
-  public boolean hasChildren() {
-    return false;
-  }
-
-  @Override
-  public boolean hasReferences() {
-    return false;
-  }
-
-  @SuppressWarnings("unchecked")
-  @Override
-  public Iterator<Marker> iterator() {
-    return Collections.EMPTY_LIST.iterator();
-  }
-
-  @Override
-  public boolean contains(Marker other) {
-    return false;
-  }
-
-  @Override
-  public boolean contains(String name) {
-    return false;
-  }
-
-  @Override
-  public String toString() {
-    return getName();
   }
 }

--- a/foundations/foundation-common/pom.xml
+++ b/foundations/foundation-common/pom.xml
@@ -85,5 +85,13 @@
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>foundation-test-scaffolding</artifactId>
     </dependency>
+
+    <!-- some unit test case depend on log4j1, so set this dependency after test scope area -->
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <scope>provided</scope>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/AbstractMarker.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/AbstractMarker.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.foundation.common.log;
+
+import java.util.Collections;
+import java.util.Iterator;
+
+import org.slf4j.Marker;
+
+public abstract class AbstractMarker implements Marker {
+  private static final long serialVersionUID = -1L;
+
+  @Override
+  public void add(Marker reference) {
+
+  }
+
+  @Override
+  public boolean remove(Marker reference) {
+    return false;
+  }
+
+  @Deprecated
+  @Override
+  public boolean hasChildren() {
+    return false;
+  }
+
+  @Override
+  public boolean hasReferences() {
+    return false;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public Iterator<Marker> iterator() {
+    return Collections.EMPTY_LIST.iterator();
+  }
+
+  @Override
+  public boolean contains(Marker other) {
+    return false;
+  }
+
+  @Override
+  public boolean contains(String name) {
+    return false;
+  }
+
+  @Override
+  public String toString() {
+    return getName();
+  }
+}

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/LogMarkerLeakFixUtils.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/LogMarkerLeakFixUtils.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.foundation.common.log;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.servicecomb.foundation.common.utils.ReflectUtils;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.impl.StaticMarkerBinder;
+
+/**
+ * <pre>
+ * ScbMaker.getName() is relate to invocation traceId and invocationId
+ * it's dynamic, not static
+ *
+ * this will cause log4j2 always create new Marker instance and cache them
+ * that's a memory leak problem
+ * </pre>
+ */
+public final class LogMarkerLeakFixUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LogMarkerLeakFixUtils.class);
+
+  private LogMarkerLeakFixUtils() {
+  }
+
+  @SuppressWarnings("unchecked")
+  public static void fix() {
+    Class<?> staticMarkerBinderClass = ReflectUtils.getClassByName(null, "org.slf4j.impl.StaticMarkerBinder");
+    if (staticMarkerBinderClass == null) {
+      return;
+    }
+
+    IMarkerFactory markerFactory = StaticMarkerBinder.SINGLETON.getMarkerFactory();
+    if (markerFactory.getClass().getName()
+        .equals("org.apache.servicecomb.foundation.common.log.NoCacheLog4jMarkerFactory")) {
+      return;
+    }
+
+    if (markerFactory.getClass().getName().equals("org.apache.logging.slf4j.Log4jMarkerFactory")) {
+      fixMarkerFactory(markerFactory, new NoCacheLog4jMarkerFactory(),
+          "Failed to fix Log4jMarkerFactory leak problem.");
+      LOGGER.info("fixed Log4jMarkerFactory marker leak problem.");
+      return;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void fixMarkerFactory(IMarkerFactory orgFactory, NoCacheLog4jMarkerFactory fixedFactory,
+      String failMessage) {
+    try {
+      Field markerField = FieldUtils.getDeclaredField(orgFactory.getClass(), "markerMap", true);
+      ConcurrentMap<String, Marker> orgMarkerMap = (ConcurrentMap<String, Marker>) FieldUtils
+          .readField(markerField, orgFactory);
+
+      ConcurrentMap<String, Marker> newMarkerMap = (ConcurrentMap<String, Marker>) FieldUtils
+          .readField(markerField, fixedFactory);
+      newMarkerMap.putAll(orgMarkerMap);
+      ReflectUtils.setField(StaticMarkerBinder.SINGLETON, "markerFactory", fixedFactory);
+    } catch (Throwable e) {
+      throw new IllegalStateException(failMessage, e);
+    }
+  }
+}

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheLog4j2Marker.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheLog4j2Marker.java
@@ -76,4 +76,9 @@ public class NoCacheLog4j2Marker extends Log4jMarker implements Marker {
   public Marker setParents(Marker... markers) {
     return this;
   }
+
+  @Override
+  public String toString() {
+    return slf4jMarker.getName();
+  }
 }

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheLog4j2Marker.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheLog4j2Marker.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.foundation.common.log;
+
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.slf4j.Log4jMarker;
+
+/**
+ * avoid log4j2 leak marker instances
+ */
+public class NoCacheLog4j2Marker extends Log4jMarker implements Marker {
+  private static final long serialVersionUID = -1L;
+
+  private final org.slf4j.Marker slf4jMarker;
+
+  public NoCacheLog4j2Marker(org.slf4j.Marker slf4jMarker) {
+    super(null);
+    this.slf4jMarker = slf4jMarker;
+  }
+
+  @Override
+  public Marker getLog4jMarker() {
+    return this;
+  }
+
+  @Override
+  public Marker addParents(Marker... markers) {
+    return this;
+  }
+
+  @Override
+  public final String getName() {
+    return slf4jMarker.getName();
+  }
+
+  @Override
+  public Marker[] getParents() {
+    return null;
+  }
+
+  @Override
+  public boolean hasParents() {
+    return false;
+  }
+
+  @Override
+  public boolean isInstanceOf(Marker m) {
+    return false;
+  }
+
+  @Override
+  public boolean isInstanceOf(String name) {
+    return false;
+  }
+
+  @Override
+  public boolean remove(Marker marker) {
+    return false;
+  }
+
+  @Override
+  public Marker setParents(Marker... markers) {
+    return this;
+  }
+}

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheLog4jMarkerFactory.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheLog4jMarkerFactory.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.foundation.common.log;
+
+import org.apache.logging.slf4j.Log4jMarkerFactory;
+import org.slf4j.Marker;
+
+/**
+ * avoid log4j2 leak marker instances
+ */
+public class NoCacheLog4jMarkerFactory extends Log4jMarkerFactory {
+  @Override
+  public Marker getMarker(Marker slf4jMarker) {
+    if (slf4jMarker instanceof NoCacheMarker) {
+      return new NoCacheLog4j2Marker(slf4jMarker);
+    }
+
+    return super.getMarker(slf4jMarker);
+  }
+}

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheMarker.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/log/NoCacheMarker.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.foundation.common.log;
+
+public interface NoCacheMarker {
+}

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/ReflectUtils.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/ReflectUtils.java
@@ -91,4 +91,13 @@ public final class ReflectUtils {
   public static <T> T constructArrayType(Class<?> cls) {
     return (T) Array.newInstance(cls, 0).getClass();
   }
+
+  public static Class<?> getClassByName(ClassLoader classLoader, String clsName) {
+    classLoader = JvmUtils.correctClassLoader(classLoader);
+    try {
+      return classLoader.loadClass(clsName);
+    } catch (ClassNotFoundException e) {
+      return null;
+    }
+  }
 }

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/log/TestLogMarkerLeakFixUtils.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/log/TestLogMarkerLeakFixUtils.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.foundation.common.log;
+
+import org.apache.logging.slf4j.Log4jMarkerFactory;
+import org.apache.servicecomb.foundation.common.utils.ReflectUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.IMarkerFactory;
+import org.slf4j.impl.StaticMarkerBinder;
+
+import mockit.Expectations;
+
+public class TestLogMarkerLeakFixUtils {
+  static IMarkerFactory orgMarkerFactory = StaticMarkerBinder.SINGLETON.getMarkerFactory();
+
+  @After
+  public void tearDown() {
+    ReflectUtils.setField(StaticMarkerBinder.SINGLETON, "markerFactory", orgMarkerFactory);
+  }
+
+  @Test
+  public void noBinder() {
+    new Expectations(ReflectUtils.class) {
+      {
+        ReflectUtils.getClassByName(null, "org.slf4j.impl.StaticMarkerBinder");
+        result = null;
+      }
+    };
+
+    // nothing happened
+    LogMarkerLeakFixUtils.fix();
+  }
+
+  // log4j1 not support marker, no need to fix
+  @Test
+  public void log4j1() {
+    Assert.assertEquals("org.slf4j.helpers.BasicMarkerFactory", orgMarkerFactory.getClass().getName());
+
+    LogMarkerLeakFixUtils.fix();
+
+    Assert.assertSame(orgMarkerFactory, StaticMarkerBinder.SINGLETON.getMarkerFactory());
+  }
+
+  // log4j2 need to adapt slf4j marker to log4j2 marker, and always cache the adapt result
+  // need to fix
+  @Test
+  public void log4j2() {
+    Assert.assertEquals("org.slf4j.helpers.BasicMarkerFactory", orgMarkerFactory.getClass().getName());
+
+    // change to log4j2
+    ReflectUtils.setField(StaticMarkerBinder.SINGLETON, "markerFactory", new Log4jMarkerFactory());
+    Assert.assertEquals("org.apache.logging.slf4j.Log4jMarkerFactory",
+        StaticMarkerBinder.SINGLETON.getMarkerFactory().getClass().getName());
+
+    LogMarkerLeakFixUtils.fix();
+
+    Assert.assertEquals(NoCacheLog4jMarkerFactory.class, StaticMarkerBinder.SINGLETON.getMarkerFactory().getClass());
+  }
+
+  // logback no need to adapt marker type, just use it directly, no need to fix
+  @Test
+  public void logback() {
+    Assert.assertEquals("org.slf4j.helpers.BasicMarkerFactory", orgMarkerFactory.getClass().getName());
+
+    LogMarkerLeakFixUtils.fix();
+
+    Assert.assertSame(orgMarkerFactory, StaticMarkerBinder.SINGLETON.getMarkerFactory());
+  }
+}

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/log/TestNoCacheLog4jMarkerFactory.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/log/TestNoCacheLog4jMarkerFactory.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.foundation.common.log;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.logging.slf4j.Log4jMarkerFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Marker;
+
+public class TestNoCacheLog4jMarkerFactory {
+  static class TestNoCacheMarker extends AbstractMarker implements NoCacheMarker {
+    private static final long serialVersionUID = -1L;
+
+    @Override
+    public String getName() {
+      return null;
+    }
+  }
+
+  static class TestMarker extends AbstractMarker {
+    private static final long serialVersionUID = -1L;
+
+    String name;
+
+    @Override
+    public String getName() {
+      return name;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void noCache() throws IllegalAccessException {
+    NoCacheLog4jMarkerFactory markerFactory = new NoCacheLog4jMarkerFactory();
+    Field field = FieldUtils.getDeclaredField(Log4jMarkerFactory.class, "markerMap", true);
+    ConcurrentMap<String, Marker> markerMap = (ConcurrentMap<String, Marker>) FieldUtils
+        .readField(field, markerFactory);
+
+    TestNoCacheMarker marker = new TestNoCacheMarker();
+    Marker newMarker = markerFactory.getMarker(marker);
+
+    Assert.assertSame(NoCacheLog4j2Marker.class, newMarker.getClass());
+    Assert.assertEquals(0, markerMap.size());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void cache() throws IllegalAccessException {
+    NoCacheLog4jMarkerFactory markerFactory = new NoCacheLog4jMarkerFactory();
+    Field field = FieldUtils.getDeclaredField(Log4jMarkerFactory.class, "markerMap", true);
+    ConcurrentMap<String, Marker> markerMap = (ConcurrentMap<String, Marker>) FieldUtils
+        .readField(field, markerFactory);
+
+    TestMarker marker = new TestMarker();
+
+    {
+      Assert.assertEquals(0, markerMap.size());
+
+      marker.name = "1";
+      Marker newMarker = markerFactory.getMarker(marker);
+
+      Assert.assertEquals("org.apache.logging.slf4j.Log4jMarker", newMarker.getClass().getName());
+      Assert.assertEquals(1, markerMap.size());
+    }
+
+    {
+      Assert.assertEquals(1, markerMap.size());
+
+      marker.name = "2";
+      Marker newMarker = markerFactory.getMarker(marker);
+
+      Assert.assertEquals("org.apache.logging.slf4j.Log4jMarker", newMarker.getClass().getName());
+      Assert.assertEquals(2, markerMap.size());
+    }
+  }
+}

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/log/TestNoCacheLog4jMarkerFactory.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/log/TestNoCacheLog4jMarkerFactory.java
@@ -26,15 +26,6 @@ import org.junit.Test;
 import org.slf4j.Marker;
 
 public class TestNoCacheLog4jMarkerFactory {
-  static class TestNoCacheMarker extends AbstractMarker implements NoCacheMarker {
-    private static final long serialVersionUID = -1L;
-
-    @Override
-    public String getName() {
-      return null;
-    }
-  }
-
   static class TestMarker extends AbstractMarker {
     private static final long serialVersionUID = -1L;
 
@@ -46,6 +37,10 @@ public class TestNoCacheLog4jMarkerFactory {
     }
   }
 
+  static class TestNoCacheMarker extends TestMarker implements NoCacheMarker {
+    private static final long serialVersionUID = -1L;
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void noCache() throws IllegalAccessException {
@@ -55,8 +50,10 @@ public class TestNoCacheLog4jMarkerFactory {
         .readField(field, markerFactory);
 
     TestNoCacheMarker marker = new TestNoCacheMarker();
+    marker.name = "name";
     Marker newMarker = markerFactory.getMarker(marker);
 
+    Assert.assertEquals(marker.name, newMarker.toString());
     Assert.assertSame(NoCacheLog4j2Marker.class, newMarker.getClass());
     Assert.assertEquals(0, markerMap.size());
   }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/utils/ClassUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/utils/ClassUtils.java
@@ -26,7 +26,7 @@ import javax.lang.model.SourceVersion;
 
 import org.apache.servicecomb.common.javassist.ClassConfig;
 import org.apache.servicecomb.common.javassist.JavassistUtils;
-import org.apache.servicecomb.foundation.common.utils.JvmUtils;
+import org.apache.servicecomb.foundation.common.utils.ReflectUtils;
 import org.apache.servicecomb.swagger.converter.ConverterMgr;
 import org.apache.servicecomb.swagger.converter.SwaggerToClassGenerator;
 import org.apache.servicecomb.swagger.generator.core.OperationGenerator;
@@ -44,12 +44,7 @@ public final class ClassUtils {
   }
 
   public static Class<?> getClassByName(ClassLoader classLoader, String clsName) {
-    classLoader = JvmUtils.correctClassLoader(classLoader);
-    try {
-      return classLoader.loadClass(clsName);
-    } catch (ClassNotFoundException e) {
-      return null;
-    }
+    return ReflectUtils.getClassByName(classLoader, clsName);
   }
 
   // 将一系列body parameter包装成一个class


### PR DESCRIPTION
ScbMarker.getName() is relate to traceId and invocationId, it's dynamic

log4j2 always convert slf4j marker to log4j marker type, and cache the instance by name, that will cause a memory leak problem.

log4j1 not support marker feature, no problem

logback use slf4j marker instance directly, no problem