### PR TITLE
【SCB-1615】Extended dynamic configuration support for Nacos

### DIFF
--- a/dynamic-config/config-cc/pom.xml
+++ b/dynamic-config/config-cc/pom.xml
@@ -51,6 +51,11 @@
       <artifactId>vertx-codegen</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/dynamic-config/config-nacos/pom.xml
+++ b/dynamic-config/config-nacos/pom.xml
@@ -25,8 +25,8 @@
     <version>2.0.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>config-apollo</artifactId>
-  <name>Java Chassis::Dynamic Config::Apollo</name>
+  <artifactId>config-nacos</artifactId>
+  <name>Java Chassis::Dynamic Config::Nacos</name>
   <dependencies>
     <dependency>
       <groupId>org.apache.servicecomb</groupId>
@@ -43,6 +43,11 @@
     <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
+    </dependency>
+    <!--nacos client-->
+    <dependency>
+      <groupId>com.alibaba.nacos</groupId>
+      <artifactId>nacos-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/archaius/sources/NacosConfigurationSourceImpl.java
+++ b/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/archaius/sources/NacosConfigurationSourceImpl.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.config.archaius.sources;
+
+import static com.netflix.config.WatchedUpdateResult.createIncremental;
+import static org.apache.servicecomb.config.client.ConfigurationAction.CREATE;
+import static org.apache.servicecomb.config.client.ConfigurationAction.DELETE;
+import static org.apache.servicecomb.config.client.ConfigurationAction.SET;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import javax.validation.constraints.NotNull;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+import org.apache.commons.configuration.Configuration;
+import org.apache.servicecomb.config.ConfigMapping;
+import org.apache.servicecomb.config.client.NacosClient;
+import org.apache.servicecomb.config.client.NacosConfig;
+import org.apache.servicecomb.config.client.ConfigurationAction;
+import org.apache.servicecomb.config.spi.ConfigCenterConfigurationSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.netflix.config.WatchedUpdateListener;
+import com.netflix.config.WatchedUpdateResult;
+
+public class NacosConfigurationSourceImpl implements ConfigCenterConfigurationSource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConfigCenterConfigurationSource.class);
+
+  private final Map<String, Object> valueCache = new ConcurrentHashMap<>();
+
+  private List<WatchedUpdateListener> listeners = new CopyOnWriteArrayList<>();
+
+  private static final String NACOS_CONFIG_SERVER_ADDR_KEY = "nacos.config.serverAddr";
+
+  public NacosConfigurationSourceImpl() {
+  }
+
+  private final UpdateHandler updateHandler = new UpdateHandler();
+
+  @Override
+  public boolean isValidSource(Configuration localConfiguration) {
+    if (localConfiguration.getProperty(NACOS_CONFIG_SERVER_ADDR_KEY) == null) {
+      LOGGER.warn("Nacos configuration source is not configured!");
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public void init(Configuration localConfiguration) {
+    NacosConfig.setConcurrentCompositeConfiguration(localConfiguration);
+    init();
+  }
+
+  private void init() {
+    NacosClient nacosClient = new NacosClient(updateHandler);
+    nacosClient.refreshNacosConfig();
+  }
+
+  @Override
+  public void addUpdateListener(@NotNull WatchedUpdateListener watchedUpdateListener) {
+    listeners.add(watchedUpdateListener);
+  }
+
+  @Override
+  public void removeUpdateListener(@NotNull WatchedUpdateListener watchedUpdateListener) {
+    listeners.remove(watchedUpdateListener);
+  }
+
+  private void updateConfiguration(WatchedUpdateResult result) {
+    for (WatchedUpdateListener l : listeners) {
+      try {
+        l.updateConfiguration(result);
+      } catch (Throwable ex) {
+        LOGGER.error("Error in invoking WatchedUpdateListener", ex);
+      }
+    }
+  }
+
+  @Override
+  public Map<String, Object> getCurrentData() throws Exception {
+    return valueCache;
+  }
+
+  public List<WatchedUpdateListener> getCurrentListeners() {
+    return listeners;
+  }
+
+  public class UpdateHandler {
+    public void handle(ConfigurationAction action, Map<String, Object> config) {
+      if (config == null || config.isEmpty()) {
+        return;
+      }
+      Map<String, Object> configuration = ConfigMapping.getConvertedMap(config);
+      if (CREATE.equals(action)) {
+        valueCache.putAll(configuration);
+
+        updateConfiguration(createIncremental(ImmutableMap.copyOf(configuration),
+            null,
+            null));
+      } else if (SET.equals(action)) {
+        valueCache.putAll(configuration);
+
+        updateConfiguration(createIncremental(null,
+            ImmutableMap.copyOf(configuration),
+            null));
+      } else if (DELETE.equals(action)) {
+        configuration.keySet().forEach(valueCache::remove);
+        updateConfiguration(createIncremental(null,
+            null,
+            ImmutableMap.copyOf(configuration)));
+      } else {
+        LOGGER.error("action: {} is invalid.", action.name());
+        return;
+      }
+      LOGGER.warn("Config value cache changed: action:{}; item:{}", action.name(), configuration.keySet());
+    }
+  }
+}

--- a/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/client/ConfigurationAction.java
+++ b/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/client/ConfigurationAction.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.config.client;
+
+public enum ConfigurationAction {
+  CREATE,
+  SET,
+  DELETE
+}

--- a/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/client/NacosClient.java
+++ b/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/client/NacosClient.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.config.client;
+
+import static org.apache.servicecomb.config.client.ConfigurationAction.CREATE;
+import static org.apache.servicecomb.config.client.ConfigurationAction.DELETE;
+import static org.apache.servicecomb.config.client.ConfigurationAction.SET;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.*;
+
+import com.alibaba.nacos.api.NacosFactory;
+import com.alibaba.nacos.api.config.ConfigService;
+import com.alibaba.nacos.api.config.listener.Listener;
+import org.apache.servicecomb.config.archaius.sources.NacosConfigurationSourceImpl.UpdateHandler;
+import org.apache.servicecomb.foundation.common.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+public class NacosClient {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NacosClient.class);
+
+  private static final NacosConfig NACOS_CONFIG = NacosConfig.INSTANCE;
+
+  private static final Map<String, Object> originalConfigMap = new ConcurrentHashMap<>();
+
+  private final String serverAddr = NACOS_CONFIG.getServerAddr();
+
+  private final String dataId = NACOS_CONFIG.getDataId();
+
+  private final String group = NACOS_CONFIG.getGroup();
+
+  private final UpdateHandler updateHandler;
+
+  public NacosClient(UpdateHandler updateHandler) {
+    this.updateHandler = updateHandler;
+  }
+
+  public void refreshNacosConfig() {
+        new ConfigRefresh(serverAddr, dataId, group).refreshConfig();
+  }
+
+  class ConfigRefresh {
+      private final String serverAddr;
+      private final String dataId;
+      private final String group;
+      ConfigRefresh(String serverAddr,String dataId,String group) {
+          this.serverAddr = serverAddr;
+          this.dataId = dataId;
+          this.group = group;
+      }
+
+    @SuppressWarnings("unchecked")
+    void refreshConfig() {
+          Properties properties = new Properties();
+          properties.put("serverAddr",serverAddr);
+          properties.put("dataId",dataId);
+          properties.put("group",group);
+      try{
+        ConfigService configService = NacosFactory.createConfigService(properties);
+        String content = configService.getConfig(dataId, group, 5000);
+        Map<String, Object> body = JsonUtils.OBJ_MAPPER.readValue(content,
+              new TypeReference<Map<String, Object>>() {
+              });
+        refreshConfigItems(body);
+        configService.addListener(dataId, group, new Listener() {
+          @Override
+          public void receiveConfigInfo(String configInfo) {
+              LOGGER.info("receive from nacos:"+configInfo);
+              try {
+                  Map<String, Object> body = JsonUtils.OBJ_MAPPER.readValue(configInfo,
+                          new TypeReference<Map<String, Object>>() {
+                          });
+                  refreshConfigItems(body);
+              } catch (IOException e) {
+                  LOGGER.error("JsonObject parse config center response error: ", e);
+              }
+          }
+          @Override
+          public Executor getExecutor() {
+            return null;
+          }
+        });
+      }catch (Exception e){
+          LOGGER.error("Receive nacos config error: ", e);
+      }
+
+    }
+
+    private void refreshConfigItems(Map<String, Object> map) {
+      compareChangedConfig(originalConfigMap, map);
+      originalConfigMap.clear();
+      originalConfigMap.putAll(map);
+    }
+
+    void compareChangedConfig(Map<String, Object> before, Map<String, Object> after) {
+      Map<String, Object> itemsCreated = new HashMap<>();
+      Map<String, Object> itemsDeleted = new HashMap<>();
+      Map<String, Object> itemsModified = new HashMap<>();
+      if (before == null || before.isEmpty()) {
+        updateHandler.handle(CREATE, after);
+        return;
+      }
+      if (after == null || after.isEmpty()) {
+        updateHandler.handle(DELETE, before);
+        return;
+      }
+      after.entrySet().forEach(stringObjectEntry -> {
+        String itemKey = stringObjectEntry.getKey();
+        Object itemValue = stringObjectEntry.getValue();
+        if (!before.containsKey(itemKey)) {
+          itemsCreated.put(itemKey, itemValue);
+        } else if (!itemValue.equals(before.get(itemKey))) {
+          itemsModified.put(itemKey, itemValue);
+        }
+      });
+      for (String itemKey : before.keySet()) {
+        if (!after.containsKey(itemKey)) {
+          itemsDeleted.put(itemKey, "");
+        }
+      }
+      updateHandler.handle(CREATE, itemsCreated);
+      updateHandler.handle(SET, itemsModified);
+      updateHandler.handle(DELETE, itemsDeleted);
+    }
+  }
+}
+

--- a/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/client/NacosConfig.java
+++ b/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/client/NacosConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.config.client;
+
+import org.apache.commons.configuration.Configuration;
+
+public class NacosConfig {
+  public static final NacosConfig INSTANCE = new NacosConfig();
+
+  private static Configuration finalConfig;
+
+  private static final String DATA_ID = "nacos.config.dataId";
+
+  private static final String SERVER_ADDR = "nacos.config.serverAddr";
+
+  private static final String GROUP = "nacos.config.group";
+
+  private NacosConfig() {
+  }
+
+  public static void setConcurrentCompositeConfiguration(Configuration config) {
+    finalConfig = config;
+  }
+
+  public Configuration getConcurrentCompositeConfiguration() {
+    return finalConfig;
+  }
+
+  public String getServerAddr() {
+    return finalConfig.getString(SERVER_ADDR);
+  }
+
+  public String getDataId(){
+    return finalConfig.getString(DATA_ID);
+  }
+
+  public String getGroup(){
+    return finalConfig.getString(GROUP);
+  }
+}

--- a/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/archaius/sources/NacosConfigurationSourceImplTest.java
+++ b/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/archaius/sources/NacosConfigurationSourceImplTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.config.archaius.sources;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.servicecomb.config.archaius.sources.NacosConfigurationSourceImpl.UpdateHandler;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.netflix.config.WatchedUpdateListener;
+
+import mockit.Deencapsulation;
+
+import static org.apache.servicecomb.config.client.ConfigurationAction.*;
+
+public class NacosConfigurationSourceImplTest {
+  @Test
+  public void testCreate() throws Exception {
+    NacosConfigurationSourceImpl nacosConfigurationSource = new NacosConfigurationSourceImpl();
+    nacosConfigurationSource.addUpdateListener(result -> Assert.assertTrue(!result.getAdded().isEmpty()));
+    UpdateHandler udateHandler = Deencapsulation.getField(nacosConfigurationSource, UpdateHandler.class);
+    Map<String, Object> createItems = new HashMap<>();
+    createItems.put("nacosTestKey", "testValue");
+    udateHandler.handle(CREATE, createItems);
+  }
+
+  @Test
+  public void testUpdate() throws Exception {
+    NacosConfigurationSourceImpl nacosConfigurationSource = new NacosConfigurationSourceImpl();
+    nacosConfigurationSource.addUpdateListener(result -> Assert.assertTrue(!result.getChanged().isEmpty()));
+    UpdateHandler udateHandler = Deencapsulation.getField(nacosConfigurationSource, UpdateHandler.class);
+    Map<String, Object> updateItems = new HashMap<>();
+    updateItems.put("nacosTestKey", "testValue");
+    udateHandler.handle(SET, updateItems);
+
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    NacosConfigurationSourceImpl nacosConfigurationSource = new NacosConfigurationSourceImpl();
+    nacosConfigurationSource.addUpdateListener(result -> Assert.assertTrue(!result.getDeleted().isEmpty()));
+    UpdateHandler udateHandler = Deencapsulation.getField(nacosConfigurationSource, UpdateHandler.class);
+    Map<String, Object> deleteItems = new HashMap<>();
+    deleteItems.put("nacosTestKey", "testValue");
+
+    nacosConfigurationSource.getCurrentData().put("nacosTestKey", "testValue");
+    udateHandler.handle(DELETE, deleteItems);
+    Assert.assertTrue(nacosConfigurationSource.getCurrentData().isEmpty());
+  }
+
+  @Test
+  public void testRemoveUpdateListener() {
+    NacosConfigurationSourceImpl nacosConfigurationSource = new NacosConfigurationSourceImpl();
+    WatchedUpdateListener watchedUpdateListener = Mockito.mock(WatchedUpdateListener.class);
+    nacosConfigurationSource.addUpdateListener(watchedUpdateListener);
+    nacosConfigurationSource.removeUpdateListener(watchedUpdateListener);
+    Assert.assertTrue(nacosConfigurationSource.getCurrentListeners().isEmpty());
+  }
+}

--- a/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/client/NacosClientTest.java
+++ b/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/client/NacosClientTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.config.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.servicecomb.config.ConfigUtil;
+import org.apache.servicecomb.config.archaius.sources.NacosConfigurationSourceImpl;
+import org.apache.servicecomb.config.archaius.sources.NacosConfigurationSourceImpl.UpdateHandler;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import mockit.Deencapsulation;
+
+public class NacosClientTest {
+  @BeforeClass
+  public static void setUpClass() {
+    NacosConfig.setConcurrentCompositeConfiguration(ConfigUtil.createLocalConfig());
+  }
+
+  @Test
+  public void refreshNacosConfig() {
+
+    NacosConfigurationSourceImpl impl = new NacosConfigurationSourceImpl();
+    UpdateHandler updateHandler = impl.new UpdateHandler();
+    NacosClient nacosClient = new NacosClient(updateHandler);
+    //nacosClient.refreshNacosConfig();
+    Map<String, Object> originMap = Deencapsulation.getField(nacosClient, "originalConfigMap");
+    Assert.assertEquals(1, originMap.size());
+  }
+
+  @Test
+  public void testCompareChangedConfig() {
+    boolean status = true;
+    Map<String, Object> before = new HashMap<>();
+    Map<String, Object> after = new HashMap<>();
+
+    NacosConfigurationSourceImpl impl = new NacosConfigurationSourceImpl();
+    UpdateHandler updateHandler = impl.new UpdateHandler();
+    NacosClient nacosClient = new NacosClient(updateHandler);
+
+    NacosClient.ConfigRefresh cr = nacosClient.new ConfigRefresh("","","");
+
+    try {
+      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+    } catch (Exception e) {
+      status = false;
+    }
+    Assert.assertTrue(status);
+
+    status = true;
+    before.put("test", "testValue");
+    try {
+      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+    } catch (Exception e) {
+      status = false;
+    }
+    Assert.assertTrue(status);
+
+    status = true;
+    after.put("test", "testValue2");
+    try {
+      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+    } catch (Exception e) {
+      status = false;
+    }
+    Assert.assertTrue(status);
+
+    status = true;
+    try {
+      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+    } catch (Exception e) {
+      status = false;
+    }
+    Assert.assertTrue(status);
+  }
+}

--- a/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/client/NacosConfigTest.java
+++ b/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/client/NacosConfigTest.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.config.client;
+
+import org.apache.servicecomb.config.ConfigUtil;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class NacosConfigTest {
+  @BeforeClass
+  public static void setUpClass() {
+    NacosConfig.setConcurrentCompositeConfiguration(ConfigUtil.createLocalConfig());
+  }
+
+  @Test
+  public void getServiceName() {
+    NacosConfig instance = NacosConfig.INSTANCE;
+    Assert.assertEquals("DEFAULT_GROUP", instance.getGroup());
+    Assert.assertEquals("127.0.0.1:8848", instance.getServerAddr());
+    Assert.assertEquals("example", instance.getDataId());
+  }
+}

--- a/dynamic-config/pom.xml
+++ b/dynamic-config/pom.xml
@@ -34,6 +34,7 @@
   <modules>
     <module>config-apollo</module>
     <module>config-cc</module>
+    <module>config-nacos</module>
   </modules>
 
 </project>

--- a/java-chassis-dependencies/default/pom.xml
+++ b/java-chassis-dependencies/default/pom.xml
@@ -113,6 +113,9 @@
     <zipkin.version>2.19.1</zipkin.version>
     <zipkin-reporter.version>2.7.13</zipkin-reporter.version>
     <zookeeper.version>3.4.14</zookeeper.version>
+    <nacos-client.version>1.1.4</nacos-client.version>
+    <slf4j-jdk.version>1.7.25</slf4j-jdk.version>
+
     <!-- Base dir of main -->
     <main.basedir>${basedir}/../..</main.basedir>
   </properties>
@@ -1340,6 +1343,18 @@
         <groupId>org.apache.servicecomb.archetypes</groupId>
         <artifactId>business-service-springmvc-archetype</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.alibaba.nacos</groupId>
+        <artifactId>nacos-client</artifactId>
+        <version>${nacos-client.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <version>${slf4j-jdk.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
How to use:
1.Download base model from http://start.servicecomb.io  and add maven dependence:
<dependency>
			<groupId>org.apache.servicecomb</groupId>
			<artifactId>config-nacos</artifactId>
			<version>2.0.0-SNAPSHOT</version>
</dependency>
2.Start nacos console model(git url:https://github.com/alibaba/nacos) ,both account and password is "nacos" and add properties(example):
Data ID: example
Group:DEFAULT_GROUP
JSON:
{
    "nacos":"666"
}
3.In base model,add info in microservice.yaml:
nacos:
  config:
    serverAddr: 127.0.0.1:8848
    dataId: example
    group: DEFAULT_GROUP
4.Then add blow code and start base model,you will get properties(If properties on nacos has changed, you can also get new value):
@RestSchema(schemaId = "nacos")
@RequestMapping(path = "/")
public class NacosImpl {
    /**
     * 从nacos获取配置
     * @return
     */
    @GetMapping(path = "/config")
    @ResponseBody
    public String config() throws Exception{
        final String config = DynamicPropertyFactory.getInstance()
                .getStringProperty("nacos","").getValue();
        return JSON.toJSONString(config);
    }
} 
