### PR TITLE
SCB-1275 Fixed the starting error of bmi example

### DIFF
--- a/samples/bmi/pom.xml
+++ b/samples/bmi/pom.xml
@@ -19,13 +19,6 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.springframework.boot</groupId>
-    <artifactId>spring-boot-starter-parent</artifactId>
-    <version>1.5.12.RELEASE</version>
-    <relativePath/> <!-- lookup parent from repository -->
-  </parent>
-
   <groupId>org.apache.servicecomb.samples</groupId>
   <artifactId>bmi</artifactId>
   <name>Java Chassis::Samples::BMI</name>
@@ -44,6 +37,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
     <java-chassis.version>${project.version}</java-chassis.version>
+    <spring-boot-1.version>1.5.14.RELEASE</spring-boot-1.version>
   </properties>
 
   <dependencyManagement>
@@ -55,6 +49,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot-1.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -62,6 +63,10 @@
     <dependency>
       <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
The issue is caused by bmi example is base on the spring-boot parent pom. 
I just put the java-chassis BOM and spring-boot BOM together to address the validate API version issue.