### PR TITLE
[SCB-1710] catch the throwable from the scheduled pulling task

### DIFF
--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/concurrency/SuppressedRunnableWrapper.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/concurrency/SuppressedRunnableWrapper.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.foundation.common.concurrency;
+
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A wrapper for {@link Runnable}.
+ * All the exceptions thrown from {@link Runnable#run()} are caught and handled.
+ */
+public class SuppressedRunnableWrapper implements Runnable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SuppressedRunnableWrapper.class);
+
+  private final Runnable target;
+
+  private final Consumer<Throwable> errorHandler;
+
+  public SuppressedRunnableWrapper(Runnable runnable) {
+    this(runnable, null);
+  }
+
+  public SuppressedRunnableWrapper(Runnable runnable, Consumer<Throwable> errorHandler) {
+    this.target = runnable;
+    this.errorHandler = errorHandler;
+  }
+
+  @Override
+  public void run() {
+    try {
+      target.run();
+    } catch (Throwable e) {
+      handleError(e);
+    }
+  }
+
+  private void handleError(Throwable e) {
+    if (null == errorHandler) {
+      LOGGER.error("task {} execute error!", target, e);
+      return;
+    }
+    errorHandler.accept(e);
+  }
+}

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/concurrency/RunnableWrapperTest.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/concurrency/RunnableWrapperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.foundation.common.concurrency;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Test;
+
+public class RunnableWrapperTest {
+  /**
+   * {@link SuppressedRunnableWrapper} should ensure that any {@link Throwable} thrown from {@link Runnable}
+   * should not interrupt the scheduled tasks.
+   */
+  @Test
+  public void run() throws InterruptedException {
+    ScheduledThreadPoolExecutor scheduledThreadPoolExecutor = new ScheduledThreadPoolExecutor(1);
+    CountDownLatch countDownLatch = new CountDownLatch(3);
+    scheduledThreadPoolExecutor.scheduleAtFixedRate(
+        new SuppressedRunnableWrapper(
+            () -> {
+              countDownLatch.countDown();
+              switch ((int) countDownLatch.getCount()) {
+                case 2:
+                  throw new Error("Normal case, this is a mocked error");
+                case 1:
+                  throw new IllegalStateException("Normal case, this is a mocked exception");
+                default:
+              }
+            }
+        ),
+        1,
+        1,
+        TimeUnit.MILLISECONDS);
+
+    countDownLatch.await(1000, TimeUnit.MILLISECONDS);
+    assertEquals(0, countDownLatch.getCount());
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -53,7 +53,7 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
     super.init();
     taskPool = new ScheduledThreadPoolExecutor(3,
         new ThreadFactory() {
-          private int taskId;
+          private int taskId = 0;
 
           @Override
           public Thread newThread(Runnable r) {

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -18,8 +18,10 @@ package org.apache.servicecomb.serviceregistry.registry;
 
 import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.servicecomb.foundation.common.concurrency.SuppressedRunnableWrapper;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
 import org.apache.servicecomb.serviceregistry.client.http.ServiceRegistryClientImpl;
@@ -50,18 +52,16 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
   public void init() {
     super.init();
     taskPool = new ScheduledThreadPoolExecutor(3,
-        task -> {
-          return new Thread(task) {
-            @Override
-            public void run() {
-              try {
-                setName("Service Center Task [" + task.toString() + "[" + this.getId() + "]]");
-                super.run();
-              } catch (Throwable e) {
-                LOGGER.error("task {} execute error.", getName(), e);
-              }
-            }
-          };
+        new ThreadFactory() {
+          private int taskId;
+
+          @Override
+          public Thread newThread(Runnable r) {
+            Thread thread = new Thread(r, "Service Center Task [" + (taskId++) + "]");
+            thread.setUncaughtExceptionHandler(
+                (t, e) -> LOGGER.error("Service Center Task Thread is terminated! thread: [{}]", t, e));
+            return thread;
+          }
         },
         (task, executor) -> LOGGER.warn("Too many pending tasks, reject " + task.toString())
     );
@@ -83,7 +83,7 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
         TimeUnit.SECONDS);
 
     taskPool.scheduleAtFixedRate(
-        appManager::pullInstances,
+        new SuppressedRunnableWrapper(appManager::pullInstances),
         serviceRegistryConfig.getInstancePullInterval(),
         serviceRegistryConfig.getInstancePullInterval(),
         TimeUnit.SECONDS);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SCB-1710

solution:
- add a wrapper class `SuppressedRunnableWrapper` to decorate the scheduled tasks, to ensure that no `Throwable` is thrown out of the tasks. This wrapper can be reused later.
- wrap the `org.apache.servicecomb.serviceregistry.consumer.AppManager#pullInstances` scheduled task by `SuppressedRunnableWrapper`