### PR TITLE
 [SCB-1691] Refactor registry module

### DIFF
--- a/core/src/main/java/org/apache/servicecomb/core/handler/impl/ProducerOperationHandler.java
+++ b/core/src/main/java/org/apache/servicecomb/core/handler/impl/ProducerOperationHandler.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.ws.rs.core.Response.Status;
 
-import org.apache.servicecomb.core.Const;
 import org.apache.servicecomb.core.Handler;
 import org.apache.servicecomb.core.Invocation;
 import org.apache.servicecomb.core.exception.ExceptionUtils;

--- a/core/src/main/java/org/apache/servicecomb/core/provider/consumer/MicroserviceReferenceConfig.java
+++ b/core/src/main/java/org/apache/servicecomb/core/provider/consumer/MicroserviceReferenceConfig.java
@@ -100,7 +100,7 @@ public class MicroserviceReferenceConfig {
   }
 
   private void mark3rdPartyService(OperationMeta operationMeta, ReferenceConfig referenceConfig) {
-    final MicroserviceVersions microserviceVersions = RegistryUtils.getServiceRegistry().getAppManager()
+    final MicroserviceVersions microserviceVersions = RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersions(
             operationMeta.getMicroserviceMeta().getAppId(),
             operationMeta.getMicroserviceName());

--- a/core/src/main/java/org/apache/servicecomb/core/provider/producer/ProducerBootListener.java
+++ b/core/src/main/java/org/apache/servicecomb/core/provider/producer/ProducerBootListener.java
@@ -28,6 +28,7 @@ import org.apache.servicecomb.core.definition.MicroserviceMeta;
 import org.apache.servicecomb.core.definition.OperationMeta;
 import org.apache.servicecomb.core.definition.SchemaMeta;
 import org.apache.servicecomb.foundation.common.utils.IOUtils;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.Const;
 import org.apache.servicecomb.serviceregistry.api.registry.BasePath;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
@@ -65,10 +66,14 @@ public class ProducerBootListener implements BootListener {
           microserviceMeta.getMicroserviceName(),
           schemaMeta.getSchemaId(),
           content);
-      microservice.addSchema(schemaMeta.getSchemaId(), content);
+      RegistryUtils.executeOnEachServiceRegistry(sr -> {
+        sr.getMicroservice().addSchema(schemaMeta.getSchemaId(), content);
+      });
     }
 
-    saveBasePaths(microserviceMeta, microservice);
+    RegistryUtils.executeOnEachServiceRegistry(sr -> {
+      saveBasePaths(microserviceMeta, sr.getMicroservice());
+    });
   }
 
   // just compatible to old 3rd components， servicecomb not use it......

--- a/core/src/main/java/org/apache/servicecomb/core/transport/TransportManager.java
+++ b/core/src/main/java/org/apache/servicecomb/core/transport/TransportManager.java
@@ -29,6 +29,7 @@ import org.apache.servicecomb.core.SCBEngine;
 import org.apache.servicecomb.core.Transport;
 import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,8 +61,10 @@ public class TransportManager {
         Endpoint endpoint = transport.getPublishEndpoint();
         if (endpoint != null && endpoint.getEndpoint() != null) {
           LOGGER.info("endpoint to publish: {}", endpoint.getEndpoint());
-          Microservice microservice = scbEngine.getServiceRegistry().getMicroservice();
-          microservice.getInstance().getEndpoints().add(endpoint.getEndpoint());
+          RegistryUtils.executeOnEachServiceRegistry(sr -> {
+            Microservice microservice = sr.getMicroservice();
+            microservice.getInstance().getEndpoints().add(endpoint.getEndpoint());
+          });
         }
         continue;
       }

--- a/core/src/test/java/org/apache/servicecomb/core/handler/impl/TestSimpleLoadBalanceHandler.java
+++ b/core/src/test/java/org/apache/servicecomb/core/handler/impl/TestSimpleLoadBalanceHandler.java
@@ -27,6 +27,7 @@ import org.apache.servicecomb.core.Transport;
 import org.apache.servicecomb.core.bootstrap.SCBBootstrap;
 import org.apache.servicecomb.foundation.common.cache.VersionedCache;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.discovery.DiscoveryFilter;
 import org.apache.servicecomb.swagger.invocation.AsyncResponse;
@@ -67,9 +68,9 @@ public class TestSimpleLoadBalanceHandler {
       }
     };
 
-    new Expectations(scbEngine.getServiceRegistry().getInstanceCacheManager()) {
+    new Expectations(RegistryUtils.getInstanceCacheManager()) {
       {
-        scbEngine.getServiceRegistry().getInstanceCacheManager()
+        RegistryUtils.getInstanceCacheManager()
             .getOrCreateVersionedCache(anyString, anyString, anyString);
         result = instanceVersionedCache;
       }

--- a/demo/demo-edge/consumer/src/main/java/org/apache/servicecomb/demo/edge/consumer/Consumer.java
+++ b/demo/demo-edge/consumer/src/main/java/org/apache/servicecomb/demo/edge/consumer/Consumer.java
@@ -264,7 +264,7 @@ public class Consumer {
 
   private URIEndpointObject prepareEdge(String prefix) {
     Microservice microservice = RegistryUtils.getMicroservice();
-    MicroserviceInstance microserviceInstance = (MicroserviceInstance) RegistryUtils.getServiceRegistry()
+    MicroserviceInstance microserviceInstance = (MicroserviceInstance) RegistryUtils
         .getAppManager()
         .getOrCreateMicroserviceVersionRule(microservice.getAppId(), "edge", DefinitionConst.VERSION_RULE_ALL)
         .getVersionedCache()

--- a/demo/demo-jaxrs/jaxrs-client/src/main/java/org/apache/servicecomb/demo/jaxrs/client/MultiErrorCodeServiceClient.java
+++ b/demo/demo-jaxrs/jaxrs-client/src/main/java/org/apache/servicecomb/demo/jaxrs/client/MultiErrorCodeServiceClient.java
@@ -78,7 +78,7 @@ public class MultiErrorCodeServiceClient implements CategorizedTestCase {
 
   private static void prepareServerDirectURL() {
     Microservice microservice = RegistryUtils.getMicroservice();
-    MicroserviceInstance microserviceInstance = (MicroserviceInstance) RegistryUtils.getServiceRegistry()
+    MicroserviceInstance microserviceInstance = (MicroserviceInstance) RegistryUtils
         .getAppManager()
         .getOrCreateMicroserviceVersionRule(microservice.getAppId(), "jaxrs", DefinitionConst.VERSION_RULE_ALL)
         .getVersionedCache()

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/event/SimpleSubscriber.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/event/SimpleSubscriber.java
@@ -106,8 +106,8 @@ public class SimpleSubscriber {
     try {
       dispatcher.accept(event);
     } catch (Throwable e) {
-      LOGGER.error("event process should not throw error. ", e);
       if (enableExceptionPropagation) {
+        LOGGER.error("event process should not throw error. ", e);
         throw e;
       }
     }

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalanceHandler2.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalanceHandler2.java
@@ -172,7 +172,7 @@ public class TestLoadBalanceHandler2 {
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
     when(serviceRegistry.getMicroserviceInstance()).thenReturn(myself);
-    when(serviceRegistry.getInstanceCacheManager()).thenReturn(instanceCacheManager);
+    mockUpInstanceCacheManager(instanceCacheManager);
     when(instanceCacheManager.getOrCreateVersionedCache("testApp", "testMicroserviceName", "0.0.0+"))
         .thenReturn(parent);
     when(transportManager.findTransport("rest")).thenReturn(transport);
@@ -299,7 +299,7 @@ public class TestLoadBalanceHandler2 {
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
     when(serviceRegistry.getMicroserviceInstance()).thenReturn(myself);
-    when(serviceRegistry.getInstanceCacheManager()).thenReturn(instanceCacheManager);
+    mockUpInstanceCacheManager(instanceCacheManager);
     when(instanceCacheManager.getOrCreateVersionedCache("testApp", "testMicroserviceName", "0.0.0+"))
         .thenReturn(parent);
     when(transportManager.findTransport("rest")).thenReturn(transport);
@@ -410,7 +410,7 @@ public class TestLoadBalanceHandler2 {
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
     when(serviceRegistry.getMicroserviceInstance()).thenReturn(myself);
-    when(serviceRegistry.getInstanceCacheManager()).thenReturn(instanceCacheManager);
+    mockUpInstanceCacheManager(instanceCacheManager);
     when(instanceCacheManager.getOrCreateVersionedCache("testApp", "testMicroserviceName", "0.0.0+"))
         .thenReturn(parent);
     when(transportManager.findTransport("rest")).thenReturn(transport);
@@ -537,7 +537,7 @@ public class TestLoadBalanceHandler2 {
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
     when(serviceRegistry.getMicroserviceInstance()).thenReturn(myself);
-    when(serviceRegistry.getInstanceCacheManager()).thenReturn(instanceCacheManager);
+    mockUpInstanceCacheManager(instanceCacheManager);
     when(instanceCacheManager.getOrCreateVersionedCache("testApp", "testMicroserviceName", "0.0.0+"))
         .thenReturn(parent);
     when(transportManager.findTransport("rest")).thenReturn(transport);
@@ -681,7 +681,7 @@ public class TestLoadBalanceHandler2 {
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
     when(serviceRegistry.getMicroserviceInstance()).thenReturn(myself);
-    when(serviceRegistry.getInstanceCacheManager()).thenReturn(instanceCacheManager);
+    mockUpInstanceCacheManager(instanceCacheManager);
     when(instanceCacheManager.getOrCreateVersionedCache("testApp", "testMicroserviceName", "0.0.0+"))
         .thenReturn(parent);
     when(transportManager.findTransport("rest")).thenReturn(transport);
@@ -800,7 +800,7 @@ public class TestLoadBalanceHandler2 {
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
     when(serviceRegistry.getMicroserviceInstance()).thenReturn(myself);
-    when(serviceRegistry.getInstanceCacheManager()).thenReturn(instanceCacheManager);
+    mockUpInstanceCacheManager(instanceCacheManager);
     when(instanceCacheManager.getOrCreateVersionedCache("testApp", "testMicroserviceName", "0.0.0+"))
         .thenReturn(parent);
     when(transportManager.findTransport("rest")).thenReturn(transport);
@@ -982,5 +982,14 @@ public class TestLoadBalanceHandler2 {
 
   private void mockDelayMillis(long delay) {
     mockTimeMillis.value += delay;
+  }
+
+  private void mockUpInstanceCacheManager(InstanceCacheManager instanceCacheManager) {
+    new MockUp<RegistryUtils>() {
+      @Mock
+      InstanceCacheManager getInstanceCacheManager() {
+        return instanceCacheManager;
+      }
+    };
   }
 }

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalanceHandler2.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalanceHandler2.java
@@ -119,7 +119,7 @@ public class TestLoadBalanceHandler2 {
     Invocation invocation = new Invocation(referenceConfig, operationMeta, new HashMap<>());
 
     InstanceCacheManager instanceCacheManager = Mockito.mock(InstanceCacheManager.class);
-    ServiceRegistry serviceRegistry = Mockito.mock(ServiceRegistry.class);
+    ServiceRegistry serviceRegistry = mockUpServiceRegistry();
     TransportManager transportManager = Mockito.mock(TransportManager.class);
     Transport transport = Mockito.mock(Transport.class);
     ArchaiusUtils.setProperty("servicecomb.loadbalance.filter.operation.enabled", "false");
@@ -268,7 +268,7 @@ public class TestLoadBalanceHandler2 {
     Invocation invocation = new Invocation(referenceConfig, operationMeta, new HashMap<>());
 
     InstanceCacheManager instanceCacheManager = Mockito.mock(InstanceCacheManager.class);
-    ServiceRegistry serviceRegistry = Mockito.mock(ServiceRegistry.class);
+    ServiceRegistry serviceRegistry = mockUpServiceRegistry();
     TransportManager transportManager = Mockito.mock(TransportManager.class);
     Transport transport = Mockito.mock(Transport.class);
     ArchaiusUtils.setProperty("servicecomb.loadbalance.filter.operation.enabled", "false");
@@ -357,7 +357,7 @@ public class TestLoadBalanceHandler2 {
     Invocation invocation = new Invocation(referenceConfig, operationMeta, new HashMap<>());
 
     InstanceCacheManager instanceCacheManager = Mockito.mock(InstanceCacheManager.class);
-    ServiceRegistry serviceRegistry = Mockito.mock(ServiceRegistry.class);
+    ServiceRegistry serviceRegistry = mockUpServiceRegistry();
     TransportManager transportManager = Mockito.mock(TransportManager.class);
     Transport transport = Mockito.mock(Transport.class);
     ArchaiusUtils.setProperty("servicecomb.loadbalance.filter.operation.enabled", "false");
@@ -484,7 +484,7 @@ public class TestLoadBalanceHandler2 {
     });
 
     InstanceCacheManager instanceCacheManager = Mockito.mock(InstanceCacheManager.class);
-    ServiceRegistry serviceRegistry = Mockito.mock(ServiceRegistry.class);
+    ServiceRegistry serviceRegistry = mockUpServiceRegistry();
     TransportManager transportManager = Mockito.mock(TransportManager.class);
     Transport transport = Mockito.mock(Transport.class);
     ArchaiusUtils.setProperty("servicecomb.loadbalance.filter.operation.enabled", "false");
@@ -627,7 +627,7 @@ public class TestLoadBalanceHandler2 {
     });
 
     InstanceCacheManager instanceCacheManager = Mockito.mock(InstanceCacheManager.class);
-    ServiceRegistry serviceRegistry = Mockito.mock(ServiceRegistry.class);
+    ServiceRegistry serviceRegistry = mockUpServiceRegistry();
     TransportManager transportManager = Mockito.mock(TransportManager.class);
     Transport transport = Mockito.mock(Transport.class);
     ArchaiusUtils.setProperty("servicecomb.loadbalance.filter.operation.enabled", "false");
@@ -778,7 +778,7 @@ public class TestLoadBalanceHandler2 {
     AsyncResponse asyncResp = Mockito.mock(AsyncResponse.class);
 
     InstanceCacheManager instanceCacheManager = Mockito.mock(InstanceCacheManager.class);
-    ServiceRegistry serviceRegistry = Mockito.mock(ServiceRegistry.class);
+    ServiceRegistry serviceRegistry = mockUpServiceRegistry();
     TransportManager transportManager = Mockito.mock(TransportManager.class);
     Transport transport = Mockito.mock(Transport.class);
     ArchaiusUtils.setProperty("servicecomb.loadbalance.filter.operation.enabled", "false");
@@ -991,5 +991,11 @@ public class TestLoadBalanceHandler2 {
         return instanceCacheManager;
       }
     };
+  }
+
+  private ServiceRegistry mockUpServiceRegistry() {
+    ServiceRegistry serviceRegistry = Mockito.mock(ServiceRegistry.class);
+    when(serviceRegistry.getEventBus()).thenReturn(EventManager.getEventBus());
+    return serviceRegistry;
   }
 }

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadbalanceHandler.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadbalanceHandler.java
@@ -35,6 +35,7 @@ import org.apache.servicecomb.core.transport.TransportManager;
 import org.apache.servicecomb.foundation.common.Holder;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.ServiceRegistry;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.cache.CacheEndpoint;
@@ -99,7 +100,7 @@ public class TestLoadbalanceHandler {
   public static void classSetup() {
     scbEngine = new SCBBootstrap().useLocalRegistry().createSCBEngineForTest().run();
     serviceRegistry = scbEngine.getServiceRegistry();
-    instanceCacheManager = serviceRegistry.getInstanceCacheManager();
+    instanceCacheManager = RegistryUtils.getInstanceCacheManager();
     transportManager = scbEngine.getTransportManager();
   }
 

--- a/integration-tests/it-common/src/main/java/org/apache/servicecomb/it/ITUtils.java
+++ b/integration-tests/it-common/src/main/java/org/apache/servicecomb/it/ITUtils.java
@@ -77,7 +77,7 @@ public final class ITUtils {
 
     Map<String, MicroserviceInstance> instances;
     for (; ; ) {
-      MicroserviceVersionRule microserviceVersionRule = RegistryUtils.getServiceRegistry()
+      MicroserviceVersionRule microserviceVersionRule = RegistryUtils
           .getAppManager()
           .getOrCreateMicroserviceVersionRule(appId, microserviceName, strVersionRule);
       instances = microserviceVersionRule.getInstances();
@@ -92,7 +92,7 @@ public final class ITUtils {
           minInstanceCount,
           instances.size());
       // pull at once
-      RegistryUtils.getServiceRegistry().getAppManager().pullInstances();
+      RegistryUtils.getAppManager().pullInstances();
       forceWait(TimeUnit.SECONDS, 1);
     }
 

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/deploy/MicroserviceDeploy.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/deploy/MicroserviceDeploy.java
@@ -55,7 +55,7 @@ public class MicroserviceDeploy extends NormalDeploy {
   }
 
   public void ensureReady() throws Throwable {
-    MicroserviceVersionRule microserviceVersionRule = RegistryUtils.getServiceRegistry().getAppManager()
+    MicroserviceVersionRule microserviceVersionRule = RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersionRule(microserviceDeployDefinition.getAppId(),
             microserviceDeployDefinition.getMicroserviceName(),
             microserviceDeployDefinition.getVersion());

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/extend/engine/GateRestTemplate.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/extend/engine/GateRestTemplate.java
@@ -70,7 +70,7 @@ public class GateRestTemplate extends RestTemplate {
   }
 
   private String getUrlPrefix(String gateName, String producerName, String schemaId) {
-    MicroserviceVersionRule microserviceVersionRule = RegistryUtils.getServiceRegistry().getAppManager()
+    MicroserviceVersionRule microserviceVersionRule = RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersionRule(RegistryUtils.getAppId(), gateName,
             DefinitionConst.VERSION_RULE_ALL);
     MicroserviceInstance microserviceInstance = microserviceVersionRule.getInstances().values().stream().findFirst()

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/extend/engine/ITSCBAsyncRestTemplate.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/extend/engine/ITSCBAsyncRestTemplate.java
@@ -51,7 +51,7 @@ public class ITSCBAsyncRestTemplate extends CseAsyncRestTemplate {
     ensureProviderBasePath(producerName);
 
     urlPrefix = String.format("cse://%s%s", producerName, basePath);
-    instance = RegistryUtils.getServiceRegistry().getAppManager()
+    instance = RegistryUtils.getAppManager()
         .getOrCreateMicroserviceManager(RegistryUtils.getAppId())
         .getOrCreateMicroserviceVersions(producerName).getPulledInstances().get(0);
 
@@ -78,7 +78,7 @@ public class ITSCBAsyncRestTemplate extends CseAsyncRestTemplate {
 
   private void ensureProviderBasePath(String producerName) {
     MicroserviceManager microserviceManager =
-        RegistryUtils.getServiceRegistry().getAppManager().getOrCreateMicroserviceManager(RegistryUtils.getAppId());
+        RegistryUtils.getAppManager().getOrCreateMicroserviceManager(RegistryUtils.getAppId());
     MicroserviceVersions producerMicroserviceVersions =
         microserviceManager.getOrCreateMicroserviceVersions(producerName);
     Optional<MicroserviceVersion> latestMicroserviceVersion =

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/extend/engine/ITSCBRestTemplate.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/extend/engine/ITSCBRestTemplate.java
@@ -48,7 +48,7 @@ public class ITSCBRestTemplate extends CseRestTemplate {
     SchemaMeta schemaMeta = microserviceMeta.ensureFindSchemaMeta(schemaId);
     basePath = schemaMeta.getSwagger().getBasePath();
     urlPrefix = String.format("cse://%s%s", producerName, basePath);
-    instance = RegistryUtils.getServiceRegistry().getAppManager()
+    instance = RegistryUtils.getAppManager()
         .getOrCreateMicroserviceManager(RegistryUtils.getAppId())
         .getOrCreateMicroserviceVersions(producerName).getPulledInstances().get(0);
 

--- a/integration-tests/it-edge/src/main/java/org/apache/servicecomb/it/edge/PreLoadBootListener.java
+++ b/integration-tests/it-edge/src/main/java/org/apache/servicecomb/it/edge/PreLoadBootListener.java
@@ -36,7 +36,7 @@ public class PreLoadBootListener implements BootListener {
   @Override
   public void onBootEvent(BootEvent bootEvent) {
     if (bootEvent.getEventType() == EventType.BEFORE_REGISTRY) {
-      MicroserviceVersionRule rule = RegistryUtils.getServiceRegistry().getAppManager()
+      MicroserviceVersionRule rule = RegistryUtils.getAppManager()
           .getOrCreateMicroserviceVersionRule(RegistryUtils.getAppId(), "it-producer", "0+");
       if (rule.getInstances().size() == 0) {
         LOGGER.warn("Prefetch not successful, maybe the provider not started.");

--- a/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/async/CseAsyncClientHttpRequestTest.java
+++ b/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/async/CseAsyncClientHttpRequestTest.java
@@ -25,6 +25,8 @@ import org.apache.servicecomb.core.SCBEngine;
 import org.apache.servicecomb.core.bootstrap.SCBBootstrap;
 import org.apache.servicecomb.foundation.common.Holder;
 import org.apache.servicecomb.provider.springmvc.reference.CseClientHttpResponse;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
+import org.apache.servicecomb.serviceregistry.consumer.AppManager;
 import org.apache.servicecomb.swagger.invocation.Response;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,11 +40,14 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import mockit.Deencapsulation;
+
 public class CseAsyncClientHttpRequestTest {
   static SCBEngine scbEngine;
 
   @BeforeClass
   public static void classSetup() {
+    Deencapsulation.setField(RegistryUtils.class, "appManager", new AppManager());
     scbEngine = new SCBBootstrap().useLocalRegistry().createSCBEngineForTest()
         .addProducerMeta("sid1", new CseAsyncClientHttpRequestTestSchema()).run();
   }
@@ -81,7 +86,7 @@ public class CseAsyncClientHttpRequestTest {
     byte[] body = "abc".getBytes();
     client.setRequestBody(body);
     client.executeAsync();
-    Assert.assertArrayEquals(body, ( byte[])holder.value.getInvocationArguments().get("input"));
+    Assert.assertArrayEquals(body, (byte[]) holder.value.getInvocationArguments().get("input"));
   }
 
   @Test

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/RegistryUtils.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/RegistryUtils.java
@@ -22,6 +22,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Matcher;
 
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.servicecomb.config.ConfigUtil;
@@ -258,5 +260,20 @@ public final class RegistryUtils {
 
   public static Microservice getAggregatedRemoteMicroservice(String microserviceId) {
     return serviceRegistry.getAggregatedRemoteMicroservice(microserviceId);
+  }
+
+  /**
+   * To validate whether the name is legal value.
+   * @param name name of the {@link ServiceRegistry}
+   * @throws IllegalArgumentException the input value is illegal
+   */
+  public static void validateRegistryName(String name) {
+    Objects.requireNonNull(name, "null value is not allowed for the name of ServiceRegistry");
+    Matcher checkMatcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher(name);
+    boolean isNameValid = checkMatcher.matches();
+    if (!isNameValid) {
+      throw new IllegalArgumentException(
+          "Illegal registry name, the format should be " + ServiceRegistry.REGISTRY_NAME_FORMAT);
+    }
   }
 }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/ServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/ServiceRegistry.java
@@ -25,6 +25,8 @@ import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
 import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCacheKey;
 
 import com.google.common.eventbus.EventBus;
 
@@ -71,6 +73,8 @@ public interface ServiceRegistry {
 
   MicroserviceInstances findServiceInstances(String appId, String microserviceName,
       String microserviceVersionRule, String revision);
+
+  MicroserviceCache findMicroserviceCache(MicroserviceCacheKey microserviceCacheKey);
 
   boolean updateMicroserviceProperties(Map<String, String> properties);
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/ServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/ServiceRegistry.java
@@ -19,6 +19,7 @@ package org.apache.servicecomb.serviceregistry;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
@@ -28,6 +29,16 @@ import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import com.google.common.eventbus.EventBus;
 
 public interface ServiceRegistry {
+  String DEFAULT_REGISTRY_NAME = "Default";
+  String REGISTRY_NAME_FORMAT = "[a-zA-Z]([-_]?[a-zA-Z0-9])+";
+  Pattern REGISTRY_NAME_PATTERN = Pattern.compile(REGISTRY_NAME_FORMAT);
+
+  /**
+   * Get a name representing this ServiceRegistry instance.
+   * The name should be unique.
+   */
+  String getName();
+
   void init();
 
   void run();

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/ServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/ServiceRegistry.java
@@ -22,11 +22,8 @@ import java.util.Set;
 
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
-import org.apache.servicecomb.serviceregistry.cache.InstanceCacheManager;
 import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
 import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
-import org.apache.servicecomb.serviceregistry.consumer.AppManager;
-import org.apache.servicecomb.serviceregistry.swagger.SwaggerLoader;
 
 import com.google.common.eventbus.EventBus;
 
@@ -39,21 +36,24 @@ public interface ServiceRegistry {
 
   EventBus getEventBus();
 
-  SwaggerLoader getSwaggerLoader();
-
   Set<String> getCombinedMicroserviceNames();
 
+  /**
+   * Get the AppId of this microservice instance itself.
+   */
   String getAppId();
 
+  /**
+   * Get the {@link Microservice} of this microservice instance itself.
+   */
   Microservice getMicroservice();
 
+  /**
+   * Get the {@link MicroserviceInstance} of this microservice instance itself.
+   */
   MicroserviceInstance getMicroserviceInstance();
 
   ServiceRegistryClient getServiceRegistryClient();
-
-  AppManager getAppManager();
-
-  InstanceCacheManager getInstanceCacheManager();
 
   List<MicroserviceInstance> findServiceInstance(String appId, String microserviceName,
       String microserviceVersionRule);
@@ -65,8 +65,6 @@ public interface ServiceRegistry {
 
   /**
    * full update, not increase update
-   * @param instanceProperties
-   * @return
    */
   boolean updateInstanceProperties(Map<String, String> instanceProperties);
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/cache/MicroserviceInstanceCache.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/cache/MicroserviceInstanceCache.java
@@ -52,7 +52,7 @@ public class MicroserviceInstanceCache {
   public static Microservice getOrCreate(String serviceId) {
     try {
       return microservices.get(serviceId, () -> {
-        Microservice microservice = RegistryUtils.getServiceRegistryClient().getAggregatedMicroservice(serviceId);
+        Microservice microservice = RegistryUtils.getAggregatedRemoteMicroservice(serviceId);
         if (microservice == null) {
           throw new IllegalArgumentException("service id not exists.");
         }
@@ -70,9 +70,9 @@ public class MicroserviceInstanceCache {
       return instances.get(key, new Callable<MicroserviceInstance>() {
 
         @Override
-        public MicroserviceInstance call() throws Exception {
-          MicroserviceInstance instance = RegistryUtils.getServiceRegistryClient()
-              .findServiceInstance(serviceId, instanceId);
+        public MicroserviceInstance call() {
+          MicroserviceInstance instance = RegistryUtils.getResultFromFirstValidServiceRegistry(
+              sr -> sr.getServiceRegistryClient().findServiceInstance(serviceId, instanceId));
           if (instance == null) {
             throw new IllegalArgumentException("instance id not exists.");
           }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/IpPortManager.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/IpPortManager.java
@@ -30,7 +30,9 @@ import org.apache.servicecomb.foundation.common.net.URIEndpointObject;
 import org.apache.servicecomb.serviceregistry.cache.CacheEndpoint;
 import org.apache.servicecomb.serviceregistry.cache.InstanceCache;
 import org.apache.servicecomb.serviceregistry.cache.InstanceCacheManager;
+import org.apache.servicecomb.serviceregistry.cache.InstanceCacheManagerNew;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
+import org.apache.servicecomb.serviceregistry.consumer.AppManager;
 import org.apache.servicecomb.serviceregistry.definition.DefinitionConst;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +42,7 @@ public class IpPortManager {
 
   private ServiceRegistryConfig serviceRegistryConfig;
 
-  private InstanceCacheManager instanceCacheManager;
+  InstanceCacheManager instanceCacheManager;
 
   private String defaultTransport = "rest";
 
@@ -60,9 +62,9 @@ public class IpPortManager {
     return maxRetryTimes;
   }
 
-  public IpPortManager(ServiceRegistryConfig serviceRegistryConfig, InstanceCacheManager instanceCacheManager) {
+  public IpPortManager(ServiceRegistryConfig serviceRegistryConfig) {
     this.serviceRegistryConfig = serviceRegistryConfig;
-    this.instanceCacheManager = instanceCacheManager;
+    this.instanceCacheManager = new InstanceCacheManagerNew(new AppManager());
 
     defaultTransport = serviceRegistryConfig.getTransport();
     defaultIpPort = serviceRegistryConfig.getIpPort();

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
@@ -434,30 +434,26 @@ public class LocalServiceRegistryClientImpl implements ServiceRegistryClient {
   }
 
   @Override
-  public boolean undateMicroserviceInstanceStatus(String microserviceId, String microserviceInstanceId, String status) {
+  public boolean updateMicroserviceInstanceStatus(String microserviceId, String instanceId,
+      MicroserviceInstanceStatus status) {
+    if (null == status) {
+      throw new IllegalArgumentException("null status is now allowed");
+    }
+
     Map<String, MicroserviceInstance> instanceMap = microserviceInstanceMap.get(microserviceId);
     if (instanceMap == null) {
       throw new IllegalArgumentException("Invalid serviceId, serviceId=" + microserviceId);
     }
 
-    MicroserviceInstance microserviceInstance = instanceMap.get(microserviceInstanceId);
+    MicroserviceInstance microserviceInstance = instanceMap.get(instanceId);
     if (microserviceInstance == null) {
       throw new IllegalArgumentException(
-              String.format("Invalid argument. microserviceId=%s, microserviceInstanceId=%s.",
-                      microserviceId,
-                      microserviceInstanceId));
+          String.format("Invalid argument. microserviceId=%s, instanceId=%s.",
+              microserviceId,
+              instanceId));
     }
-    MicroserviceInstanceStatus instanceStatus;
-    try {
-      instanceStatus = MicroserviceInstanceStatus.valueOf(status);
-    }
-    catch (IllegalArgumentException e){
-      throw new IllegalArgumentException("Invalid status.");
-    }
-    if (null != instanceStatus) {
-      microserviceInstance.setStatus(instanceStatus);
-      return true;
-    }
-    return false;
+
+    microserviceInstance.setStatus(status);
+    return true;
   }
 }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/ServiceRegistryClient.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/ServiceRegistryClient.java
@@ -179,6 +179,27 @@ public interface ServiceRegistryClient {
    * @param microserviceId
    * @param microserviceInstanceId
    * @return
+   * @deprecated use {@link #updateMicroserviceInstanceStatus(String, String, MicroserviceInstanceStatus)} instead
    */
-  boolean undateMicroserviceInstanceStatus(String microserviceId, String microserviceInstanceId, String status);
+  @Deprecated
+  default boolean undateMicroserviceInstanceStatus(String microserviceId, String microserviceInstanceId,
+      String status) {
+    MicroserviceInstanceStatus instanceStatus;
+    try {
+      instanceStatus = MicroserviceInstanceStatus.valueOf(status);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid status: " + status);
+    }
+
+    return updateMicroserviceInstanceStatus(microserviceId, microserviceInstanceId, instanceStatus);
+  }
+
+  /**
+   * Update the instance status registered in service center.
+   * @param microserviceId the microserviceId of the instance
+   * @param instanceId the instanceId of the instance
+   * @param status update to this status
+   * @return whether this operation success
+   */
+  boolean updateMicroserviceInstanceStatus(String microserviceId, String instanceId, MicroserviceInstanceStatus status);
 }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/ClientPool.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/ClientPool.java
@@ -19,15 +19,11 @@ package org.apache.servicecomb.serviceregistry.client.http;
 
 import org.apache.servicecomb.foundation.vertx.client.http.HttpClientWithContext;
 
-import io.vertx.core.http.HttpClientOptions;
-
 /**
  * Created by on 2017/4/28.
  */
-public interface ClientPool {
+interface ClientPool {
   void create();
-
-  HttpClientOptions createHttpClientOptions();
 
   HttpClientWithContext getClient();
 }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/HttpClientPool.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/HttpClientPool.java
@@ -27,9 +27,6 @@ import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
 import io.vertx.core.net.ProxyOptions;
 
-/**
- * Created by on 2017/4/28.
- */
 final class HttpClientPool extends AbstractClientPool {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClientPool.class);

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RestClientUtil.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RestClientUtil.java
@@ -43,11 +43,11 @@ import io.vertx.core.http.HttpMethod;
 final class RestClientUtil {
   private static final Logger LOGGER = LoggerFactory.getLogger(RestClientUtil.class);
 
-  private static final String HEADER_CONTENT_TYPE = "Content-Type";
+  static final String HEADER_CONTENT_TYPE = "Content-Type";
 
-  private static final String HEADER_USER_AGENT = "User-Agent";
+  static final String HEADER_USER_AGENT = "User-Agent";
 
-  private static final String HEADER_TENANT_NAME = "x-domain-name";
+  static final String HEADER_TENANT_NAME = "x-domain-name";
 
   private List<AuthHeaderProvider> authHeaderProviders;
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
@@ -35,6 +35,11 @@ public final class WebsocketClientPool extends AbstractClientPool {
   public static final WebsocketClientPool INSTANCE = new WebsocketClientPool();
 
   private WebsocketClientPool() {
+    super(getHttpClientOptionsFromConfigurations(ServiceRegistryConfig.INSTANCE));
+  }
+
+  WebsocketClientPool(ServiceRegistryConfig serviceRegistryConfig) {
+    super(getHttpClientOptionsFromConfigurations(serviceRegistryConfig));
   }
 
   @Override
@@ -42,18 +47,17 @@ public final class WebsocketClientPool extends AbstractClientPool {
     return true;
   }
 
-  @Override
-  public HttpClientOptions createHttpClientOptions() {
-    HttpVersion ver = ServiceRegistryConfig.INSTANCE.getHttpVersion();
+  static HttpClientOptions getHttpClientOptionsFromConfigurations(ServiceRegistryConfig serviceRegistryConfig) {
+    HttpVersion ver = serviceRegistryConfig.getHttpVersion();
     HttpClientOptions httpClientOptions = new HttpClientOptions();
     httpClientOptions.setProtocolVersion(ver);
-    httpClientOptions.setConnectTimeout(ServiceRegistryConfig.INSTANCE.getConnectionTimeout());
-    httpClientOptions.setIdleTimeout(ServiceRegistryConfig.INSTANCE.getIdleWatchTimeout());
+    httpClientOptions.setConnectTimeout(serviceRegistryConfig.getConnectionTimeout());
+    httpClientOptions.setIdleTimeout(serviceRegistryConfig.getIdleWatchTimeout());
     if (ver == HttpVersion.HTTP_2) {
       LOGGER.debug("service center ws client protocol version is HTTP/2");
       httpClientOptions.setHttp2ClearTextUpgrade(false);
     }
-    if (ServiceRegistryConfig.INSTANCE.isSsl()) {
+    if (serviceRegistryConfig.isSsl()) {
       LOGGER.debug("service center ws client performs requests over TLS");
       VertxTLSBuilder.buildHttpClientOptions(ServiceRegistryConfig.SSL_KEY, httpClientOptions);
     }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
@@ -25,13 +25,13 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
 
-/**
- * Created by on 2017/4/28.
- */
 public final class WebsocketClientPool extends AbstractClientPool {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketClientPool.class);
 
+  /**
+   * The default instance, for default sc cluster.
+   */
   public static final WebsocketClientPool INSTANCE = new WebsocketClientPool();
 
   private WebsocketClientPool() {

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpVersion;
 
-public final class WebsocketClientPool extends AbstractClientPool {
+public class WebsocketClientPool extends AbstractClientPool {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketClientPool.class);
 
@@ -35,11 +35,11 @@ public final class WebsocketClientPool extends AbstractClientPool {
   public static final WebsocketClientPool INSTANCE = new WebsocketClientPool();
 
   private WebsocketClientPool() {
-    super(getHttpClientOptionsFromConfigurations(ServiceRegistryConfig.INSTANCE));
+    super(ServiceRegistryConfig.INSTANCE);
   }
 
   WebsocketClientPool(ServiceRegistryConfig serviceRegistryConfig) {
-    super(getHttpClientOptionsFromConfigurations(serviceRegistryConfig));
+    super(serviceRegistryConfig);
   }
 
   @Override
@@ -47,7 +47,8 @@ public final class WebsocketClientPool extends AbstractClientPool {
     return true;
   }
 
-  static HttpClientOptions getHttpClientOptionsFromConfigurations(ServiceRegistryConfig serviceRegistryConfig) {
+  @Override
+  protected HttpClientOptions getHttpClientOptionsFromConfigurations(ServiceRegistryConfig serviceRegistryConfig) {
     HttpVersion ver = serviceRegistryConfig.getHttpVersion();
     HttpClientOptions httpClientOptions = new HttpClientOptions();
     httpClientOptions.setProtocolVersion(ver);
@@ -59,7 +60,7 @@ public final class WebsocketClientPool extends AbstractClientPool {
     }
     if (serviceRegistryConfig.isSsl()) {
       LOGGER.debug("service center ws client performs requests over TLS");
-      VertxTLSBuilder.buildHttpClientOptions(ServiceRegistryConfig.SSL_KEY, httpClientOptions);
+      VertxTLSBuilder.buildHttpClientOptions(serviceRegistryConfig.getSslConfigTag(), httpClientOptions);
     }
     return httpClientOptions;
   }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientUtil.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientUtil.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.client.http;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.servicecomb.foundation.auth.AuthHeaderProvider;
+import org.apache.servicecomb.foundation.auth.SignRequest;
+import org.apache.servicecomb.foundation.common.net.IpPort;
+import org.apache.servicecomb.foundation.vertx.client.http.HttpClientWithContext;
+import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.Handler;
+import io.vertx.core.MultiMap;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.CaseInsensitiveHeaders;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.http.WebSocketConnectOptions;
+
+public final class WebsocketClientUtil {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketClientUtil.class);
+
+  private WebsocketClientPool websocketClientPool;
+
+  private List<AuthHeaderProvider> authHeaderProviders;
+
+  WebsocketClientUtil(ServiceRegistryConfig serviceRegistryConfig) {
+    websocketClientPool = new WebsocketClientPool(serviceRegistryConfig);
+    authHeaderProviders = serviceRegistryConfig.getAuthHeaderProviders();
+  }
+
+  public void open(IpPort ipPort, String url, Handler<Void> onOpen, Handler<Void> onClose,
+      Handler<Buffer> onMessage, Handler<Throwable> onException,
+      Handler<Throwable> onConnectFailed) {
+    HttpClientWithContext vertxHttpClient = websocketClientPool.getClient();
+    vertxHttpClient.runOnContext(client -> {
+      WebSocketConnectOptions options = new WebSocketConnectOptions();
+      options.setHost(ipPort.getHostOrIp()).setPort(ipPort.getPort()).setURI(url)
+          .setHeaders(getDefaultHeaders().addAll(getSignAuthHeaders(
+              createSignRequest(HttpMethod.GET.name(), ipPort, new RequestParam(), url, new HashMap<>()))));
+      client.webSocket(options, asyncResult -> {
+        if (asyncResult.failed()) {
+          onConnectFailed.handle(asyncResult.cause());
+        } else {
+          onOpen.handle(null);
+          asyncResult.result().exceptionHandler(v -> {
+            onException.handle(v);
+            try {
+              asyncResult.result().close();
+            } catch (Exception err) {
+              LOGGER.error("ws close error.", err);
+            }
+          });
+          asyncResult.result().closeHandler(v -> {
+            onClose.handle(v);
+          });
+          asyncResult.result().pongHandler(pong -> {
+            // ignore, just prevent NPE.
+          });
+          asyncResult.result().frameHandler((frame) -> onMessage.handle(frame.binaryData()));
+        }
+      });
+    });
+  }
+
+  public MultiMap getDefaultHeaders() {
+    return new CaseInsensitiveHeaders().addAll(defaultHeaders());
+  }
+
+  private Map<String, String> defaultHeaders() {
+    Map<String, String> headers = new HashMap<>();
+    headers.put(RestClientUtil.HEADER_CONTENT_TYPE, "application/json");
+    headers.put(RestClientUtil.HEADER_USER_AGENT, "cse-serviceregistry-client/1.0.0");
+    headers.put(RestClientUtil.HEADER_TENANT_NAME, ServiceRegistryConfig.INSTANCE.getTenantName());
+
+    return headers;
+  }
+
+  public Map<String, String> getSignAuthHeaders(SignRequest signReq) {
+    Map<String, String> headers = new HashMap<>();
+    authHeaderProviders.forEach(provider -> headers.putAll(provider.getSignAuthHeaders(signReq)));
+    return headers;
+  }
+
+  public SignRequest createSignRequest(String method, IpPort ipPort, RequestParam requestParam, String url,
+      Map<String, String> headers) {
+    SignRequest signReq = new SignRequest();
+    StringBuilder endpoint = new StringBuilder("https://" + ipPort.getHostOrIp());
+    endpoint.append(":" + ipPort.getPort());
+    endpoint.append(url);
+    try {
+      signReq.setEndpoint(new URI(endpoint.toString()));
+    } catch (URISyntaxException e) {
+      LOGGER.error("set uri failed, uri is {}, message: {}", endpoint.toString(), e.getMessage());
+    }
+    signReq.setContent((requestParam.getBody() != null && requestParam.getBody().length > 0)
+        ? new ByteArrayInputStream(requestParam.getBody())
+        : null);
+    signReq.setHeaders(headers);
+    signReq.setHttpMethod(method);
+    signReq.setQueryParams(requestParam.getQueryParamsMap());
+    return signReq;
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketUtils.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketUtils.java
@@ -30,8 +30,10 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.WebSocketConnectOptions;
 
 /**
- * Created by on 2017/4/28.
+ * This class is designed following singleton pattern, but it's not suitable for multi sc cluster occasion.
+ * @deprecated consider to use {@link WebsocketClientUtil} instead.
  */
+@Deprecated
 public final class WebsocketUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketUtils.class);
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
@@ -18,7 +18,9 @@
 package org.apache.servicecomb.serviceregistry.config;
 
 import java.util.ArrayList;
+import java.util.List;
 
+import org.apache.servicecomb.foundation.auth.AuthHeaderProvider;
 import org.apache.servicecomb.foundation.common.net.IpPort;
 import org.apache.servicecomb.serviceregistry.ServiceRegistry;
 
@@ -138,6 +140,8 @@ public final class ServiceRegistryConfig {
   private String proxyUsername;
 
   private String proxyPasswd;
+
+  private List<AuthHeaderProvider> authHeaderProviders;
 
   /**
    * Read the service registry related configurations and build the {@link ServiceRegistryConfig}
@@ -410,6 +414,16 @@ public final class ServiceRegistryConfig {
 
   public ServiceRegistryConfig setProxyPasswd(String proxyPasswd) {
     this.proxyPasswd = proxyPasswd;
+    return this;
+  }
+
+  public List<AuthHeaderProvider> getAuthHeaderProviders() {
+    return authHeaderProviders;
+  }
+
+  public ServiceRegistryConfig setAuthHeaderProviders(
+      List<AuthHeaderProvider> authHeaderProviders) {
+    this.authHeaderProviders = authHeaderProviders;
     return this;
   }
 }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
@@ -26,6 +26,7 @@ import org.apache.servicecomb.deployment.Deployment;
 import org.apache.servicecomb.deployment.DeploymentProvider;
 import org.apache.servicecomb.foundation.common.net.IpPort;
 import org.apache.servicecomb.foundation.common.net.NetUtils;
+import org.apache.servicecomb.serviceregistry.ServiceRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +99,8 @@ public final class ServiceRegistryConfig {
 
   public static final String WORKER_POOL_NAME = "registry-vert.x-worker-thread";
 
+  private String registryName = ServiceRegistry.DEFAULT_REGISTRY_NAME;
+
   private ServiceRegistryConfig() {
 
   }
@@ -123,7 +126,6 @@ public final class ServiceRegistryConfig {
     }
     return deployInstances;
   }
-
 
   public boolean isSsl() {
     getIpPort();
@@ -315,6 +317,15 @@ public final class ServiceRegistryConfig {
   public String getProxyPasswd() {
     String passwd = getProperty(null, PROXY_PASSWD);
     return passwd;
+  }
+
+  public String getRegistryName() {
+    return registryName;
+  }
+
+  public ServiceRegistryConfig setRegistryName(String registryName) {
+    this.registryName = registryName;
+    return this;
   }
 
   private String getProperty(String defaultValue, String... keys) {

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
@@ -19,10 +19,13 @@ package org.apache.servicecomb.serviceregistry.config;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 
 import org.apache.servicecomb.foundation.auth.AuthHeaderProvider;
 import org.apache.servicecomb.foundation.common.net.IpPort;
 import org.apache.servicecomb.serviceregistry.ServiceRegistry;
+import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import org.apache.servicecomb.serviceregistry.client.http.ServiceRegistryClientImpl;
 
 import io.vertx.core.http.HttpVersion;
 
@@ -141,7 +144,17 @@ public final class ServiceRegistryConfig {
 
   private String proxyPasswd;
 
+  private String sslConfigTag = SSL_KEY;
+
+  private String proxyConfigTag = PROXY_KEY;
+
   private List<AuthHeaderProvider> authHeaderProviders;
+
+  private Function<ServiceRegistry, ServiceRegistryClient> serviceRegistryClientConstructor =
+      serviceRegistry -> new ServiceRegistryClientImpl(this);
+
+  public ServiceRegistryConfig() {
+  }
 
   /**
    * Read the service registry related configurations and build the {@link ServiceRegistryConfig}
@@ -417,6 +430,24 @@ public final class ServiceRegistryConfig {
     return this;
   }
 
+  public String getSslConfigTag() {
+    return sslConfigTag;
+  }
+
+  public ServiceRegistryConfig setSslConfigTag(String sslConfigTag) {
+    this.sslConfigTag = sslConfigTag;
+    return this;
+  }
+
+  public String getProxyConfigTag() {
+    return proxyConfigTag;
+  }
+
+  public ServiceRegistryConfig setProxyConfigTag(String proxyConfigTag) {
+    this.proxyConfigTag = proxyConfigTag;
+    return this;
+  }
+
   public List<AuthHeaderProvider> getAuthHeaderProviders() {
     return authHeaderProviders;
   }
@@ -425,5 +456,15 @@ public final class ServiceRegistryConfig {
       List<AuthHeaderProvider> authHeaderProviders) {
     this.authHeaderProviders = authHeaderProviders;
     return this;
+  }
+
+  public ServiceRegistryConfig setServiceRegistryClientConstructor(
+      Function<ServiceRegistry, ServiceRegistryClient> serviceRegistryClientConstructor) {
+    this.serviceRegistryClientConstructor = serviceRegistryClientConstructor;
+    return this;
+  }
+
+  public ServiceRegistryClient createServiceRegistryClient(ServiceRegistry serviceRegistry) {
+    return this.serviceRegistryClientConstructor.apply(serviceRegistry);
   }
 }

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigBuilder.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigBuilder.java
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.config;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.servicecomb.config.ConfigUtil;
+import org.apache.servicecomb.deployment.Deployment;
+import org.apache.servicecomb.deployment.DeploymentProvider;
+import org.apache.servicecomb.foundation.common.net.IpPort;
+import org.apache.servicecomb.foundation.common.net.NetUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.netflix.config.DynamicBooleanProperty;
+import com.netflix.config.DynamicIntProperty;
+import com.netflix.config.DynamicPropertyFactory;
+import com.netflix.config.DynamicStringProperty;
+
+import io.vertx.core.http.HttpVersion;
+
+class ServiceRegistryConfigBuilder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServiceRegistryConfigBuilder.class);
+
+  static {
+    // ensure configurations are loaded properly
+    ConfigUtil.installDynamicConfig();
+  }
+
+  private boolean ssl;
+
+  public ServiceRegistryConfig build() {
+    return new ServiceRegistryConfig()
+        .setHttpVersion(getHttpVersion())
+        .setInstances(getInstances())
+        .setIpPort(getIpPort())
+        .setSsl(isSsl())
+        .setConnectionTimeout(getConnectionTimeout())
+        .setIdleConnectionTimeout(getIdleConnectionTimeout())
+        .setIdleWatchTimeout(getIdleWatchTimeout())
+        .setRequestTimeout(getRequestTimeout())
+        .setHeartBeatRequestTimeout(getHeartBeatRequestTimeout())
+        .setHeartbeatInterval(getHeartbeatInterval())
+        .setInstancePullInterval(getInstancePullInterval())
+        .setRegistryAutoDiscovery(isRegistryAutoDiscovery())
+        .setResendHeartBeatTimes(getResendHeartBeatTimes())
+        .setEmptyInstanceProtectionEnabled(isEmptyInstanceProtectionEnabled())
+        .setAlwaysOverrideSchema(isAlwaysOverrideSchema())
+        .setPreferIpAddress(isPreferIpAddress())
+        .setWatch(isWatch())
+        .setClientAuthEnabled(isClientAuthEnabled())
+        .setRegistryApiVersion(getRegistryApiVersion())
+        .setTenantName(getTenantName())
+        .setDomainName(getDomainName())
+        .setAccessKey(getAccessKey())
+        .setSecretKey(getSecretKey())
+        .setProxyEnable(isProxyEnable())
+        .setProxyHost(getProxyHost())
+        .setProxyPort(getProxyPort())
+        .setProxyUsername(getProxyUsername())
+        .setProxyPasswd(getProxyPasswd());
+  }
+
+  public HttpVersion getHttpVersion() {
+    DynamicStringProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getStringProperty("servicecomb.service.registry.client.httpVersion", "HTTP_1_1");
+    return HttpVersion.valueOf(property.get());
+  }
+
+  public int getInstances() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty(ServiceRegistryConfig.VERTICLE_INSTANCES, 1);
+    int deployInstances = property.get();
+    if (deployInstances <= 0) {
+      int nAvailableProcessors = Runtime.getRuntime().availableProcessors();
+      LOGGER.warn("The property `{}` must be positive integer, fallback to use number of available processors: {}",
+          ServiceRegistryConfig.VERTICLE_INSTANCES,
+          nAvailableProcessors);
+      return nAvailableProcessors;
+    }
+    return deployInstances;
+  }
+
+  /**
+   * must be invoked after {@link #getIpPort()}
+   */
+  public boolean isSsl() {
+    return this.ssl;
+  }
+
+  public ArrayList<IpPort> getIpPort() {
+    List<String> uriList = Objects
+        .requireNonNull(Deployment.getSystemBootStrapInfo(DeploymentProvider.SYSTEM_KEY_SERVICE_CENTER),
+            "no sc address found!")
+        .getAccessURL();
+    ArrayList<IpPort> ipPortList = new ArrayList<>();
+    uriList.forEach(anUriList -> {
+      try {
+        URI uri = new URI(anUriList.trim());
+        this.ssl = "https".equals(uri.getScheme());
+        ipPortList.add(NetUtils.parseIpPort(uri));
+      } catch (Exception e) {
+        LOGGER.error("servicecomb.service.registry.address invalid : {}", anUriList, e);
+      }
+    });
+    return ipPortList;
+  }
+
+  public String getTransport() {
+    return "rest";
+  }
+
+  public int getConnectionTimeout() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.client.timeout.connection",
+                ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_MS);
+    int timeout = property.get();
+    return timeout < 0 ? ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_MS : timeout;
+  }
+
+  public int getIdleConnectionTimeout() {
+    // connection pool idle timeout based on client heart beat interval. Heart beat default value is 30.
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.client.timeout.idle",
+                ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2);
+    int timeout = property.get();
+    return timeout < 1 ? ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2 : timeout;
+  }
+
+  public int getIdleWatchTimeout() {
+    // watch idle timeout based on SC PING/PONG interval. SC default value is 30.
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.client.timeout.watch",
+                ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2);
+    int timeout = property.get();
+    return timeout < 1 ? ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2 : timeout;
+  }
+
+  public int getRequestTimeout() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.client.timeout.request",
+                ServiceRegistryConfig.DEFAULT_REQUEST_TIMEOUT_IN_MS);
+    int timeout = property.get();
+    return timeout < 1 ? ServiceRegistryConfig.DEFAULT_REQUEST_TIMEOUT_IN_MS : timeout;
+  }
+
+  //Set the timeout of the heartbeat request
+  public int getHeartBeatRequestTimeout() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.client.timeout.heartbeat",
+                ServiceRegistryConfig.DEFAULT_REQUEST_HEARTBEAT_TIMEOUT_IN_MS);
+    int timeout = property.get();
+    return timeout < 1 ? ServiceRegistryConfig.DEFAULT_REQUEST_HEARTBEAT_TIMEOUT_IN_MS : timeout;
+  }
+
+  public int getHeartbeatInterval() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.instance.healthCheck.interval",
+                ServiceRegistryConfig.DEFAULT_CHECK_INTERVAL_IN_S);
+    int interval = property.get();
+    return interval < 0 ? ServiceRegistryConfig.DEFAULT_CHECK_INTERVAL_IN_S : interval;
+  }
+
+  public int getInstancePullInterval() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.instance.pull.interval",
+                ServiceRegistryConfig.DEFAULT_CHECK_INTERVAL_IN_S);
+    int interval = property.get();
+    return interval < 0 ? ServiceRegistryConfig.DEFAULT_CHECK_INTERVAL_IN_S : interval;
+  }
+
+  public boolean isRegistryAutoDiscovery() {
+    DynamicBooleanProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getBooleanProperty("servicecomb.service.registry.autodiscovery",
+                false);
+    return property.get();
+  }
+
+  public int getResendHeartBeatTimes() {
+    DynamicIntProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getIntProperty("servicecomb.service.registry.instance.healthCheck.times",
+                ServiceRegistryConfig.DEFAULT_CHECK_TIMES);
+    int times = property.get();
+    return times < 0 ? ServiceRegistryConfig.DEFAULT_CHECK_TIMES : times;
+  }
+
+  public boolean isEmptyInstanceProtectionEnabled() {
+    DynamicBooleanProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getBooleanProperty("servicecomb.service.registry.instance.empty.protection",
+                true);
+    return property.get();
+  }
+
+  public boolean isAlwaysOverrideSchema() {
+    DynamicBooleanProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getBooleanProperty("servicecomb.service.registry.instance.alwaysOverrideSchema",
+                false);
+    return property.get();
+  }
+
+  public boolean isPreferIpAddress() {
+    DynamicBooleanProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getBooleanProperty("servicecomb.service.registry.instance.preferIpAddress",
+                false);
+    return property.get();
+  }
+
+  public boolean isWatch() {
+    DynamicBooleanProperty property =
+        DynamicPropertyFactory.getInstance()
+            .getBooleanProperty("servicecomb.service.registry.instance.watch",
+                true);
+    return property.get();
+  }
+
+  public boolean isClientAuthEnabled() {
+    String isAuthEnabled = getProperty("false", ServiceRegistryConfig.AUTH_ENABLED);
+    return Boolean.parseBoolean(isAuthEnabled);
+  }
+
+  public String getRegistryApiVersion() {
+    return getProperty("v4", ServiceRegistryConfig.REGISTRY_API_VERSION);
+  }
+
+  public String getTenantName() {
+    return getProperty(ServiceRegistryConfig.NO_TENANT, ServiceRegistryConfig.TENANT_NAME);
+  }
+
+  public String getDomainName() {
+    return getProperty(ServiceRegistryConfig.NO_DOMAIN, ServiceRegistryConfig.DOMAIN_NAME);
+  }
+
+  public String getAccessKey() {
+    return getProperty(null, ServiceRegistryConfig.TENANT_ACCESS_KEY);
+  }
+
+  public String getSecretKey() {
+    return getProperty(null, ServiceRegistryConfig.TENANT_SECRET_KEY);
+  }
+
+  public Boolean isProxyEnable() {
+    String enable = getProperty("false", ServiceRegistryConfig.PROXY_ENABLE);
+    return Boolean.parseBoolean(enable);
+  }
+
+  public String getProxyHost() {
+    return getProperty("127.0.0.1", ServiceRegistryConfig.PROXY_HOST);
+  }
+
+  public int getProxyPort() {
+    String port = getProperty("8080", ServiceRegistryConfig.PROXY_PORT);
+    return Integer.parseInt(port);
+  }
+
+  public String getProxyUsername() {
+    return getProperty(null, ServiceRegistryConfig.PROXY_USERNAME);
+  }
+
+  public String getProxyPasswd() {
+    return getProperty(null, ServiceRegistryConfig.PROXY_PASSWD);
+  }
+
+  private String getProperty(String defaultValue, String... keys) {
+    String property = null;
+    for (String key : keys) {
+      property = DynamicPropertyFactory.getInstance().getStringProperty(key, null).get();
+      if (property != null) {
+        break;
+      }
+    }
+
+    if (property != null) {
+      return property;
+    } else {
+      return defaultValue;
+    }
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigBuilder.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigBuilder.java
@@ -25,8 +25,10 @@ import java.util.Objects;
 import org.apache.servicecomb.config.ConfigUtil;
 import org.apache.servicecomb.deployment.Deployment;
 import org.apache.servicecomb.deployment.DeploymentProvider;
+import org.apache.servicecomb.foundation.auth.AuthHeaderProvider;
 import org.apache.servicecomb.foundation.common.net.IpPort;
 import org.apache.servicecomb.foundation.common.net.NetUtils;
+import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,7 +78,8 @@ class ServiceRegistryConfigBuilder {
         .setProxyHost(getProxyHost())
         .setProxyPort(getProxyPort())
         .setProxyUsername(getProxyUsername())
-        .setProxyPasswd(getProxyPasswd());
+        .setProxyPasswd(getProxyPasswd())
+        .setAuthHeaderProviders(getAuthHeaderProviders());
   }
 
   public HttpVersion getHttpVersion() {
@@ -290,6 +293,10 @@ class ServiceRegistryConfigBuilder {
 
   public String getProxyPasswd() {
     return getProperty(null, ServiceRegistryConfig.PROXY_PASSWD);
+  }
+
+  public List<AuthHeaderProvider> getAuthHeaderProviders() {
+    return SPIServiceUtils.getAllService(AuthHeaderProvider.class);
   }
 
   private String getProperty(String defaultValue, String... keys) {

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/AppManager.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/AppManager.java
@@ -20,30 +20,22 @@ package org.apache.servicecomb.serviceregistry.consumer;
 import java.util.Map;
 
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
-import org.apache.servicecomb.serviceregistry.ServiceRegistry;
+import org.apache.servicecomb.foundation.common.event.EventManager;
 import org.apache.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
 import org.apache.servicecomb.serviceregistry.task.event.SafeModeChangeEvent;
 
 import com.google.common.eventbus.EventBus;
 
 public class AppManager {
-  private ServiceRegistry serviceRegistry;
-
   // key: appId
   private Map<String, MicroserviceManager> apps = new ConcurrentHashMapEx<>();
 
-  public AppManager(ServiceRegistry serviceRegistry) {
-    this.serviceRegistry = serviceRegistry;
-
+  public AppManager() {
     getEventBus().register(this);
   }
 
-  public ServiceRegistry getServiceRegistry() {
-    return serviceRegistry;
-  }
-
   public EventBus getEventBus() {
-    return serviceRegistry.getEventBus();
+    return EventManager.getEventBus();
   }
 
   public Map<String, MicroserviceManager> getApps() {

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/MicroserviceVersion.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/MicroserviceVersion.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.apache.servicecomb.foundation.common.VendorExtensions;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.event.CreateMicroserviceVersionEvent;
@@ -47,10 +48,7 @@ public class MicroserviceVersion {
   public MicroserviceVersion(MicroserviceVersions microserviceVersions, String microserviceId,
       String microserviceName,
       Collection<MicroserviceInstance> instances) {
-    Microservice microservice = microserviceVersions
-        .getAppManager()
-        .getServiceRegistry()
-        .getAggregatedRemoteMicroservice(microserviceId);
+    Microservice microservice = RegistryUtils.getAggregatedRemoteMicroservice(microserviceId);
     if (microservice == null) {
       throw new IllegalStateException(
           String.format("failed to query by microserviceId '%s' from ServiceCenter.", microserviceId));

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
@@ -166,7 +166,7 @@ public class MicroserviceVersions {
       return;
     }
 
-    if (!microserviceInstances.isNeedRefresh()) {
+    if (null != revision && revision.equals(microserviceInstances.getRevision())) {
       return;
     }
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/MicroserviceVersions.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import org.apache.servicecomb.foundation.common.VendorExtensions;
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.Const;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
@@ -35,9 +36,9 @@ import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import org.apache.servicecomb.serviceregistry.definition.DefinitionConst;
 import org.apache.servicecomb.serviceregistry.definition.MicroserviceNameParser;
-import org.apache.servicecomb.serviceregistry.task.event.SafeModeChangeEvent;
 import org.apache.servicecomb.serviceregistry.event.CreateMicroserviceEvent;
 import org.apache.servicecomb.serviceregistry.event.DestroyMicroserviceEvent;
+import org.apache.servicecomb.serviceregistry.task.event.SafeModeChangeEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,7 +178,7 @@ public class MicroserviceVersions {
   }
 
   protected MicroserviceInstances findServiceInstances() {
-    return appManager.getServiceRegistry().findServiceInstances(appId,
+    return RegistryUtils.findServiceInstances(appId,
         microserviceName,
         DefinitionConst.VERSION_RULE_ALL,
         revision);

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/StaticMicroserviceVersions.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/consumer/StaticMicroserviceVersions.java
@@ -20,6 +20,7 @@ package org.apache.servicecomb.serviceregistry.consumer;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.api.response.FindInstancesResponse;
@@ -48,7 +49,7 @@ public class StaticMicroserviceVersions extends MicroserviceVersions {
   public StaticMicroserviceVersions init(Class<?> schemaIntfCls, String version,
       List<MicroserviceInstance> addedInstances) {
     this.schemaIntfCls = schemaIntfCls;
-    Swagger swagger = this.appManager.getServiceRegistry().getSwaggerLoader()
+    Swagger swagger = RegistryUtils.getSwaggerLoader()
         .registerSwagger(appId, shortName, shortName, schemaIntfCls);
     String swaggerContent = SwaggerUtils.swaggerToString(swagger);
     LOGGER.info("generate swagger for 3rd party service [{}]/[{}], swagger: {}",
@@ -88,7 +89,7 @@ public class StaticMicroserviceVersions extends MicroserviceVersions {
   }
 
   private void createMicroservice(String version) {
-    String environment = appManager.getServiceRegistry().getMicroservice().getEnvironment();
+    String environment = RegistryUtils.getMicroservice().getEnvironment();
 
     microservice.setAppId(this.getAppId());
     microservice.setServiceName(this.getShortName());

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/InstanceCacheCheckTask.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/InstanceCacheCheckTask.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.consumer.AppManager;
 import org.apache.servicecomb.serviceregistry.registry.RemoteServiceRegistry;
 import org.apache.servicecomb.serviceregistry.registry.ServiceRegistryTaskInitializer;
@@ -86,7 +87,7 @@ public class InstanceCacheCheckTask implements ServiceRegistryTaskInitializer {
 
   @Override
   public void init(RemoteServiceRegistry remoteServiceRegistry) {
-    appManager = remoteServiceRegistry.getAppManager();
+    appManager = RegistryUtils.getAppManager();
     taskPool = remoteServiceRegistry.getTaskPool();
     eventBus = remoteServiceRegistry.getEventBus();
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/discovery/DiscoveryTree.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/discovery/DiscoveryTree.java
@@ -116,7 +116,6 @@ public class DiscoveryTree {
   public DiscoveryTreeNode discovery(DiscoveryContext context, String appId, String microserviceName,
       String versionRule) {
     VersionedCache instanceVersionedCache = RegistryUtils
-        .getServiceRegistry()
         .getInstanceCacheManager()
         .getOrCreateVersionedCache(appId, microserviceName, versionRule);
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
@@ -46,6 +46,8 @@ import org.apache.servicecomb.serviceregistry.consumer.MicroserviceManager;
 import org.apache.servicecomb.serviceregistry.consumer.StaticMicroserviceVersions;
 import org.apache.servicecomb.serviceregistry.definition.MicroserviceDefinition;
 import org.apache.servicecomb.serviceregistry.definition.MicroserviceNameParser;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCacheKey;
 import org.apache.servicecomb.serviceregistry.task.MicroserviceServiceCenterTask;
 import org.apache.servicecomb.serviceregistry.task.ServiceCenterTask;
 import org.apache.servicecomb.serviceregistry.task.event.RecoveryEvent;
@@ -243,6 +245,12 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
           instance.getEndpoints());
     }
     return microserviceInstances;
+  }
+
+  @Override
+  public MicroserviceCache findMicroserviceCache(MicroserviceCacheKey microserviceCacheKey) {
+    // TODO find MicroserviceCache from ServiceRegistryCache
+    return null;
   }
 
   @Override

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
@@ -39,7 +39,6 @@ import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceFactory;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
-import org.apache.servicecomb.serviceregistry.client.IpPortManager;
 import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
 import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
@@ -76,8 +75,6 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
 
   protected Microservice microservice;
 
-  protected IpPortManager ipPortManager;
-
   protected ServiceRegistryClient srClient;
 
   protected ServiceRegistryConfig serviceRegistryConfig;
@@ -101,9 +98,9 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
 
   @Override
   public void init() {
-    ipPortManager = new IpPortManager(serviceRegistryConfig, RegistryUtils.getInstanceCacheManager());
     if (srClient == null) {
       srClient = createServiceRegistryClient();
+      eventBus.register(srClient);
     }
 
     createServiceCenterTask();
@@ -141,10 +138,6 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
 
   public void setServiceRegistryClient(ServiceRegistryClient serviceRegistryClient) {
     this.srClient = serviceRegistryClient;
-  }
-
-  public IpPortManager getIpPortManager() {
-    return ipPortManager;
   }
 
   @Override

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
@@ -81,8 +81,11 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
 
   protected ExecutorService executorService = MoreExecutors.newDirectExecutorService();
 
+  private String name;
+
   public AbstractServiceRegistry(EventBus eventBus, ServiceRegistryConfig serviceRegistryConfig,
       MicroserviceDefinition microserviceDefinition) {
+    setName(serviceRegistryConfig.getRegistryName());
     this.eventBus = eventBus;
     this.serviceRegistryConfig = serviceRegistryConfig;
     this.microserviceDefinition = microserviceDefinition;
@@ -310,6 +313,16 @@ public abstract class AbstractServiceRegistry implements ServiceRegistry {
     }
 
     registerMicroserviceMapping(microserviceName, version, microserviceInstances, schemaIntfCls);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  void setName(String name) {
+    RegistryUtils.validateRegistryName(name);
+    this.name = name;
   }
 
   @Subscribe

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -58,7 +58,8 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
 
           @Override
           public Thread newThread(Runnable r) {
-            Thread thread = new Thread(r, "Service Center Task [" + (taskId++) + "]");
+            Thread thread = new Thread(r,
+                RemoteServiceRegistry.super.getName() + " Service Center Task [" + (taskId++) + "]");
             thread.setUncaughtExceptionHandler(
                 (t, e) -> LOGGER.error("Service Center Task Thread is terminated! thread: [{}]", t, e));
             return thread;

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.servicecomb.foundation.common.concurrency.SuppressedRunnableWrapper;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
 import org.apache.servicecomb.serviceregistry.client.http.ServiceRegistryClientImpl;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
@@ -83,7 +84,7 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
         TimeUnit.SECONDS);
 
     taskPool.scheduleAtFixedRate(
-        new SuppressedRunnableWrapper(appManager::pullInstances),
+        new SuppressedRunnableWrapper(RegistryUtils.getAppManager()::pullInstances),
         serviceRegistryConfig.getInstancePullInterval(),
         serviceRegistryConfig.getInstancePullInterval(),
         TimeUnit.SECONDS);

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.servicecomb.foundation.common.concurrency.SuppressedRunnableWrapper;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
-import org.apache.servicecomb.serviceregistry.client.http.ServiceRegistryClientImpl;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import org.apache.servicecomb.serviceregistry.definition.MicroserviceDefinition;
 import org.slf4j.Logger;
@@ -68,7 +67,7 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
 
   @Override
   protected ServiceRegistryClient createServiceRegistryClient() {
-    return new ServiceRegistryClientImpl(serviceRegistryConfig);
+    return serviceRegistryConfig.createServiceRegistryClient(this);
   }
 
   @Override

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -72,7 +72,7 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
 
   @Override
   protected ServiceRegistryClient createServiceRegistryClient() {
-    return new ServiceRegistryClientImpl(ipPortManager);
+    return new ServiceRegistryClientImpl(ipPortManager, serviceRegistryConfig);
   }
 
   @Override

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.servicecomb.foundation.common.concurrency.SuppressedRunnableWrapper;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
-import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
 import org.apache.servicecomb.serviceregistry.client.http.ServiceRegistryClientImpl;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
@@ -85,7 +84,9 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
         TimeUnit.SECONDS);
 
     taskPool.scheduleAtFixedRate(
-        new SuppressedRunnableWrapper(RegistryUtils.getAppManager()::pullInstances),
+        new SuppressedRunnableWrapper(() -> {
+          serviceRegistryCache.refreshCache();
+        }),
         serviceRegistryConfig.getInstancePullInterval(),
         serviceRegistryConfig.getInstancePullInterval(),
         TimeUnit.SECONDS);

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -27,13 +27,10 @@ import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
 import org.apache.servicecomb.serviceregistry.client.http.ServiceRegistryClientImpl;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import org.apache.servicecomb.serviceregistry.definition.MicroserviceDefinition;
-import org.apache.servicecomb.serviceregistry.task.HeartbeatResult;
-import org.apache.servicecomb.serviceregistry.task.MicroserviceInstanceHeartbeatTask;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.eventbus.EventBus;
-import com.google.common.eventbus.Subscribe;
 
 public class RemoteServiceRegistry extends AbstractServiceRegistry {
   private static final Logger LOGGER = LoggerFactory.getLogger(RemoteServiceRegistry.class);
@@ -71,7 +68,7 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
 
   @Override
   protected ServiceRegistryClient createServiceRegistryClient() {
-    return new ServiceRegistryClientImpl(ipPortManager, serviceRegistryConfig);
+    return new ServiceRegistryClientImpl(serviceRegistryConfig);
   }
 
   @Override
@@ -93,13 +90,6 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
 
     for (ServiceRegistryTaskInitializer initializer : taskInitializers) {
       initializer.init(this);
-    }
-  }
-
-  @Subscribe
-  public void onMicroserviceHeartbeatTask(MicroserviceInstanceHeartbeatTask event) {
-    if (HeartbeatResult.SUCCESS.equals(event.getHeartbeatResult())) {
-      ipPortManager.initAutoDiscovery();
     }
   }
 

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/ServiceRegistryFactory.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/ServiceRegistryFactory.java
@@ -52,8 +52,16 @@ public final class ServiceRegistryFactory {
     return new LocalServiceRegistry(eventBus, serviceRegistryConfig, microserviceDefinition).localFile(localFile);
   }
 
+  public static ServiceRegistry create(ServiceRegistryConfig serviceRegistryConfig,
+      MicroserviceDefinition microserviceDefinition) {
+    return create(null, serviceRegistryConfig, microserviceDefinition);
+  }
+
   public static ServiceRegistry create(EventBus eventBus, ServiceRegistryConfig serviceRegistryConfig,
       MicroserviceDefinition microserviceDefinition) {
+    if (null == eventBus) {
+      eventBus = new SimpleEventBus();
+    }
     String localModeFile = System.getProperty(LocalServiceRegistryClientImpl.LOCAL_REGISTRY_FILE_KEY);
     if (!StringUtils.isEmpty(localModeFile)) {
       LOGGER.info(

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/ServiceRegistryFactory.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/ServiceRegistryFactory.java
@@ -35,27 +35,7 @@ import com.google.common.eventbus.EventBus;
 public final class ServiceRegistryFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceRegistryFactory.class);
 
-  private static final Object LOCK = new Object();
-
-  private static volatile ServiceRegistry serviceRegistry;
-
   private ServiceRegistryFactory() {
-  }
-
-  public static ServiceRegistry getServiceRegistry() {
-    return serviceRegistry;
-  }
-
-  public static ServiceRegistry getOrCreate(EventBus eventBus, ServiceRegistryConfig serviceRegistryConfig,
-      MicroserviceDefinition microserviceDefinition) {
-    if (serviceRegistry == null) {
-      synchronized (LOCK) {
-        if (serviceRegistry == null) {
-          serviceRegistry = create(eventBus, serviceRegistryConfig, microserviceDefinition);
-        }
-      }
-    }
-    return serviceRegistry;
   }
 
   public static ServiceRegistry createLocal() {

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateMicroserviceCache.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateMicroserviceCache.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.servicecomb.serviceregistry.ServiceRegistry;
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+
+public class AggregateMicroserviceCache implements MicroserviceCache {
+  private MicroserviceCacheKey key;
+
+  Map<String, MicroserviceCache> caches;
+
+  AtomicLong revisionCounter = new AtomicLong();
+
+  private String revisionId = revisionCounter.toString();
+
+  private MicroserviceCacheStatus status = MicroserviceCacheStatus.INIT;
+
+  private List<MicroserviceInstance> instances = new ArrayList<>();
+
+  Collection<ServiceRegistry> serviceRegistries;
+
+  private final Object refreshLock = new Object();
+
+  public AggregateMicroserviceCache(MicroserviceCacheKey key, Collection<ServiceRegistry> serviceRegistries) {
+    this.key = key;
+    this.serviceRegistries = serviceRegistries;
+
+    refresh();
+  }
+
+  public void refresh() {
+    synchronized (refreshLock) {
+      fillInMicroserviceCaches();
+      fillInInstanceList();
+      updateRevisionId();
+      refreshStatus();
+    }
+  }
+
+  private void fillInMicroserviceCaches() {
+    HashMap<String, MicroserviceCache> cacheMap = new LinkedHashMap<>();
+    for (ServiceRegistry serviceRegistry : serviceRegistries) {
+      MicroserviceCache microserviceCache = serviceRegistry.findMicroserviceCache(key);
+      if (isValidMicroserviceCache(microserviceCache)) {
+        cacheMap.put(serviceRegistry.getName(), microserviceCache);
+      }
+    }
+    caches = cacheMap;
+  }
+
+  private void fillInInstanceList() {
+    ArrayList<MicroserviceInstance> instances = new ArrayList<>();
+    for (Entry<String, MicroserviceCache> stringMicroserviceCacheEntry : caches.entrySet()) {
+      instances.addAll(stringMicroserviceCacheEntry.getValue().getInstances());
+    }
+    this.instances = Collections.unmodifiableList(instances);
+  }
+
+  private void updateRevisionId() {
+    revisionCounter.incrementAndGet();
+    revisionId = revisionCounter.toString();
+  }
+
+  private void refreshStatus() {
+    if (caches.size() == 0) {
+      status = MicroserviceCacheStatus.SERVICE_NOT_FOUND;
+    } else {
+      status = MicroserviceCacheStatus.REFRESHED;
+    }
+  }
+
+  private boolean isValidMicroserviceCache(MicroserviceCache microserviceCache) {
+    return !(
+        Objects.isNull(microserviceCache)
+            || MicroserviceCacheStatus.SERVICE_NOT_FOUND.equals(microserviceCache.getStatus())
+    );
+  }
+
+  @Override
+  public MicroserviceCacheKey getKey() {
+    return key;
+  }
+
+  @Override
+  public List<MicroserviceInstance> getInstances() {
+    return instances;
+  }
+
+  @Override
+  public String getRevisionId() {
+    return revisionId;
+  }
+
+  @Override
+  public MicroserviceCacheStatus getStatus() {
+    return status;
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateServiceRegistryCache.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateServiceRegistryCache.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
+import org.apache.servicecomb.serviceregistry.ServiceRegistry;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache.MicroserviceCacheStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.eventbus.Subscribe;
+
+public class AggregateServiceRegistryCache implements ServiceRegistryCache {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(AggregateServiceRegistryCache.class);
+
+  Collection<ServiceRegistry> serviceRegistries;
+
+  final Map<MicroserviceCacheKey, AggregateMicroserviceCache> microserviceCache = new ConcurrentHashMapEx<>();
+
+  private Consumer<List<MicroserviceCache>> cacheRefreshedWatcher;
+
+  public AggregateServiceRegistryCache(Collection<ServiceRegistry> serviceRegistries) {
+    this.serviceRegistries = serviceRegistries;
+  }
+
+  @Override
+  public MicroserviceCache findServiceCache(MicroserviceCacheKey microserviceCacheKey) {
+    AggregateMicroserviceCache microserviceCache = this.microserviceCache.computeIfAbsent(microserviceCacheKey,
+        key -> new AggregateMicroserviceCache(key, serviceRegistries));
+    removeMicroserviceCacheIfNotExist(microserviceCache);
+    return microserviceCache;
+  }
+
+  @Override
+  public ServiceRegistryCache setCacheRefreshedWatcher(Consumer<List<MicroserviceCache>> cacheRefreshedWatcher) {
+    this.cacheRefreshedWatcher = cacheRefreshedWatcher;
+    return this;
+  }
+
+  @Subscribe
+  public void onMicroserviceCacheRefreshed(MicroserviceCacheRefreshedEvent event) {
+    List<MicroserviceCache> microserviceCaches = event.getMicroserviceCaches();
+    if (null == microserviceCaches || microserviceCaches.isEmpty()) {
+      return;
+    }
+
+    List<MicroserviceCache> refreshedAggregateMicroserviceCaches = microserviceCaches.stream()
+        .map(cache -> this.microserviceCache.get(cache.getKey()))
+        .filter(Objects::nonNull)
+        .peek(AggregateMicroserviceCache::refresh)
+        .peek(this::removeMicroserviceCacheIfNotExist)
+        .collect(Collectors.toList());
+
+    LOGGER.info("[{}] caches get refreshed", refreshedAggregateMicroserviceCaches.size());
+    refreshedAggregateMicroserviceCaches.forEach(cache -> {
+      LOGGER.info("[{}]: status={}, revisionId={}", cache.getKey(), cache.getStatus(), cache.getRevisionId());
+    });
+
+    if (null != cacheRefreshedWatcher) {
+      cacheRefreshedWatcher.accept(refreshedAggregateMicroserviceCaches);
+    }
+  }
+
+  private void removeMicroserviceCacheIfNotExist(MicroserviceCache cache) {
+    if (MicroserviceCacheStatus.SERVICE_NOT_FOUND.equals(cache.getStatus())) {
+      microserviceCache.remove(cache.getKey());
+      LOGGER.info("microserviceCache[{}] got removed", cache.getKey());
+    }
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCache.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCache.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.List;
+
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+
+public interface MicroserviceCache {
+  MicroserviceCacheKey getKey();
+
+  List<MicroserviceInstance> getInstances();
+
+  String getRevisionId();
+
+  MicroserviceCacheStatus getStatus();
+
+  enum MicroserviceCacheStatus {
+    /**
+     * init status, not pull instances from sc yet
+     */
+    INIT,
+    /**
+     * unknown error
+     */
+    UNKNOWN_ERROR,
+    /**
+     * error occurs while getting access to service center
+     */
+    CLIENT_ERROR,
+    /**
+     * success to query the service center, but no target microservice found
+     */
+    SERVICE_NOT_FOUND,
+    /**
+     * success to query the service center, but the target microservice instance list is not changed
+     */
+    NO_CHANGE,
+    /**
+     * success to query the service center, and the target microservice instance list is changed.
+     * the cached instance list gets refreshed successfully.
+     */
+    REFRESHED,
+    /**
+     * unknown error occurs while setting the pulled instances into this cache
+     */
+    SETTING_CACHE_ERROR
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheKey.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheKey.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.Objects;
+
+import org.apache.servicecomb.serviceregistry.definition.DefinitionConst;
+import org.apache.servicecomb.serviceregistry.definition.MicroserviceNameParser;
+
+public class MicroserviceCacheKey {
+  private String env;
+
+  private String appId;
+
+  private String serviceName;
+
+  private static final String VERSION_RULE = DefinitionConst.VERSION_RULE_ALL;
+
+  public static MicroserviceCacheKeyBuilder builder() {
+    return new MicroserviceCacheKeyBuilder();
+  }
+
+  MicroserviceCacheKey() {
+  }
+
+  public void validate() {
+    Objects.requireNonNull(this.env, "microserviceCacheKey.env is null");
+    Objects.requireNonNull(this.appId, "microserviceCacheKey.appId is null");
+    Objects.requireNonNull(this.serviceName, "microserviceCacheKey.serviceName is null");
+  }
+
+  public String getEnv() {
+    return env;
+  }
+
+  public String getAppId() {
+    return appId;
+  }
+
+  public String getServiceName() {
+    return serviceName;
+  }
+
+  public String getVersionRule() {
+    return VERSION_RULE;
+  }
+
+  public String plainKey() {
+    return serviceName + "@" + appId + "@" + env;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MicroserviceCacheKey that = (MicroserviceCacheKey) o;
+    return Objects.equals(env, that.env) &&
+        Objects.equals(appId, that.appId) &&
+        Objects.equals(serviceName, that.serviceName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(env, appId, serviceName);
+  }
+
+  @Override
+  public String toString() {
+    return plainKey();
+  }
+
+  public static class MicroserviceCacheKeyBuilder {
+    private MicroserviceCacheKey microserviceCacheKey;
+
+    public MicroserviceCacheKey build() {
+      microserviceCacheKey.validate();
+      MicroserviceNameParser microserviceNameParser =
+          new MicroserviceNameParser(microserviceCacheKey.appId, microserviceCacheKey.serviceName);
+      microserviceCacheKey.appId = microserviceNameParser.getAppId();
+      microserviceCacheKey.serviceName = microserviceNameParser.getShortName();
+      return microserviceCacheKey;
+    }
+
+    public MicroserviceCacheKeyBuilder env(String env) {
+      microserviceCacheKey.env = env;
+      return this;
+    }
+
+    public MicroserviceCacheKeyBuilder appId(String appId) {
+      microserviceCacheKey.appId = appId;
+      return this;
+    }
+
+    public MicroserviceCacheKeyBuilder serviceName(String serviceName) {
+      microserviceCacheKey.serviceName = serviceName;
+      return this;
+    }
+
+    MicroserviceCacheKeyBuilder() {
+      microserviceCacheKey = new MicroserviceCacheKey();
+    }
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheRefreshedEvent.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheRefreshedEvent.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.List;
+
+public class MicroserviceCacheRefreshedEvent {
+  private final List<MicroserviceCache> microserviceCaches;
+
+  public MicroserviceCacheRefreshedEvent(List<MicroserviceCache> microserviceCaches) {
+    this.microserviceCaches = microserviceCaches;
+  }
+
+  public List<MicroserviceCache> getMicroserviceCaches() {
+    return microserviceCaches;
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableMicroserviceCache.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableMicroserviceCache.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
+import org.apache.servicecomb.serviceregistry.api.Const;
+import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import org.apache.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import org.apache.servicecomb.serviceregistry.consumer.MicroserviceInstancePing;
+import org.apache.servicecomb.serviceregistry.task.event.SafeModeChangeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RefreshableMicroserviceCache implements MicroserviceCache {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RefreshableMicroserviceCache.class);
+
+  MicroserviceCacheKey key;
+
+  List<MicroserviceInstance> instances = Collections.unmodifiableList(new ArrayList<>());
+
+  Microservice consumerService;
+
+  String revisionId;
+
+  ServiceRegistryClient srClient;
+
+  boolean safeMode;
+
+  MicroserviceCacheStatus status = MicroserviceCacheStatus.INIT;
+
+  private final Object SET_OPERATION_LOCK = new Object();
+
+  boolean emptyInstanceProtectionEnabled;
+
+  MicroserviceInstancePing instancePing = SPIServiceUtils.getPriorityHighestService(MicroserviceInstancePing.class);
+
+  RefreshableMicroserviceCache(Microservice consumerService, MicroserviceCacheKey key, ServiceRegistryClient srClient,
+      boolean emptyInstanceProtectionEnabled) {
+    this.key = key;
+    this.consumerService = consumerService;
+    this.srClient = srClient;
+    this.emptyInstanceProtectionEnabled = emptyInstanceProtectionEnabled;
+  }
+
+  void refresh() {
+    safePullInstance(revisionId);
+  }
+
+  void forceRefresh() {
+    safePullInstance(null);
+  }
+
+  private void safePullInstance(String revisionId) {
+    try {
+      pullInstance(revisionId);
+    } catch (Throwable e) {
+      LOGGER.error("unknown error occurs while pulling instances", e);
+      setStatus(MicroserviceCacheStatus.UNKNOWN_ERROR);
+    }
+  }
+
+  void pullInstance(String revisionId) {
+    MicroserviceInstances serviceInstances = pullInstanceFromServiceCenter(revisionId);
+
+    if (serviceInstances == null) {
+      LOGGER.error("Can not find any instances from service center due to previous errors. service={}/{}/{}",
+          key.getAppId(),
+          key.getServiceName(),
+          key.getVersionRule());
+      setStatus(MicroserviceCacheStatus.CLIENT_ERROR);
+      return;
+    }
+
+    if (serviceInstances.isMicroserviceNotExist()) {
+      setStatus(MicroserviceCacheStatus.SERVICE_NOT_FOUND);
+      return;
+    }
+
+    if (!serviceInstances.isNeedRefresh()) {
+      LOGGER.debug("instances revision is not changed, service={}/{}/{}", key.getAppId(), key.getServiceName(),
+          key.getVersionRule());
+      setStatus(MicroserviceCacheStatus.NO_CHANGE);
+      return;
+    }
+
+    List<MicroserviceInstance> instances = serviceInstances.getInstancesResponse().getInstances();
+    LOGGER.info("find instances[{}] from service center success. service={}/{}/{}, old revision={}, new revision={}",
+        instances.size(),
+        key.getAppId(),
+        key.getServiceName(),
+        key.getVersionRule(),
+        this.revisionId,
+        serviceInstances.getRevision());
+    for (MicroserviceInstance instance : instances) {
+      LOGGER.info("service id={}, instance id={}, endpoints={}",
+          instance.getServiceId(),
+          instance.getInstanceId(),
+          instance.getEndpoints());
+    }
+    safeSetInstances(instances, serviceInstances.getRevision());
+  }
+
+  MicroserviceInstances pullInstanceFromServiceCenter(String revisionId) {
+    return srClient.findServiceInstances(consumerService.getServiceId(),
+        key.getAppId(), key.getServiceName(), key.getVersionRule(), revisionId);
+  }
+
+  private void safeSetInstances(List<MicroserviceInstance> pulledInstances, String rev) {
+    try {
+      synchronized (SET_OPERATION_LOCK) {
+        setInstances(pulledInstances, rev);
+        setStatus(MicroserviceCacheStatus.REFRESHED);
+      }
+    } catch (Throwable e) {
+      setStatus(MicroserviceCacheStatus.SETTING_CACHE_ERROR);
+      LOGGER.error("Failed to setInstances, appId={}, microserviceName={}.",
+          key.getAppId(),
+          key.getServiceName(),
+          e);
+    }
+  }
+
+  private void setInstances(List<MicroserviceInstance> pulledInstances, String rev) {
+    Set<MicroserviceInstance> mergedInstances = mergeInstances(pulledInstances);
+    LOGGER.debug("actually set instances[{}] for {}", mergedInstances.size(), key.plainKey());
+    for (MicroserviceInstance mergedInstance : mergedInstances) {
+      LOGGER.debug("serviceId={}, instanceId={}, endpoints={}",
+          mergedInstance.getServiceId(),
+          mergedInstance.getInstanceId(),
+          mergedInstance.getEndpoints());
+    }
+    instances = Collections.unmodifiableList(new ArrayList<>(mergedInstances));
+    revisionId = rev;
+  }
+
+  protected Set<MicroserviceInstance> mergeInstances(List<MicroserviceInstance> pulledInstances) {
+    Set<MicroserviceInstance> mergedInstances = new LinkedHashSet<>(pulledInstances);
+
+    if (safeMode) {
+      // in safe mode, instances will never be deleted
+      mergedInstances.addAll(instances);
+      return mergedInstances;
+    }
+
+    if (!inEmptyPulledInstancesProtectionSituation(pulledInstances)) {
+      return mergedInstances;
+    }
+
+    if (null == instancePing) {
+      LOGGER.info("no MicroserviceInstancePing implementation loaded, abandon the old instance list");
+      return mergedInstances;
+    }
+
+    instances.forEach(instance -> {
+      if (!mergedInstances.contains(instance)) {
+        if (instancePing.ping(instance)) {
+          mergedInstances.add(instance);
+        }
+      }
+    });
+    return mergedInstances;
+  }
+
+  private boolean inEmptyPulledInstancesProtectionSituation(List<MicroserviceInstance> pulledInstances) {
+    return pulledInstances.isEmpty()
+        && instances != null
+        && !instances.isEmpty()
+        && isEmptyInstanceProtectionEnabled();
+  }
+
+  @Override
+  public MicroserviceCacheKey getKey() {
+    return key;
+  }
+
+  @Override
+  public List<MicroserviceInstance> getInstances() {
+    return instances;
+  }
+
+  @Override
+  public String getRevisionId() {
+    return revisionId;
+  }
+
+  void clearRevisionId() {
+    revisionId = null;
+  }
+
+  @Override
+  public MicroserviceCacheStatus getStatus() {
+    return status;
+  }
+
+  void setStatus(MicroserviceCacheStatus status) {
+    this.status = status;
+  }
+
+  boolean isEmptyInstanceProtectionEnabled() {
+    return emptyInstanceProtectionEnabled;
+  }
+
+  void setEmptyInstanceProtectionEnabled(boolean emptyInstanceProtectionEnabled) {
+    this.emptyInstanceProtectionEnabled = emptyInstanceProtectionEnabled;
+  }
+
+  void onMicroserviceInstanceChanged(MicroserviceInstanceChangedEvent event) {
+    if (!microserviceMatched(event)) {
+      return;
+    }
+    refresh();
+  }
+
+  void onSafeModeChanged(SafeModeChangeEvent modeChangeEvent) {
+    this.safeMode = modeChangeEvent.getCurrentMode();
+  }
+
+  private boolean microserviceMatched(MicroserviceInstanceChangedEvent event) {
+    return (key.getAppId().equals(event.getKey().getAppId())) // appId matched
+        && ( // microserviceName matched
+        key.getServiceName().equals(event.getKey().getServiceName())
+            || key.getServiceName().equals(
+            event.getKey().getAppId() + Const.APP_SERVICE_SEPARATOR + event.getKey().getServiceName()
+        ));
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableServiceRegistryCache.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableServiceRegistryCache.java
@@ -1,0 +1,182 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
+import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
+import org.apache.servicecomb.serviceregistry.api.response.MicroserviceInstanceChangedEvent;
+import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache.MicroserviceCacheStatus;
+import org.apache.servicecomb.serviceregistry.task.event.SafeModeChangeEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cache the pulled microservice instances.
+ */
+public class RefreshableServiceRegistryCache implements ServiceRegistryCache {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RefreshableServiceRegistryCache.class);
+
+  Map<MicroserviceCacheKey, RefreshableMicroserviceCache> microserviceCache = new ConcurrentHashMapEx<>();
+
+  Microservice consumerService;
+
+  ServiceRegistryClient srClient;
+
+  boolean emptyInstanceProtectionEnabled = false;
+
+  Consumer<List<MicroserviceCache>> cacheRefreshedWatcher;
+
+  ReentrantLock refreshLock = new ReentrantLock();
+
+  public RefreshableServiceRegistryCache(Microservice consumerService, ServiceRegistryClient srClient) {
+    this.consumerService = consumerService;
+    this.srClient = srClient;
+  }
+
+  public void refreshCache() {
+    if (!refreshLock.tryLock()) {
+      LOGGER.info("ignore concurrent refresh request");
+      return;
+    }
+
+    try {
+      List<MicroserviceCache> refreshedCaches = refreshInnerState(false);
+      notifyWatcher(refreshedCaches);
+    } catch (Exception e) {
+      LOGGER.error("failed to refresh caches", e);
+    } finally {
+      refreshLock.unlock();
+    }
+  }
+
+  public void forceRefreshCache() {
+    refreshLock.lock();
+    try {
+      List<MicroserviceCache> refreshedCaches = refreshInnerState(true);
+      notifyWatcher(refreshedCaches);
+    } catch (Exception e) {
+      LOGGER.error("failed to refresh caches", e);
+    } finally {
+      refreshLock.unlock();
+    }
+  }
+
+  private List<MicroserviceCache> refreshInnerState(boolean isForced) {
+    return microserviceCache.values().stream()
+        .peek(cache -> {
+          if (isForced) {
+            cache.forceRefresh();
+          } else {
+            cache.refresh();
+          }
+        })
+        .filter(this::isRefreshedMicroserviceCache)
+        .peek(this::removeCacheIfServiceNotFound)
+        .collect(Collectors.toList());
+  }
+
+  private boolean isRefreshedMicroserviceCache(MicroserviceCache microserviceCache) {
+    return MicroserviceCacheStatus.REFRESHED.equals(microserviceCache.getStatus())
+        || MicroserviceCacheStatus.SERVICE_NOT_FOUND.equals(microserviceCache.getStatus());
+  }
+
+  private void notifyWatcher(List<MicroserviceCache> refreshedCaches) {
+    if (refreshedCaches.isEmpty() || null == cacheRefreshedWatcher) {
+      return;
+    }
+    cacheRefreshedWatcher.accept(refreshedCaches);
+  }
+
+  @Override
+  public MicroserviceCache findServiceCache(MicroserviceCacheKey microserviceCacheKey) {
+    microserviceCacheKey.validate();
+    RefreshableMicroserviceCache targetCache = microserviceCache
+        .computeIfAbsent(microserviceCacheKey, pk -> {
+          RefreshableMicroserviceCache microserviceCache = createMicroserviceCache(microserviceCacheKey);
+          microserviceCache.refresh();
+          return microserviceCache;
+        });
+    removeCacheIfServiceNotFound(targetCache);
+    return targetCache;
+  }
+
+  private void removeCacheIfServiceNotFound(MicroserviceCache targetCache) {
+    if (MicroserviceCacheStatus.SERVICE_NOT_FOUND.equals(targetCache.getStatus())) {
+      microserviceCache.remove(targetCache.getKey());
+      LOGGER.info("microserviceCache[{}] got removed", targetCache.getKey());
+    }
+  }
+
+  RefreshableMicroserviceCache createMicroserviceCache(MicroserviceCacheKey microserviceCacheKey) {
+    return new RefreshableMicroserviceCache(
+        consumerService,
+        microserviceCacheKey,
+        srClient,
+        emptyInstanceProtectionEnabled);
+  }
+
+  public RefreshableServiceRegistryCache setEmptyInstanceProtectionEnabled(boolean emptyInstanceProtectionEnabled) {
+    this.emptyInstanceProtectionEnabled = emptyInstanceProtectionEnabled;
+    return this;
+  }
+
+  @Override
+  public ServiceRegistryCache setCacheRefreshedWatcher(
+      Consumer<List<MicroserviceCache>> cacheRefreshedWatcher) {
+    this.cacheRefreshedWatcher = cacheRefreshedWatcher;
+    return this;
+  }
+
+  public void clearRevisionId(MicroserviceCacheKey key) {
+    RefreshableMicroserviceCache microserviceCache = this.microserviceCache.get(key);
+    if (null != microserviceCache) {
+      microserviceCache.clearRevisionId();
+    }
+  }
+
+  public void clearAllRevisionId() {
+    for (Entry<MicroserviceCacheKey, RefreshableMicroserviceCache> cacheEntry : microserviceCache.entrySet()) {
+      cacheEntry.getValue().clearRevisionId();
+    }
+  }
+
+  public void onMicroserviceInstanceChanged(MicroserviceInstanceChangedEvent event) {
+    List<MicroserviceCache> refreshedCaches =
+        microserviceCache.entrySet().stream()
+            .peek(cacheEntry -> cacheEntry.getValue().onMicroserviceInstanceChanged(event))
+            .filter(cacheEntry -> isRefreshedMicroserviceCache(cacheEntry.getValue()))
+            .map(Entry::getValue)
+            .collect(Collectors.toList());
+
+    notifyWatcher(refreshedCaches);
+  }
+
+  public void onSafeModeChanged(SafeModeChangeEvent modeChangeEvent) {
+    for (Entry<MicroserviceCacheKey, RefreshableMicroserviceCache> cacheEntry : microserviceCache.entrySet()) {
+      cacheEntry.getValue().onSafeModeChanged(modeChangeEvent);
+    }
+  }
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/ServiceRegistryCache.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/ServiceRegistryCache.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface ServiceRegistryCache {
+  MicroserviceCache findServiceCache(MicroserviceCacheKey microserviceCacheKey);
+
+  ServiceRegistryCache setCacheRefreshedWatcher(Consumer<List<MicroserviceCache>> cacheRefreshedWatcher);
+}

--- a/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/swagger/SwaggerLoader.java
+++ b/service-registry/src/main/java/org/apache/servicecomb/serviceregistry/swagger/SwaggerLoader.java
@@ -27,7 +27,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
 import org.apache.servicecomb.foundation.common.utils.JvmUtils;
 import org.apache.servicecomb.foundation.common.utils.ResourceUtil;
-import org.apache.servicecomb.serviceregistry.ServiceRegistry;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.definition.MicroserviceNameParser;
 import org.apache.servicecomb.swagger.SwaggerUtils;
@@ -40,15 +40,12 @@ import io.swagger.models.Swagger;
 public class SwaggerLoader {
   private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerLoader.class);
 
-  private ServiceRegistry serviceRegistry;
-
   // first key : appId
   // second key: microservice short name
   // third key : schemaId
   private Map<String, Map<String, Map<String, Swagger>>> apps = new ConcurrentHashMapEx<>();
 
-  public SwaggerLoader(ServiceRegistry serviceRegistry) {
-    this.serviceRegistry = serviceRegistry;
+  public SwaggerLoader() {
   }
 
   /**
@@ -67,7 +64,7 @@ public class SwaggerLoader {
    * @param swaggersLocation eg. "test/schemas", will load all test/schemas/*.yaml
    */
   public void registerSwaggersInLocation(String swaggersLocation) {
-    String microserviceName = serviceRegistry.getMicroservice().getServiceName();
+    String microserviceName = RegistryUtils.getMicroservice().getServiceName();
     registerSwaggersInLocation(microserviceName, swaggersLocation);
   }
 
@@ -93,7 +90,7 @@ public class SwaggerLoader {
   }
 
   public void registerSwagger(String schemaId, Swagger swagger) {
-    registerSwagger(serviceRegistry.getMicroservice().getServiceName(), schemaId, swagger);
+    registerSwagger(RegistryUtils.getMicroservice().getServiceName(), schemaId, swagger);
   }
 
   public void registerSwagger(String microserviceName, String schemaId, String swaggerContent) {
@@ -108,7 +105,7 @@ public class SwaggerLoader {
   }
 
   public void registerSwagger(String microserviceName, String schemaId, Swagger swagger) {
-    MicroserviceNameParser parser = new MicroserviceNameParser(serviceRegistry.getAppId(), microserviceName);
+    MicroserviceNameParser parser = new MicroserviceNameParser(RegistryUtils.getAppId(), microserviceName);
     registerSwagger(parser.getAppId(), parser.getShortName(), schemaId, swagger);
   }
 
@@ -160,7 +157,7 @@ public class SwaggerLoader {
   }
 
   private Swagger loadFromResource(String appId, String shortName, String schemaId) {
-    if (appId.equals(serviceRegistry.getAppId())) {
+    if (appId.equals(RegistryUtils.getAppId())) {
       Swagger swagger = loadFromResource(String.format("microservices/%s/%s.yaml", shortName, schemaId));
       if (swagger != null) {
         return swagger;
@@ -181,7 +178,7 @@ public class SwaggerLoader {
   }
 
   private Swagger loadFromRemote(Microservice microservice, String schemaId) {
-    String schemaContent = serviceRegistry.getServiceRegistryClient()
+    String schemaContent = RegistryUtils
         .getAggregatedSchema(microservice.getServiceId(), schemaId);
     if (schemaContent != null) {
       LOGGER.info(

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/MockMicroserviceVersions.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/MockMicroserviceVersions.java
@@ -30,7 +30,6 @@ import org.apache.servicecomb.serviceregistry.consumer.AppManager;
 import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersion;
 import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersionRule;
 import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersions;
-import org.apache.servicecomb.serviceregistry.registry.ServiceRegistryFactory;
 import org.apache.servicecomb.serviceregistry.version.Version;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -45,14 +44,16 @@ public class MockMicroserviceVersions extends MicroserviceVersions {
   private List<MicroserviceInstance> mockedInstances = new ArrayList<>();
 
   public MockMicroserviceVersions() {
-    super(new AppManager(ServiceRegistryFactory.createLocal()), "appId", "msName");
+    super(new AppManager(), "appId", "msName");
 
-    new MockUp<ServiceRegistry>(appManager.getServiceRegistry()) {
+    ServiceRegistry serviceRegistry = new MockUp<ServiceRegistry>() {
       @Mock
       Microservice getAggregatedRemoteMicroservice(String microserviceId) {
         return mockedMicroservices.get(microserviceId);
       }
-    };
+    }.getMockInstance();
+
+    RegistryUtils.setServiceRegistry(serviceRegistry);
 
     addMock("1.0.0", 2);
     addMock("2.0.0", 2);

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/MockMicroserviceVersions.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/MockMicroserviceVersions.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.apache.servicecomb.foundation.common.event.EventManager;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.consumer.AppManager;
@@ -33,6 +34,8 @@ import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersions;
 import org.apache.servicecomb.serviceregistry.version.Version;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+
+import com.google.common.eventbus.EventBus;
 
 import mockit.Mock;
 import mockit.MockUp;
@@ -50,6 +53,11 @@ public class MockMicroserviceVersions extends MicroserviceVersions {
       @Mock
       Microservice getAggregatedRemoteMicroservice(String microserviceId) {
         return mockedMicroservices.get(microserviceId);
+      }
+
+      @Mock
+      EventBus getEventBus() {
+        return EventManager.getEventBus();
       }
     }.getMockInstance();
 

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/RegistryUtilsTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/RegistryUtilsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry;
+
+import java.util.Collections;
+
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache.MicroserviceCacheStatus;
+import org.apache.servicecomb.serviceregistry.registry.cache.MockedMicroserviceCache;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class RegistryUtilsTest {
+  @Test
+  public void convertCacheToMicroserviceInstances() {
+    MockedMicroserviceCache microserviceCache = new MockedMicroserviceCache();
+    microserviceCache.setStatus(MicroserviceCacheStatus.CLIENT_ERROR);
+    MicroserviceInstances microserviceInstances = RegistryUtils
+        .convertCacheToMicroserviceInstances(microserviceCache);
+    Assert.assertNull(microserviceInstances);
+
+    microserviceCache = new MockedMicroserviceCache();
+    microserviceCache.setStatus(MicroserviceCacheStatus.SETTING_CACHE_ERROR);
+    microserviceInstances = RegistryUtils.convertCacheToMicroserviceInstances(microserviceCache);
+    Assert.assertNull(microserviceInstances);
+
+    microserviceCache = new MockedMicroserviceCache();
+    microserviceCache.setStatus(MicroserviceCacheStatus.INIT);
+    microserviceInstances = RegistryUtils.convertCacheToMicroserviceInstances(microserviceCache);
+    Assert.assertNull(microserviceInstances);
+
+    microserviceCache = new MockedMicroserviceCache();
+    microserviceCache.setStatus(MicroserviceCacheStatus.SERVICE_NOT_FOUND);
+    microserviceInstances = RegistryUtils.convertCacheToMicroserviceInstances(microserviceCache);
+    Assert.assertTrue(microserviceInstances.isMicroserviceNotExist());
+    Assert.assertFalse(microserviceInstances.isNeedRefresh());
+    Assert.assertEquals("", microserviceInstances.getRevision());
+    Assert.assertNull(microserviceInstances.getInstancesResponse());
+
+    microserviceCache = new MockedMicroserviceCache();
+    microserviceCache.setStatus(MicroserviceCacheStatus.REFRESHED);
+    microserviceCache.setRevisionId("0166f3c18702617d5e55cf911e4e412cc8760dab");
+    MicroserviceInstance microserviceInstance = new MicroserviceInstance();
+    microserviceCache.setInstances(Collections.singletonList(microserviceInstance));
+    microserviceInstances = RegistryUtils.convertCacheToMicroserviceInstances(microserviceCache);
+    Assert.assertFalse(microserviceInstances.isMicroserviceNotExist());
+    Assert.assertTrue(microserviceInstances.isNeedRefresh());
+    Assert.assertEquals("0166f3c18702617d5e55cf911e4e412cc8760dab", microserviceInstances.getRevision());
+    Assert.assertEquals(1, microserviceInstances.getInstancesResponse().getInstances().size());
+    Assert.assertSame(microserviceInstance, microserviceInstances.getInstancesResponse().getInstances().get(0));
+
+    microserviceCache = new MockedMicroserviceCache();
+    microserviceCache.setStatus(MicroserviceCacheStatus.NO_CHANGE);
+    microserviceCache.setRevisionId("0166f3c18702617d5e55cf911e4e412cc8760dab");
+    microserviceInstances = RegistryUtils.convertCacheToMicroserviceInstances(microserviceCache);
+    Assert.assertFalse(microserviceInstances.isMicroserviceNotExist());
+    Assert.assertFalse(microserviceInstances.isNeedRefresh());
+    Assert.assertEquals("0166f3c18702617d5e55cf911e4e412cc8760dab", microserviceInstances.getRevision());
+    Assert.assertNull(microserviceInstances.getInstancesResponse());
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/ServiceRegistryTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/ServiceRegistryTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.regex.Matcher;
+
+import org.junit.Test;
+
+public class ServiceRegistryTest {
+  @Test
+  public void testNameFormat() {
+    Matcher matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("abc");
+    assertTrue(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("abc00");
+    assertTrue(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("ABC");
+    assertTrue(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("A2BC");
+    assertTrue(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("abc-ABC");
+    assertTrue(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("abc_ABC");
+    assertTrue(matcher.matches());
+
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("-abc");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("abc-");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("_abc");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("abc_");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("0abc");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("ab.c");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("ab?c");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("ab#c");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("ab&c");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("ab*c");
+    assertFalse(matcher.matches());
+    matcher = ServiceRegistry.REGISTRY_NAME_PATTERN.matcher("ab@c");
+    assertFalse(matcher.matches());
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestConsumers.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestConsumers.java
@@ -109,9 +109,9 @@ public class TestConsumers extends TestRegistryBase {
 
   @Test
   public void deleteWhenCreateMicroserviceVersion() {
-    new Expectations(appManager.getServiceRegistry()) {
+    new Expectations(RegistryUtils.getServiceRegistry()) {
       {
-        appManager.getServiceRegistry().getAggregatedRemoteMicroservice(serviceId);
+        RegistryUtils.getServiceRegistry().getAggregatedRemoteMicroservice(serviceId);
         result = null;
       }
     };

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestConsumers.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestConsumers.java
@@ -71,23 +71,6 @@ public class TestConsumers extends TestRegistryBase {
     MicroserviceInstanceChangedEvent event = new MicroserviceInstanceChangedEvent();
     event.setKey(key);
 
-    // not match
-    key.setAppId(appId + "1");
-    key.setServiceName(serviceName + "1");
-    eventBus.post(event);
-    Assert.assertEquals(1, microserviceManager.getVersionsByName().size());
-
-    key.setAppId(appId + "1");
-    key.setServiceName(serviceName);
-    eventBus.post(event);
-    Assert.assertEquals(1, microserviceManager.getVersionsByName().size());
-
-    key.setAppId(appId);
-    key.setServiceName(serviceName + "1");
-    eventBus.post(event);
-    Assert.assertEquals(1, microserviceManager.getVersionsByName().size());
-
-    // match
     key.setAppId(appId);
     key.setServiceName(serviceName);
     eventBus.post(event);

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistry.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistry.java
@@ -22,7 +22,7 @@ import static org.apache.servicecomb.serviceregistry.RegistryUtils.PUBLISH_ADDRE
 import java.net.InetAddress;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +79,7 @@ public class TestRegistry {
     inMemoryConfig.clear();
   }
 
+  @SuppressWarnings("deprecation")
   @Test
   public void testDelegate() {
     ServiceRegistry serviceRegistry = ServiceRegistryFactory.createLocal();
@@ -99,7 +100,7 @@ public class TestRegistry {
     Assert.assertEquals(RegistryUtils.getMicroservice().getServiceId(), instanceList.get(0).getServiceId());
 
     instanceList = RegistryUtils.findServiceInstance("default", "notExists", "0.0.1");
-    Assert.assertEquals(null, instanceList);
+    Assert.assertNull(instanceList);
 
     MicroserviceInstances microserviceInstances =
         RegistryUtils.findServiceInstances("default", "default", "0.0.1", "0");
@@ -193,7 +194,7 @@ public class TestRegistry {
     };
 
     Assert.assertEquals("rest://172.0.0.0:8080", RegistryUtils.getPublishAddress("rest", "172.0.0.0:8080"));
-    Assert.assertEquals(null, RegistryUtils.getPublishAddress("rest", null));
+    Assert.assertNull(RegistryUtils.getPublishAddress("rest", null));
 
     URI uri = new URI(RegistryUtils.getPublishAddress("rest", "0.0.0.0:8080"));
     Assert.assertEquals("1.1.1.1:8080", uri.getAuthority());
@@ -224,7 +225,7 @@ public class TestRegistry {
         };
       }
     };
-    String query = URLEncodedUtils.format(Arrays.asList(new BasicNameValuePair("country", "中 国")),
+    String query = URLEncodedUtils.format(Collections.singletonList(new BasicNameValuePair("country", "中 国")),
         StandardCharsets.UTF_8.name());
     Assert.assertEquals("rest://1.1.1.1:8080?" + query,
         RegistryUtils.getPublishAddress("rest", "172.0.0.0:8080?" + query));

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistry.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistry.java
@@ -89,7 +89,6 @@ public class TestRegistry {
     Assert.assertEquals(serviceRegistry, RegistryUtils.getServiceRegistry());
 
     Assert.assertEquals(serviceRegistry.getServiceRegistryClient(), RegistryUtils.getServiceRegistryClient());
-    Assert.assertEquals(serviceRegistry.getInstanceCacheManager(), RegistryUtils.getInstanceCacheManager());
 
     Microservice microservice = RegistryUtils.getMicroservice();
     Assert.assertEquals(serviceRegistry.getMicroservice(), microservice);

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistryBase.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistryBase.java
@@ -29,6 +29,7 @@ import org.junit.Before;
 
 import com.google.common.eventbus.EventBus;
 
+import mockit.Deencapsulation;
 import mockit.Expectations;
 
 public class TestRegistryBase {
@@ -66,11 +67,12 @@ public class TestRegistryBase {
     serviceRegistry = ServiceRegistryFactory.createLocal("registry.yaml");
     serviceRegistry.init();
 
-    appManager = serviceRegistry.getAppManager();
+    Deencapsulation.setField(RegistryUtils.class, "appManager", new AppManager());
+    appManager = RegistryUtils.getAppManager();
     microserviceManager = appManager.getOrCreateMicroserviceManager(appId);
     eventBus = serviceRegistry.getEventBus();
 
-    serviceRegistry.getSwaggerLoader().registerSwagger(appId, serviceName, schemaId, Hello.class);
+    RegistryUtils.getSwaggerLoader().registerSwagger(appId, serviceName, schemaId, Hello.class);
 
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
@@ -86,9 +88,9 @@ public class TestRegistryBase {
   protected void mockNotExist() {
     MicroserviceInstances microserviceInstances = new MicroserviceInstances();
     microserviceInstances.setMicroserviceNotExist(true);
-    new Expectations(appManager.getServiceRegistry()) {
+    new Expectations(RegistryUtils.getServiceRegistry()) {
       {
-        appManager.getServiceRegistry()
+        RegistryUtils.getServiceRegistry()
             .findServiceInstances(anyString, anyString, DefinitionConst.VERSION_RULE_ALL, anyString);
         result = microserviceInstances;
       }
@@ -96,9 +98,9 @@ public class TestRegistryBase {
   }
 
   protected void mockDisconnect() {
-    new Expectations(appManager.getServiceRegistry()) {
+    new Expectations(RegistryUtils.getServiceRegistry()) {
       {
-        appManager.getServiceRegistry()
+        RegistryUtils.getServiceRegistry()
             .findServiceInstances(anyString, anyString, DefinitionConst.VERSION_RULE_ALL, anyString);
         result = null;
       }

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistryBase.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/TestRegistryBase.java
@@ -22,7 +22,6 @@ import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
 import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
 import org.apache.servicecomb.serviceregistry.consumer.AppManager;
 import org.apache.servicecomb.serviceregistry.consumer.MicroserviceManager;
-import org.apache.servicecomb.serviceregistry.definition.DefinitionConst;
 import org.apache.servicecomb.serviceregistry.registry.ServiceRegistryFactory;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -30,7 +29,8 @@ import org.junit.Before;
 import com.google.common.eventbus.EventBus;
 
 import mockit.Deencapsulation;
-import mockit.Expectations;
+import mockit.Mock;
+import mockit.MockUp;
 
 public class TestRegistryBase {
   protected ServiceRegistry serviceRegistry;
@@ -88,21 +88,21 @@ public class TestRegistryBase {
   protected void mockNotExist() {
     MicroserviceInstances microserviceInstances = new MicroserviceInstances();
     microserviceInstances.setMicroserviceNotExist(true);
-    new Expectations(RegistryUtils.getServiceRegistry()) {
-      {
-        RegistryUtils.getServiceRegistry()
-            .findServiceInstances(anyString, anyString, DefinitionConst.VERSION_RULE_ALL, anyString);
-        result = microserviceInstances;
+    new MockUp<RegistryUtils>() {
+      @Mock
+      MicroserviceInstances findServiceInstances(String appId, String serviceName,
+          String versionRule, String revision) {
+        return microserviceInstances;
       }
     };
   }
 
   protected void mockDisconnect() {
-    new Expectations(RegistryUtils.getServiceRegistry()) {
-      {
-        RegistryUtils.getServiceRegistry()
-            .findServiceInstances(anyString, anyString, DefinitionConst.VERSION_RULE_ALL, anyString);
-        result = null;
+    new MockUp<RegistryUtils>() {
+      @Mock
+      MicroserviceInstances findServiceInstances(String appId, String serviceName,
+          String versionRule, String revision) {
+        return null;
       }
     };
   }

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/TestIpPortManager.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/TestIpPortManager.java
@@ -48,16 +48,12 @@ public class TestIpPortManager {
 
   AbstractServiceRegistry serviceRegistry;
 
-  IpPortManager manager;
-
   @Before
   public void setup() {
     ConfigUtil.createLocalConfig();
     serviceRegistry = (AbstractServiceRegistry) ServiceRegistryFactory.createLocal();
     serviceRegistry.setServiceRegistryClient(srClient);
     serviceRegistry.init();
-
-    manager = serviceRegistry.getIpPortManager();
   }
 
   @Test
@@ -79,7 +75,8 @@ public class TestIpPortManager {
       }
     };
 
-    IpPortManager manager = new IpPortManager(config, cacheManager);
+    IpPortManager manager = new IpPortManager(config);
+    manager.instanceCacheManager = cacheManager;
     IpPort address1 = manager.getAvailableAddress();
 
     if (address1.getPort() == 9980) {

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/RestUtilsTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/RestUtilsTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import io.vertx.core.MultiMap;
 import io.vertx.core.http.HttpMethod;
 
+@SuppressWarnings("deprecation")
 public class RestUtilsTest {
   @Test
   public void defaultHeadersContainServiceRegistryAndAuthentication() throws Exception {

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestClientHttp.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestClientHttp.java
@@ -63,24 +63,34 @@ public class TestClientHttp {
       public void await() throws InterruptedException {
       }
     };
-    new MockUp<RestUtils>() {
+    new MockUp<RestClientUtil>() {
       @Mock
       void httpDo(RequestContext requestContext, Handler<RestResponse> responseHandler) {
       }
     };
-
-    new MockUp<WebsocketUtils>() {
+    new MockUp<WebsocketClientUtil>() {
       @Mock
       void open(IpPort ipPort, String url, Handler<Void> onOpen, Handler<Void> onClose,
           Handler<Buffer> onMessage, Handler<Throwable> onException,
           Handler<Throwable> onConnectFailed) {
       }
     };
+    // mock up this two client pool, since this UT case doesn't require the client pool actually boot up.
+    new MockUp<HttpClientPool>() {
+      @Mock
+      void create() {
+      }
+    };
+    new MockUp<WebsocketClientPool>() {
+      @Mock
+      void create() {
+      }
+    };
 
     MicroserviceFactory microserviceFactory = new MicroserviceFactory();
     Microservice microservice = microserviceFactory.create("app", "ms");
 
-    ServiceRegistryClientImpl oClient = new ServiceRegistryClientImpl(manager);
+    ServiceRegistryClientImpl oClient = new ServiceRegistryClientImpl(manager, ServiceRegistryConfig.INSTANCE);
     oClient.init();
     oClient.registerMicroservice(microservice);
     oClient.registerMicroserviceInstance(microservice.getInstance());

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestClientHttp.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestClientHttp.java
@@ -24,7 +24,6 @@ import org.apache.servicecomb.foundation.vertx.AsyncResultCallback;
 import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceFactory;
-import org.apache.servicecomb.serviceregistry.cache.InstanceCacheManager;
 import org.apache.servicecomb.serviceregistry.client.Endpoints;
 import org.apache.servicecomb.serviceregistry.client.IpPortManager;
 import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
@@ -90,36 +89,31 @@ public class TestClientHttp {
     MicroserviceFactory microserviceFactory = new MicroserviceFactory();
     Microservice microservice = microserviceFactory.create("app", "ms");
 
-    ServiceRegistryClientImpl oClient = new ServiceRegistryClientImpl(manager, ServiceRegistryConfig.INSTANCE);
+    ServiceRegistryClientImpl oClient = new ServiceRegistryClientImpl(ServiceRegistryConfig.INSTANCE);
     oClient.init();
     oClient.registerMicroservice(microservice);
     oClient.registerMicroserviceInstance(microservice.getInstance());
-    Assert.assertEquals(null, oClient.getMicroservice(microservice.getServiceId()));
-    Assert.assertEquals(null, oClient.getMicroserviceInstance("testConsumerID", "testproviderID"));
-    Assert.assertEquals(null,
-        oClient.findServiceInstance(microservice.getServiceId(),
-            microservice.getAppId(),
-            microservice.getServiceName(),
-            microservice.getVersion()));
-    Assert.assertEquals(null,
-        oClient.findServiceInstances(microservice.getServiceId(),
-            microservice.getAppId(),
-            microservice.getServiceName(),
-            microservice.getVersion(),
-            "0"));
-    Assert.assertEquals(null,
-        oClient.getMicroserviceId(microservice.getAppId(),
-            microservice.getServiceName(),
-            microservice.getVersion(),
-            microservice.getEnvironment()));
-    Assert.assertEquals(null,
-        oClient.heartbeat(microservice.getServiceId(),
-            microservice.getInstance().getInstanceId()));
+    Assert.assertNull(oClient.getMicroservice(microservice.getServiceId()));
+    Assert.assertNull(oClient.getMicroserviceInstance("testConsumerID", "testproviderID"));
+    Assert.assertNull(oClient.findServiceInstance(microservice.getServiceId(),
+        microservice.getAppId(),
+        microservice.getServiceName(),
+        microservice.getVersion()));
+    Assert.assertNull(oClient.findServiceInstances(microservice.getServiceId(),
+        microservice.getAppId(),
+        microservice.getServiceName(),
+        microservice.getVersion(),
+        "0"));
+    Assert.assertNull(oClient.getMicroserviceId(microservice.getAppId(),
+        microservice.getServiceName(),
+        microservice.getVersion(),
+        microservice.getEnvironment()));
+    Assert.assertNull(oClient.heartbeat(microservice.getServiceId(),
+        microservice.getInstance().getInstanceId()));
     oClient.watch("",
         Mockito.mock(AsyncResultCallback.class));
-    Assert.assertEquals(false,
-        oClient.unregisterMicroserviceInstance(microservice.getServiceId(),
-            microservice.getInstance().getInstanceId()));
+    Assert.assertFalse(oClient.unregisterMicroserviceInstance(microservice.getServiceId(),
+        microservice.getInstance().getInstanceId()));
   }
 
   @Test
@@ -133,12 +127,12 @@ public class TestClientHttp {
     Assert.assertEquals("//test", oContext.getUri());
     Assert.assertEquals(io.vertx.core.http.HttpMethod.POST, oContext.getMethod());
     Assert.assertEquals(8080, oContext.getIpPort().getPort());
-    Assert.assertEquals(null, oContext.getParams());
+    Assert.assertNull(oContext.getParams());
 
     RestResponse oResponse = new RestResponse(null, null);
     oResponse.setRequestContext(oContext);
     Assert.assertEquals(oContext, oResponse.getRequestContext());
-    Assert.assertEquals(null, oResponse.getResponse());
+    Assert.assertNull(oResponse.getResponse());
   }
 
   @Test
@@ -150,24 +144,24 @@ public class TestClientHttp {
     oParam.addHeader("testKey", "testValue");
     oParam.addQueryParam("testParam", "ValueParam");
     oParam.addQueryParam("testParam1", "ValueParam");
-    Assert.assertEquals(null, oParam.getCookies());
-    Assert.assertEquals(null, oParam.getBody());
+    Assert.assertNull(oParam.getCookies());
+    Assert.assertNull(oParam.getBody());
     Assert.assertNotEquals(null, oParam.getHeaders());
     Assert.assertNotEquals(null, oParam.getQueryParams());
     oParam.setQueryParams(null);
     Assert.assertEquals("", oParam.getQueryParams());
     oParam.setFormFields(null);
-    Assert.assertEquals(null, oParam.getFormFields());
+    Assert.assertNull(oParam.getFormFields());
     Endpoints oEndpoints = new Endpoints();
     oEndpoints.setInstances(null);
     oEndpoints.setVersion("1.0");
-    Assert.assertEquals(null, oEndpoints.getInstances());
+    Assert.assertNull(oEndpoints.getInstances());
     Assert.assertEquals("1.0", oEndpoints.getVersion());
   }
 
   @Test
-  public void testIpPortManager(@Mocked InstanceCacheManager instanceCacheManager) throws Exception {
-    IpPortManager oManager = new IpPortManager(ServiceRegistryConfig.INSTANCE, instanceCacheManager);
+  public void testIpPortManager() {
+    IpPortManager oManager = new IpPortManager(ServiceRegistryConfig.INSTANCE);
     IpPort oIPPort = oManager.getNextAvailableAddress(new IpPort("", 33));
     Assert.assertEquals(oIPPort.getHostOrIp(), oManager.getAvailableAddress().getHostOrIp());
   }

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestHttpClientPool.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestHttpClientPool.java
@@ -46,7 +46,11 @@ public class TestHttpClientPool {
     ArchaiusUtils.setProperty(ServiceRegistryConfig.PROXY_USERNAME, "user");
     ArchaiusUtils.setProperty(ServiceRegistryConfig.PROXY_PASSWD, "pass");
 
-    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+    HttpClientOptions httpClientOptions = new HttpClientPool(ServiceRegistryConfig.buildFromConfiguration()) {
+      @Override
+      public void create() {
+      }
+    }.getHttpClientOptionsFromConfigurations(
         ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(
@@ -64,7 +68,11 @@ public class TestHttpClientPool {
   public void createHttpClientOptions_noProxy() {
     ArchaiusUtils.setProperty(ServiceRegistryConfig.PROXY_ENABLE, "false");
 
-    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+    HttpClientOptions httpClientOptions = new HttpClientPool(ServiceRegistryConfig.buildFromConfiguration()) {
+      @Override
+      public void create() {
+      }
+    }.getHttpClientOptionsFromConfigurations(
         ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertNull(httpClientOptions.getProxyOptions());
@@ -74,7 +82,11 @@ public class TestHttpClientPool {
   public void createHttpClientOptions_http2() {
     ArchaiusUtils.setProperty("servicecomb.service.registry.client.httpVersion", HttpVersion.HTTP_2.name());
 
-    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+    HttpClientOptions httpClientOptions = new HttpClientPool(ServiceRegistryConfig.buildFromConfiguration()) {
+      @Override
+      public void create() {
+      }
+    }.getHttpClientOptionsFromConfigurations(
         ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_2, httpClientOptions.getProtocolVersion());
@@ -83,7 +95,11 @@ public class TestHttpClientPool {
 
   @Test
   public void createHttpClientOptions_notHttp2() {
-    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+    HttpClientOptions httpClientOptions = new HttpClientPool(ServiceRegistryConfig.buildFromConfiguration()) {
+      @Override
+      public void create() {
+      }
+    }.getHttpClientOptionsFromConfigurations(
         ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_1_1, httpClientOptions.getProtocolVersion());

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestHttpClientPool.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestHttpClientPool.java
@@ -46,7 +46,8 @@ public class TestHttpClientPool {
     ArchaiusUtils.setProperty(ServiceRegistryConfig.PROXY_USERNAME, "user");
     ArchaiusUtils.setProperty(ServiceRegistryConfig.PROXY_PASSWD, "pass");
 
-    HttpClientOptions httpClientOptions = HttpClientPool.INSTANCE.createHttpClientOptions();
+    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+        ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(
         "{"
@@ -63,7 +64,8 @@ public class TestHttpClientPool {
   public void createHttpClientOptions_noProxy() {
     ArchaiusUtils.setProperty(ServiceRegistryConfig.PROXY_ENABLE, "false");
 
-    HttpClientOptions httpClientOptions = HttpClientPool.INSTANCE.createHttpClientOptions();
+    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+        ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertNull(httpClientOptions.getProxyOptions());
   }
@@ -72,7 +74,8 @@ public class TestHttpClientPool {
   public void createHttpClientOptions_http2() {
     ArchaiusUtils.setProperty("servicecomb.service.registry.client.httpVersion", HttpVersion.HTTP_2.name());
 
-    HttpClientOptions httpClientOptions = HttpClientPool.INSTANCE.createHttpClientOptions();
+    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+        ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_2, httpClientOptions.getProtocolVersion());
     Assert.assertFalse(httpClientOptions.isHttp2ClearTextUpgrade());
@@ -80,7 +83,8 @@ public class TestHttpClientPool {
 
   @Test
   public void createHttpClientOptions_notHttp2() {
-    HttpClientOptions httpClientOptions = HttpClientPool.INSTANCE.createHttpClientOptions();
+    HttpClientOptions httpClientOptions = HttpClientPool.getHttpClientOptionsFromConfigurations(
+        ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_1_1, httpClientOptions.getProtocolVersion());
     Assert.assertTrue(httpClientOptions.isHttp2ClearTextUpgrade());

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
@@ -78,7 +78,7 @@ public class TestServiceRegistryClientImpl {
 
   @Before
   public void setUp() throws Exception {
-    oClient = new ServiceRegistryClientImpl(ipPortManager, ServiceRegistryConfig.buildFromConfiguration());
+    oClient = new ServiceRegistryClientImpl(ServiceRegistryConfig.buildFromConfiguration());
 
     new MockUp<RegistryUtils>() {
       @Mock

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestWebsocketClientPool.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestWebsocketClientPool.java
@@ -41,7 +41,11 @@ public class TestWebsocketClientPool {
   public void createHttpClientOptions_http2() {
     ArchaiusUtils.setProperty("servicecomb.service.registry.client.httpVersion", HttpVersion.HTTP_2.name());
 
-    HttpClientOptions httpClientOptions = WebsocketClientPool.getHttpClientOptionsFromConfigurations(
+    HttpClientOptions httpClientOptions = new WebsocketClientPool(ServiceRegistryConfig.buildFromConfiguration()) {
+      @Override
+      public void create() {
+      }
+    }.getHttpClientOptionsFromConfigurations(
         ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_2, httpClientOptions.getProtocolVersion());
@@ -50,7 +54,11 @@ public class TestWebsocketClientPool {
 
   @Test
   public void createHttpClientOptions_notHttp2() {
-    HttpClientOptions httpClientOptions = WebsocketClientPool.getHttpClientOptionsFromConfigurations(
+    HttpClientOptions httpClientOptions = new WebsocketClientPool(ServiceRegistryConfig.buildFromConfiguration()) {
+      @Override
+      public void create() {
+      }
+    }.getHttpClientOptionsFromConfigurations(
         ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_1_1, httpClientOptions.getProtocolVersion());

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestWebsocketClientPool.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestWebsocketClientPool.java
@@ -17,6 +17,7 @@
 package org.apache.servicecomb.serviceregistry.client.http;
 
 import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
+import org.apache.servicecomb.serviceregistry.config.ServiceRegistryConfig;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -40,7 +41,8 @@ public class TestWebsocketClientPool {
   public void createHttpClientOptions_http2() {
     ArchaiusUtils.setProperty("servicecomb.service.registry.client.httpVersion", HttpVersion.HTTP_2.name());
 
-    HttpClientOptions httpClientOptions = WebsocketClientPool.INSTANCE.createHttpClientOptions();
+    HttpClientOptions httpClientOptions = WebsocketClientPool.getHttpClientOptionsFromConfigurations(
+        ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_2, httpClientOptions.getProtocolVersion());
     Assert.assertFalse(httpClientOptions.isHttp2ClearTextUpgrade());
@@ -48,7 +50,8 @@ public class TestWebsocketClientPool {
 
   @Test
   public void createHttpClientOptions_notHttp2() {
-    HttpClientOptions httpClientOptions = WebsocketClientPool.INSTANCE.createHttpClientOptions();
+    HttpClientOptions httpClientOptions = WebsocketClientPool.getHttpClientOptionsFromConfigurations(
+        ServiceRegistryConfig.buildFromConfiguration());
 
     Assert.assertEquals(HttpVersion.HTTP_1_1, httpClientOptions.getProtocolVersion());
     Assert.assertTrue(httpClientOptions.isHttp2ClearTextUpgrade());

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
@@ -43,7 +43,7 @@ public class TestServiceRegistryConfig {
 
   @Test
   public void testServiceRegistryConfig() {
-    ServiceRegistryConfig oConfig = ServiceRegistryConfig.INSTANCE;
+    ServiceRegistryConfig oConfig = new ServiceRegistryConfigBuilder().build();
     Assert.assertNull(oConfig.getAccessKey());
     Assert.assertEquals(30000, oConfig.getConnectionTimeout());
     Assert.assertNotEquals(null, oConfig.getHeartbeatInterval());
@@ -62,10 +62,10 @@ public class TestServiceRegistryConfig {
     List<IpPort> ipPorts = oConfig.getIpPort();
     Assert.assertEquals("127.0.0.1:80", ipPorts.get(0).toString());
     Assert.assertEquals("127.0.0.1:443", ipPorts.get(1).toString());
-    Assert.assertFalse(ServiceRegistryConfig.INSTANCE.isProxyEnable());
-    Assert.assertEquals("127.0.0.1", ServiceRegistryConfig.INSTANCE.getProxyHost());
-    Assert.assertEquals(8080, ServiceRegistryConfig.INSTANCE.getProxyPort());
-    Assert.assertNull(ServiceRegistryConfig.INSTANCE.getProxyUsername());
-    Assert.assertNull(ServiceRegistryConfig.INSTANCE.getProxyPasswd());
+    Assert.assertFalse(oConfig.isProxyEnable());
+    Assert.assertEquals("127.0.0.1", oConfig.getProxyHost());
+    Assert.assertEquals(8080, oConfig.getProxyPort());
+    Assert.assertNull(oConfig.getProxyUsername());
+    Assert.assertNull(oConfig.getProxyPasswd());
   }
 }

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/TestInstanceCacheChecker.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/TestInstanceCacheChecker.java
@@ -27,6 +27,7 @@ import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
 import org.apache.servicecomb.serviceregistry.api.response.FindInstancesResponse;
 import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import org.apache.servicecomb.serviceregistry.consumer.AppManager;
 import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersionRule;
 import org.apache.servicecomb.serviceregistry.consumer.MicroserviceVersions;
 import org.apache.servicecomb.serviceregistry.definition.DefinitionConst;
@@ -38,6 +39,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import io.vertx.core.json.Json;
+import mockit.Deencapsulation;
 import mockit.Mock;
 import mockit.MockUp;
 
@@ -54,10 +56,12 @@ public class TestInstanceCacheChecker {
 
   @Before
   public void setUp() throws Exception {
+    Deencapsulation.setField(RegistryUtils.class, "appManager", new AppManager());
+
     serviceRegistry.init();
     RegistryUtils.setServiceRegistry(serviceRegistry);
 
-    checker = new InstanceCacheChecker(serviceRegistry.getAppManager());
+    checker = new InstanceCacheChecker(RegistryUtils.getAppManager());
     checker.clock = new MockClock(new Holder<>(1L));
     expectedSummary.setStatus(Status.NORMAL);
     expectedSummary.setTimestamp(1);
@@ -78,7 +82,7 @@ public class TestInstanceCacheChecker {
   @Test
   public void check_microserviceManager_empty() {
     appId = "notExist";
-    serviceRegistry.getAppManager().getOrCreateMicroserviceVersions(appId, microserviceName);
+    RegistryUtils.getAppManager().getOrCreateMicroserviceVersions(appId, microserviceName);
     InstanceCacheSummary instanceCacheSummary = checker.check();
     Assert.assertEquals(Json.encode(expectedSummary), Json.encode(instanceCacheSummary));
   }
@@ -119,7 +123,7 @@ public class TestInstanceCacheChecker {
 
     registerMicroservice(appId, microserviceName);
 
-    serviceRegistry.getAppManager()
+    RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersionRule(appId, microserviceName, DefinitionConst.VERSION_RULE_ALL);
 
     findHolder.value = null;
@@ -151,7 +155,7 @@ public class TestInstanceCacheChecker {
 
     registerMicroservice(appId, microserviceName);
 
-    serviceRegistry.getAppManager()
+    RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersionRule(appId, microserviceName, DefinitionConst.VERSION_RULE_ALL);
 
     findHolder.value.setMicroserviceNotExist(true);
@@ -183,7 +187,7 @@ public class TestInstanceCacheChecker {
 
     registerMicroservice(appId, microserviceName);
 
-    serviceRegistry.getAppManager()
+    RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersionRule(appId, microserviceName, DefinitionConst.VERSION_RULE_ALL);
 
     findHolder.value.setRevision("second");
@@ -216,7 +220,7 @@ public class TestInstanceCacheChecker {
 
     registerMicroservice(appId, microserviceName);
 
-    MicroserviceVersions microserviceVersions = serviceRegistry.getAppManager()
+    MicroserviceVersions microserviceVersions = RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersions(appId, microserviceName);
     microserviceVersions.setRevision("first");
     microserviceVersions.getOrCreateMicroserviceVersionRule(DefinitionConst.VERSION_RULE_ALL);
@@ -248,7 +252,7 @@ public class TestInstanceCacheChecker {
         Arrays.asList("rest://localhost:8080"),
         ThirdPartyServiceForUT.class);
 
-    MicroserviceVersionRule microserviceVersionRule = serviceRegistry.getAppManager()
+    MicroserviceVersionRule microserviceVersionRule = RegistryUtils.getAppManager()
         .getOrCreateMicroserviceVersionRule(appId, microserviceName, DefinitionConst.VERSION_RULE_ALL);
     Assert.assertEquals(microserviceName, microserviceVersionRule.getLatestMicroserviceVersion().getMicroserviceName());
 

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/TestInstanceCacheChecker.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/TestInstanceCacheChecker.java
@@ -177,7 +177,7 @@ public class TestInstanceCacheChecker {
   public void check_findInstances_revisionNotMatch() {
     Holder<MicroserviceInstances> findHolder = createFindServiceInstancesResult();
 
-    new MockUp<ServiceRegistry>(serviceRegistry) {
+    new MockUp<RegistryUtils>() {
       @Mock
       MicroserviceInstances findServiceInstances(String appId, String serviceName,
           String versionRule, String revision) {

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/discovery/TestDiscoveryTree.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/discovery/TestDiscoveryTree.java
@@ -24,7 +24,6 @@ import org.apache.servicecomb.foundation.common.cache.VersionedCache;
 import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.serviceregistry.RegistryUtils;
-import org.apache.servicecomb.serviceregistry.ServiceRegistry;
 import org.apache.servicecomb.serviceregistry.cache.InstanceCacheManager;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -125,7 +124,7 @@ public class TestDiscoveryTree {
     Assert.assertFalse(discoveryTree.isExpired(new DiscoveryTreeNode().cacheVersion(0), parent));
   }
 
-  class DiscoveryFilterForTest implements DiscoveryFilter {
+  static class DiscoveryFilterForTest implements DiscoveryFilter {
     protected String groupName;
 
     public DiscoveryFilterForTest(String groupName) {
@@ -167,13 +166,10 @@ public class TestDiscoveryTree {
   }
 
   @Test
-  public void easyDiscovery(@Mocked ServiceRegistry serviceRegistry,
-      @Mocked InstanceCacheManager instanceCacheManager) {
+  public void easyDiscovery(@Mocked InstanceCacheManager instanceCacheManager) {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.getServiceRegistry();
-        result = serviceRegistry;
-        serviceRegistry.getInstanceCacheManager();
+        RegistryUtils.getInstanceCacheManager();
         result = instanceCacheManager;
         instanceCacheManager.getOrCreateVersionedCache(anyString, anyString, anyString);
         result = parent;
@@ -186,13 +182,10 @@ public class TestDiscoveryTree {
   }
 
   @Test
-  public void discovery_filterReturnNull(@Mocked ServiceRegistry serviceRegistry,
-      @Mocked InstanceCacheManager instanceCacheManager) {
+  public void discovery_filterReturnNull(@Mocked InstanceCacheManager instanceCacheManager) {
     new Expectations(RegistryUtils.class) {
       {
-        RegistryUtils.getServiceRegistry();
-        result = serviceRegistry;
-        serviceRegistry.getInstanceCacheManager();
+        RegistryUtils.getInstanceCacheManager();
         result = instanceCacheManager;
         instanceCacheManager.getOrCreateVersionedCache(anyString, anyString, anyString);
         result = parent;

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/EmptyMockServiceRegistry.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/EmptyMockServiceRegistry.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.servicecomb.serviceregistry.Features;
+import org.apache.servicecomb.serviceregistry.ServiceRegistry;
+import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCacheKey;
+
+import com.google.common.eventbus.EventBus;
+
+public class EmptyMockServiceRegistry implements ServiceRegistry {
+  @Override
+  public String getName() {
+    return null;
+  }
+
+  @Override
+  public void init() {
+
+  }
+
+  @Override
+  public void run() {
+
+  }
+
+  @Override
+  public void destroy() {
+
+  }
+
+  @Override
+  public EventBus getEventBus() {
+    return null;
+  }
+
+  @Override
+  public Set<String> getCombinedMicroserviceNames() {
+    return null;
+  }
+
+  @Override
+  public String getAppId() {
+    return null;
+  }
+
+  @Override
+  public Microservice getMicroservice() {
+    return null;
+  }
+
+  @Override
+  public MicroserviceInstance getMicroserviceInstance() {
+    return null;
+  }
+
+  @Override
+  public ServiceRegistryClient getServiceRegistryClient() {
+    return null;
+  }
+
+  @Override
+  public List<MicroserviceInstance> findServiceInstance(String appId, String microserviceName,
+      String microserviceVersionRule) {
+    return null;
+  }
+
+  @Override
+  public MicroserviceInstances findServiceInstances(String appId, String microserviceName,
+      String microserviceVersionRule, String revision) {
+    return null;
+  }
+
+  @Override
+  public MicroserviceCache findMicroserviceCache(MicroserviceCacheKey microserviceCacheKey) {
+    return null;
+  }
+
+  @Override
+  public boolean updateMicroserviceProperties(Map<String, String> properties) {
+    return false;
+  }
+
+  @Override
+  public boolean updateInstanceProperties(Map<String, String> instanceProperties) {
+    return false;
+  }
+
+  @Override
+  public Microservice getRemoteMicroservice(String microserviceId) {
+    return null;
+  }
+
+  @Override
+  public Microservice getAggregatedRemoteMicroservice(String microserviceId) {
+    return null;
+  }
+
+  @Override
+  public Features getFeatures() {
+    return null;
+  }
+
+  @Override
+  public void registerMicroserviceMapping(String microserviceName, String version, List<MicroserviceInstance> instances,
+      Class<?> schemaIntfCls) {
+
+  }
+
+  @Override
+  public void registerMicroserviceMappingByEndpoints(String microserviceName, String version, List<String> endpoints,
+      Class<?> schemaIntfCls) {
+
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/TestRemoteServiceRegistry.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/TestRemoteServiceRegistry.java
@@ -78,18 +78,10 @@ public class TestRemoteServiceRegistry {
       {
         definition.getConfiguration();
         result = ConfigUtil.createLocalConfig();
-        config.getIpPort();
-        result = ipPortList;
-        config.getTransport();
-        result = "rest";
-        config.isRegistryAutoDiscovery();
-        result = true;
         config.getHeartbeatInterval();
         result = 30;
         config.getInstancePullInterval();
         result = 30;
-        config.isWatch();
-        result = false;
         config.getRegistryName();
         result = "TestRegistry";
         SPIServiceUtils.getOrLoadSortedService(ServiceRegistryTaskInitializer.class);

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/TestRemoteServiceRegistry.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/TestRemoteServiceRegistry.java
@@ -90,6 +90,8 @@ public class TestRemoteServiceRegistry {
         result = 30;
         config.isWatch();
         result = false;
+        config.getRegistryName();
+        result = "TestRegistry";
         SPIServiceUtils.getOrLoadSortedService(ServiceRegistryTaskInitializer.class);
         result = Arrays.asList(initializer);
       }

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/TestServiceRegistryFactory.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/TestServiceRegistryFactory.java
@@ -30,7 +30,6 @@ import org.junit.Test;
 
 import com.google.common.eventbus.EventBus;
 
-import mockit.Deencapsulation;
 import mockit.Mocked;
 
 /**
@@ -52,20 +51,17 @@ public class TestServiceRegistryFactory {
     ServiceRegistryClient client = serviceRegistry.getServiceRegistryClient();
     Assert.assertTrue(client instanceof ServiceRegistryClientImpl);
 
-    serviceRegistry = ServiceRegistryFactory.getOrCreate(eventBus,
+    serviceRegistry = ServiceRegistryFactory.create(eventBus,
         serviceRegistryConfig,
         microserviceDefinition);
     Assert.assertTrue(serviceRegistry instanceof RemoteServiceRegistry);
-    Assert.assertEquals(serviceRegistry, ServiceRegistryFactory.getServiceRegistry());
-
-    Deencapsulation.setField(ServiceRegistryFactory.class, "serviceRegistry", null);
 
     System.setProperty("local.registry.file", "/tmp/test.yaml");
     serviceRegistry = ServiceRegistryFactory.create(eventBus, serviceRegistryConfig, microserviceDefinition);
     serviceRegistry.init();
     client = serviceRegistry.getServiceRegistryClient();
     Assert.assertTrue(client instanceof LocalServiceRegistryClientImpl);
-    Assert.assertTrue(ServiceRegistryFactory.getOrCreate(eventBus,
+    Assert.assertTrue(ServiceRegistryFactory.create(eventBus,
         serviceRegistryConfig,
         microserviceDefinition) instanceof LocalServiceRegistry);
     System.clearProperty("local.registry.file");

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateMicroserviceCacheTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateMicroserviceCacheTest.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.servicecomb.serviceregistry.ServiceRegistry;
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import org.apache.servicecomb.serviceregistry.registry.EmptyMockServiceRegistry;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache.MicroserviceCacheStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AggregateMicroserviceCacheTest {
+
+  @Test
+  public void refresh() {
+    MicroserviceCacheKey microserviceCacheKey =
+        MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("production").build();
+
+    MockMicroserviceCache mockMicroserviceCache0 = new MockMicroserviceCache(microserviceCacheKey,
+        MicroserviceCacheStatus.NO_CHANGE);
+    MockMicroserviceCache mockMicroserviceCache2 = new MockMicroserviceCache(microserviceCacheKey,
+        MicroserviceCacheStatus.REFRESHED);
+    mockMicroserviceCache2.instances = Arrays.asList(new MicroserviceInstance(), new MicroserviceInstance());
+    MockMicroserviceCache mockMicroserviceCache3 = new MockMicroserviceCache(microserviceCacheKey,
+        MicroserviceCacheStatus.SERVICE_NOT_FOUND);
+
+    MockServiceRegistry mockServiceRegistry0 = new MockServiceRegistry().setName("s0")
+        .addCache(mockMicroserviceCache0)
+        .addCache(new MockMicroserviceCache(
+            MicroserviceCacheKey.builder().serviceName("svc2").appId("app").env("production").build(),
+            MicroserviceCacheStatus.REFRESHED));
+    MockServiceRegistry mockServiceRegistry1 = new MockServiceRegistry().setName("s1");
+    MockServiceRegistry mockServiceRegistry2 = new MockServiceRegistry().setName("s2")
+        .addCache(mockMicroserviceCache2);
+    MockServiceRegistry mockServiceRegistry3 = new MockServiceRegistry().setName("s3")
+        .addCache(mockMicroserviceCache3);
+
+    List<ServiceRegistry> serviceRegistries = Arrays.asList(
+        mockServiceRegistry0,
+        mockServiceRegistry1,
+        mockServiceRegistry2,
+        mockServiceRegistry3
+    );
+
+    AggregateMicroserviceCache compositeMicroserviceCache = new AggregateMicroserviceCache(
+        microserviceCacheKey,
+        serviceRegistries);
+
+    // Test initialization
+    // key
+    Assert.assertSame(microserviceCacheKey, compositeMicroserviceCache.getKey());
+    // status
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, compositeMicroserviceCache.getStatus());
+    // revision
+    Assert.assertEquals("1", compositeMicroserviceCache.getRevisionId());
+    Assert.assertEquals(1L, compositeMicroserviceCache.revisionCounter.get());
+    // MicroserviceCache map
+    Assert.assertEquals(2, compositeMicroserviceCache.caches.size());
+    Assert.assertSame(mockMicroserviceCache0, compositeMicroserviceCache.caches.get("s0"));
+    Assert.assertSame(mockMicroserviceCache2, compositeMicroserviceCache.caches.get("s2"));
+    // ServiceRegistry collection
+    Assert.assertEquals(serviceRegistries.size(), compositeMicroserviceCache.serviceRegistries.size());
+    Iterator<ServiceRegistry> serviceRegistryIterator = compositeMicroserviceCache.serviceRegistries.iterator();
+    Assert.assertSame(serviceRegistries.get(0), serviceRegistryIterator.next());
+    Assert.assertSame(serviceRegistries.get(1), serviceRegistryIterator.next());
+    Assert.assertSame(serviceRegistries.get(2), serviceRegistryIterator.next());
+    Assert.assertSame(serviceRegistries.get(3), serviceRegistryIterator.next());
+    // cached instances
+    Assert.assertEquals(2, compositeMicroserviceCache.getInstances().size());
+    Assert.assertSame(mockMicroserviceCache2.instances.get(0), compositeMicroserviceCache.getInstances().get(0));
+    Assert.assertSame(mockMicroserviceCache2.instances.get(1), compositeMicroserviceCache.getInstances().get(1));
+
+    // Test refresh()
+    mockMicroserviceCache0.instances = Collections.singletonList(new MicroserviceInstance());
+    mockMicroserviceCache2.instances = Collections.singletonList(new MicroserviceInstance());
+    compositeMicroserviceCache.refresh();
+    // status
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, compositeMicroserviceCache.getStatus());
+    // revision
+    Assert.assertEquals("2", compositeMicroserviceCache.getRevisionId());
+    Assert.assertEquals(2L, compositeMicroserviceCache.revisionCounter.get());
+    // cached instances
+    Assert.assertEquals(2, compositeMicroserviceCache.getInstances().size());
+    Assert.assertSame(mockMicroserviceCache0.instances.get(0), compositeMicroserviceCache.getInstances().get(0));
+    Assert.assertSame(mockMicroserviceCache2.instances.get(0), compositeMicroserviceCache.getInstances().get(1));
+
+    // Test refresh()
+    // microservice deleted and registered
+    mockMicroserviceCache0.status = MicroserviceCacheStatus.SERVICE_NOT_FOUND;
+    mockMicroserviceCache3.status = MicroserviceCacheStatus.REFRESHED;
+    compositeMicroserviceCache.refresh();
+    // status
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, compositeMicroserviceCache.getStatus());
+    // revision
+    Assert.assertEquals("3", compositeMicroserviceCache.getRevisionId());
+    Assert.assertEquals(3L, compositeMicroserviceCache.revisionCounter.get());
+    // ServiceRegistries
+    Assert.assertNotNull(compositeMicroserviceCache.caches.get("s2"));
+    Assert.assertNotNull(compositeMicroserviceCache.caches.get("s3"));
+    // cached instances
+    Assert.assertEquals(1, compositeMicroserviceCache.getInstances().size());
+    Assert.assertSame(mockMicroserviceCache2.instances.get(0), compositeMicroserviceCache.getInstances().get(0));
+  }
+
+  public static class MockServiceRegistry extends EmptyMockServiceRegistry {
+    String name;
+
+    Map<MicroserviceCacheKey, MicroserviceCache> cacheMap = new HashMap<>();
+
+    public MockServiceRegistry setName(String name) {
+      this.name = name;
+      return this;
+    }
+
+    public MockServiceRegistry addCache(MicroserviceCache microserviceCache) {
+      cacheMap.put(microserviceCache.getKey(), microserviceCache);
+      return this;
+    }
+
+    @Override
+    public String getName() {
+      return name;
+    }
+
+    @Override
+    public MicroserviceCache findMicroserviceCache(MicroserviceCacheKey microserviceCacheKey) {
+      return cacheMap.get(microserviceCacheKey);
+    }
+  }
+
+  public static class MockMicroserviceCache extends RefreshableMicroserviceCache {
+    public MockMicroserviceCache(MicroserviceCacheKey key, MicroserviceCacheStatus microserviceCacheStatus) {
+      super(null, key, null, false);
+      setStatus(microserviceCacheStatus);
+    }
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateServiceRegistryCacheTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateServiceRegistryCacheTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.apache.servicecomb.serviceregistry.registry.cache.AggregateMicroserviceCacheTest.MockMicroserviceCache;
+import org.apache.servicecomb.serviceregistry.registry.cache.AggregateMicroserviceCacheTest.MockServiceRegistry;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache.MicroserviceCacheStatus;
+import org.junit.Before;
+import org.junit.Test;
+
+public class AggregateServiceRegistryCacheTest {
+
+  private MicroserviceCacheKey microserviceCacheKey;
+
+  private MockServiceRegistry mockServiceRegistry0;
+
+  private MockServiceRegistry mockServiceRegistry1;
+
+  private MockServiceRegistry mockServiceRegistry2;
+
+  private AggregateServiceRegistryCache aggregateServiceRegistryCache;
+
+  @Before
+  public void before() {
+    microserviceCacheKey = MicroserviceCacheKey.builder()
+        .serviceName("svc").appId("app").env("env").build();
+
+    mockServiceRegistry0 = new MockServiceRegistry()
+        .setName("s0")
+        .addCache(new MockMicroserviceCache(
+            microserviceCacheKey,
+            MicroserviceCacheStatus.NO_CHANGE));
+    mockServiceRegistry1 = new MockServiceRegistry()
+        .setName("s1")
+        .addCache(new MockMicroserviceCache(
+            microserviceCacheKey,
+            MicroserviceCacheStatus.REFRESHED))
+        .addCache(new MockMicroserviceCache(
+            MicroserviceCacheKey.builder().serviceName("svc2").appId("app").env("env").build(),
+            MicroserviceCacheStatus.NO_CHANGE));
+    mockServiceRegistry2 = new MockServiceRegistry()
+        .setName("s2")
+        .addCache(new MockMicroserviceCache(
+            microserviceCacheKey,
+            MicroserviceCacheStatus.SERVICE_NOT_FOUND));
+
+    aggregateServiceRegistryCache = new AggregateServiceRegistryCache(
+        Arrays.asList(mockServiceRegistry0, mockServiceRegistry1, mockServiceRegistry2));
+  }
+
+  @Test
+  public void findServiceCache() {
+    MicroserviceCache serviceCache = aggregateServiceRegistryCache.findServiceCache(
+        MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build()
+    );
+
+    assertTrue(serviceCache instanceof AggregateMicroserviceCache);
+    AggregateMicroserviceCache aggregateMicroserviceCache = (AggregateMicroserviceCache) serviceCache;
+    assertEquals(2, aggregateMicroserviceCache.caches.size());
+    assertSame(mockServiceRegistry0.findMicroserviceCache(microserviceCacheKey),
+        aggregateMicroserviceCache.caches.get(mockServiceRegistry0.getName()));
+    assertSame(mockServiceRegistry1.findMicroserviceCache(microserviceCacheKey),
+        aggregateMicroserviceCache.caches.get(mockServiceRegistry1.getName()));
+    // aggregateMicroserviceCache holds the cache of svc
+    assertEquals(1, aggregateServiceRegistryCache.microserviceCache.size());
+    assertNotNull(aggregateServiceRegistryCache.microserviceCache.get(microserviceCacheKey));
+
+    MicroserviceCache serviceCache2 = aggregateServiceRegistryCache.findServiceCache(
+        MicroserviceCacheKey.builder().serviceName("svc2").appId("app").env("env").build()
+    );
+
+    assertTrue(serviceCache2 instanceof AggregateMicroserviceCache);
+    AggregateMicroserviceCache aggregateMicroserviceCache2 = (AggregateMicroserviceCache) serviceCache2;
+    assertEquals(1, aggregateMicroserviceCache2.caches.size());
+    assertSame(
+        mockServiceRegistry1.findMicroserviceCache(
+            MicroserviceCacheKey.builder().serviceName("svc2").appId("app").env("env").build()),
+        aggregateMicroserviceCache2.caches.get(mockServiceRegistry1.getName()));
+    assertEquals(2, aggregateServiceRegistryCache.microserviceCache.size());
+    assertNotNull(aggregateServiceRegistryCache.microserviceCache.get(
+        MicroserviceCacheKey.builder().serviceName("svc2").appId("app").env("env").build()
+    ));
+  }
+
+  @Test
+  public void findServiceCache_not_found() {
+    MicroserviceCache serviceCache = aggregateServiceRegistryCache.findServiceCache(
+        MicroserviceCacheKey.builder().serviceName("svc-not-exist").appId("app").env("env").build()
+    );
+
+    assertTrue(serviceCache instanceof AggregateMicroserviceCache);
+    assertEquals(MicroserviceCacheStatus.SERVICE_NOT_FOUND, serviceCache.getStatus());
+    AggregateMicroserviceCache aggregateMicroserviceCache = (AggregateMicroserviceCache) serviceCache;
+    assertEquals(0, aggregateMicroserviceCache.caches.size());
+    assertEquals(3, aggregateMicroserviceCache.serviceRegistries.size());
+    // should remove the cache of not existing microservice
+    assertEquals(0, aggregateServiceRegistryCache.microserviceCache.size());
+  }
+
+  @Test
+  public void onMicroserviceCacheRefreshed() {
+    MicroserviceCacheKey microserviceCacheKey =
+        MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build();
+    MicroserviceCacheKey microserviceCacheKey2 =
+        MicroserviceCacheKey.builder().serviceName("svc2").appId("app").env("env").build();
+    aggregateServiceRegistryCache.onMicroserviceCacheRefreshed(new MicroserviceCacheRefreshedEvent(
+        Collections.singletonList(
+            new MockMicroserviceCache(
+                microserviceCacheKey,
+                MicroserviceCacheStatus.REFRESHED
+            )
+        )
+    ));
+
+    assertTrue(aggregateServiceRegistryCache.microserviceCache.isEmpty());
+
+    MicroserviceCache serviceCache = aggregateServiceRegistryCache.findServiceCache(microserviceCacheKey);
+    MicroserviceCache serviceCache2 = aggregateServiceRegistryCache.findServiceCache(microserviceCacheKey2);
+
+    assertEquals("1", serviceCache.getRevisionId());
+    assertEquals("1", serviceCache2.getRevisionId());
+
+    aggregateServiceRegistryCache.onMicroserviceCacheRefreshed(new MicroserviceCacheRefreshedEvent(
+        Collections.singletonList(
+            new MockMicroserviceCache(
+                microserviceCacheKey,
+                MicroserviceCacheStatus.REFRESHED
+            )
+        )
+    ));
+
+    assertEquals("2", serviceCache.getRevisionId());
+    assertEquals("1", serviceCache2.getRevisionId());
+
+    // test watcher
+    ArrayList<Object> refreshedCaches = new ArrayList<>();
+    aggregateServiceRegistryCache.setCacheRefreshedWatcher(refreshedCaches::addAll);
+
+    aggregateServiceRegistryCache.onMicroserviceCacheRefreshed(new MicroserviceCacheRefreshedEvent(
+        Arrays.asList(
+            new MockMicroserviceCache(
+                microserviceCacheKey,
+                MicroserviceCacheStatus.REFRESHED
+            ),
+            new MockMicroserviceCache(
+                microserviceCacheKey2,
+                MicroserviceCacheStatus.REFRESHED
+            )
+        )
+    ));
+
+    assertEquals("3", serviceCache.getRevisionId());
+    assertEquals("2", serviceCache2.getRevisionId());
+    assertEquals(2, refreshedCaches.size());
+    assertSame(serviceCache, refreshedCaches.get(0));
+    assertSame(serviceCache2, refreshedCaches.get(1));
+
+    refreshedCaches.clear();
+
+    // test removing not existing service cache
+    ((MockMicroserviceCache) mockServiceRegistry0.findMicroserviceCache(microserviceCacheKey))
+        .setStatus(MicroserviceCacheStatus.SERVICE_NOT_FOUND);
+    ((MockMicroserviceCache) mockServiceRegistry1.findMicroserviceCache(microserviceCacheKey))
+        .setStatus(MicroserviceCacheStatus.SERVICE_NOT_FOUND);
+    aggregateServiceRegistryCache.onMicroserviceCacheRefreshed(new MicroserviceCacheRefreshedEvent(
+        Arrays.asList(
+            new MockMicroserviceCache(
+                microserviceCacheKey,
+                MicroserviceCacheStatus.REFRESHED
+            ),
+            new MockMicroserviceCache(
+                microserviceCacheKey2,
+                MicroserviceCacheStatus.REFRESHED
+            )
+        )
+    ));
+
+    assertEquals("4", serviceCache.getRevisionId());
+    assertEquals("3", serviceCache2.getRevisionId());
+    assertEquals(2, refreshedCaches.size());
+    assertSame(serviceCache, refreshedCaches.get(0));
+    assertSame(serviceCache2, refreshedCaches.get(1));
+    assertEquals(MicroserviceCacheStatus.SERVICE_NOT_FOUND, serviceCache.getStatus());
+    // not existing service cache removed, only serviceCache2 is left
+    assertEquals(1, aggregateServiceRegistryCache.microserviceCache.size());
+    assertSame(serviceCache2, aggregateServiceRegistryCache.microserviceCache.get(microserviceCacheKey2));
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheKeyTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheKeyTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class MicroserviceCacheKeyTest {
+
+  @Test
+  public void constructors() {
+    checkConstructorException(null, "appId", "svc", "microserviceCacheKey.env is null");
+    checkConstructorException("env", null, "svc", "microserviceCacheKey.appId is null");
+    checkConstructorException("env", "appId", null, "microserviceCacheKey.serviceName is null");
+
+    MicroserviceCacheKey microserviceCacheKey =
+        MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build();
+    Assert.assertEquals("svc", microserviceCacheKey.getServiceName());
+    Assert.assertEquals("app", microserviceCacheKey.getAppId());
+    Assert.assertEquals("env", microserviceCacheKey.getEnv());
+    Assert.assertEquals("svc@app@env", microserviceCacheKey.toString());
+
+    microserviceCacheKey =
+        MicroserviceCacheKey.builder().serviceName("app:svc").appId("app").env("env").build();
+    Assert.assertEquals("svc", microserviceCacheKey.getServiceName());
+    Assert.assertEquals("app", microserviceCacheKey.getAppId());
+    Assert.assertEquals("env", microserviceCacheKey.getEnv());
+
+    microserviceCacheKey =
+        MicroserviceCacheKey.builder().serviceName("app2:svc").appId("app").env("env").build();
+    Assert.assertEquals("svc", microserviceCacheKey.getServiceName());
+    Assert.assertEquals("app2", microserviceCacheKey.getAppId());
+    Assert.assertEquals("env", microserviceCacheKey.getEnv());
+  }
+
+  private void checkConstructorException(String env, String appId, String svc, String expectedMessage) {
+    try {
+      MicroserviceCacheKey.builder().env(env).appId(appId).serviceName(svc).build();
+      fail("an Exception is expected!");
+    } catch (Exception e) {
+      Assert.assertEquals(expectedMessage, e.getMessage());
+    }
+  }
+
+  @Test
+  public void equals_and_hashcode() {
+    MicroserviceCacheKey microserviceCacheKey =
+        MicroserviceCacheKey.builder().env("env").appId("app").serviceName("svc").build();
+    MicroserviceCacheKey microserviceCacheKey2 =
+        MicroserviceCacheKey.builder().env("env").appId("app").serviceName("svc").build();
+    Assert.assertEquals(microserviceCacheKey, microserviceCacheKey2);
+    Assert.assertEquals(microserviceCacheKey.hashCode(), microserviceCacheKey2.hashCode());
+
+    microserviceCacheKey2 =
+        MicroserviceCacheKey.builder().env("env1").appId("app").serviceName("svc").build();
+    Assert.assertNotEquals(microserviceCacheKey, microserviceCacheKey2);
+    microserviceCacheKey2 =
+        MicroserviceCacheKey.builder().env("env").appId("app1").serviceName("svc").build();
+    Assert.assertNotEquals(microserviceCacheKey, microserviceCacheKey2);
+    microserviceCacheKey2 =
+        MicroserviceCacheKey.builder().env("env").appId("app").serviceName("svc1").build();
+    Assert.assertNotEquals(microserviceCacheKey, microserviceCacheKey2);
+  }
+
+  @Test
+  public void plainKey() {
+    MicroserviceCacheKey microserviceCacheKey =
+        MicroserviceCacheKey.builder().env("env").appId("app").serviceName("svc").build();
+    Assert.assertEquals("svc@app@env", microserviceCacheKey.plainKey());
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/MockedMicroserviceCache.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/MockedMicroserviceCache.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.List;
+
+import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
+
+public class MockedMicroserviceCache extends RefreshableMicroserviceCache {
+  public MockedMicroserviceCache() {
+    super(null, null, null, false);
+  }
+
+  public MockedMicroserviceCache(Microservice consumerService, MicroserviceCacheKey key,
+      ServiceRegistryClient srClient,
+      boolean emptyInstanceProtectionEnabled) {
+    super(consumerService, key, srClient, emptyInstanceProtectionEnabled);
+  }
+
+  @Override
+  public void setStatus(MicroserviceCacheStatus status) {
+    super.setStatus(status);
+  }
+
+  public void setInstances(List<MicroserviceInstance> instances) {
+    this.instances = instances;
+  }
+
+  public void setRevisionId(String revisionId) {
+    this.revisionId = revisionId;
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableMicroserviceCacheTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableMicroserviceCacheTest.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import org.apache.servicecomb.foundation.common.Holder;
+import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
+import org.apache.servicecomb.serviceregistry.api.registry.MicroserviceInstance;
+import org.apache.servicecomb.serviceregistry.api.response.FindInstancesResponse;
+import org.apache.servicecomb.serviceregistry.client.ServiceRegistryClient;
+import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import org.apache.servicecomb.serviceregistry.consumer.MicroserviceInstancePing;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache.MicroserviceCacheStatus;
+import org.apache.servicecomb.serviceregistry.task.event.SafeModeChangeEvent;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import mockit.Mock;
+import mockit.MockUp;
+
+public class RefreshableMicroserviceCacheTest {
+
+  private Holder<Function<Object[], MicroserviceInstances>> findServiceInstancesOprHolder = new Holder<>();
+
+  private ServiceRegistryClient srClient;
+
+  private RefreshableMicroserviceCache microserviceCache;
+
+  private List<MicroserviceInstance> pulledInstances = new ArrayList<>();
+
+  private Microservice consumerService;
+
+  @Before
+  public void setUp() throws Exception {
+    srClient = new MockUp<ServiceRegistryClient>() {
+      @Mock
+      MicroserviceInstances findServiceInstances(String consumerId, String appId, String serviceName,
+          String versionRule, String revision) {
+        return findServiceInstancesOprHolder.value
+            .apply(new Object[] {consumerId, appId, serviceName, versionRule, revision});
+      }
+    }.getMockInstance();
+    consumerService = new Microservice();
+    consumerService.setServiceId("consumerId");
+    microserviceCache = new RefreshableMicroserviceCache(
+        consumerService,
+        MicroserviceCacheKey.builder().env("env").appId("app").serviceName("svc").build(),
+        srClient,
+        false);
+
+    findServiceInstancesOprHolder.value = params -> {
+      MicroserviceInstances microserviceInstances = new MicroserviceInstances();
+      microserviceInstances.setNeedRefresh(true);
+      microserviceInstances.setRevision("rev0");
+      microserviceInstances.setMicroserviceNotExist(false);
+
+      FindInstancesResponse instancesResponse = new FindInstancesResponse();
+      instancesResponse.setInstances(pulledInstances);
+      microserviceInstances.setInstancesResponse(instancesResponse);
+
+      return microserviceInstances;
+    };
+  }
+
+  @Test
+  public void refresh() {
+    ArrayList<MicroserviceInstance> instances = new ArrayList<>();
+    findServiceInstancesOprHolder.value = params -> {
+      Assert.assertEquals("consumerId", params[0]);
+      Assert.assertEquals("app", params[1]);
+      Assert.assertEquals("svc", params[2]);
+      Assert.assertEquals("0.0.0.0+", params[3]);
+      Assert.assertNull(params[4]);
+      MicroserviceInstances microserviceInstances = new MicroserviceInstances();
+      microserviceInstances.setNeedRefresh(true);
+      microserviceInstances.setRevision("rev0");
+      microserviceInstances.setMicroserviceNotExist(false);
+
+      FindInstancesResponse instancesResponse = new FindInstancesResponse();
+      instancesResponse.setInstances(instances);
+
+      microserviceInstances.setInstancesResponse(instancesResponse);
+      return microserviceInstances;
+    };
+
+    // at the beginning, no instances in cache
+    List<MicroserviceInstance> cachedInstances = microserviceCache.getInstances();
+    Assert.assertEquals(0, cachedInstances.size());
+    Assert.assertNull(microserviceCache.getRevisionId());
+
+    // find 1 instance from sc
+    MicroserviceInstance microserviceInstance = new MicroserviceInstance();
+    instances.add(microserviceInstance);
+    microserviceInstance.setInstanceId("instanceId00");
+
+    microserviceCache.refresh();
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+
+    cachedInstances = microserviceCache.getInstances();
+    Assert.assertEquals(1, cachedInstances.size());
+    MicroserviceInstance instance = cachedInstances.iterator().next();
+    Assert.assertEquals("instanceId00", instance.getInstanceId());
+
+    // 2nd time, find 2 instances, one of them is the old instance
+    MicroserviceInstance microserviceInstance1 = new MicroserviceInstance();
+    instances.add(microserviceInstance1);
+    microserviceInstance1.setInstanceId("instanceId01");
+
+    findServiceInstancesOprHolder.value = params -> {
+      Assert.assertEquals("consumerId", params[0]);
+      Assert.assertEquals("app", params[1]);
+      Assert.assertEquals("svc", params[2]);
+      Assert.assertEquals("0.0.0.0+", params[3]);
+      Assert.assertEquals("rev0", params[4]);
+      MicroserviceInstances microserviceInstances = new MicroserviceInstances();
+      microserviceInstances.setNeedRefresh(true);
+      microserviceInstances.setRevision("rev1");
+      microserviceInstances.setMicroserviceNotExist(false);
+
+      FindInstancesResponse instancesResponse = new FindInstancesResponse();
+      instancesResponse.setInstances(instances);
+
+      microserviceInstances.setInstancesResponse(instancesResponse);
+      return microserviceInstances;
+    };
+
+    microserviceCache.refresh();
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+    cachedInstances = microserviceCache.getInstances();
+    Assert.assertEquals(2, cachedInstances.size());
+    Assert.assertEquals("instanceId00", cachedInstances.get(0).getInstanceId());
+    Assert.assertEquals("instanceId01", cachedInstances.get(1).getInstanceId());
+  }
+
+  @Test
+  public void refresh_service_error() {
+    findServiceInstancesOprHolder.value = params -> null;
+
+    List<MicroserviceInstance> oldInstanceList = microserviceCache.getInstances();
+
+    microserviceCache.refresh();
+    Assert.assertEquals(MicroserviceCacheStatus.CLIENT_ERROR, microserviceCache.getStatus());
+    Assert.assertSame(oldInstanceList, microserviceCache.getInstances());
+  }
+
+  @Test
+  public void refresh_service_not_exist() {
+    findServiceInstancesOprHolder.value = params -> {
+      MicroserviceInstances microserviceInstances = new MicroserviceInstances();
+      microserviceInstances.setMicroserviceNotExist(true);
+      return microserviceInstances;
+    };
+
+    List<MicroserviceInstance> oldInstanceList = microserviceCache.getInstances();
+
+    microserviceCache.refresh();
+    Assert.assertEquals(MicroserviceCacheStatus.SERVICE_NOT_FOUND, microserviceCache.getStatus());
+    Assert.assertSame(oldInstanceList, microserviceCache.getInstances());
+  }
+
+  @Test
+  public void refresh_service_no_change() {
+    findServiceInstancesOprHolder.value = params -> {
+      MicroserviceInstances microserviceInstances = new MicroserviceInstances();
+      microserviceInstances.setMicroserviceNotExist(false);
+      microserviceInstances.setNeedRefresh(false);
+      return microserviceInstances;
+    };
+
+    List<MicroserviceInstance> oldInstanceList = microserviceCache.getInstances();
+
+    microserviceCache.refresh();
+    Assert.assertEquals(MicroserviceCacheStatus.NO_CHANGE, microserviceCache.getStatus());
+    Assert.assertSame(oldInstanceList, microserviceCache.getInstances());
+  }
+
+  @Test
+  public void refresh_error_in_setInstances() {
+    microserviceCache = new RefreshableMicroserviceCache(
+        consumerService,
+        MicroserviceCacheKey.builder().env("env").appId("app").serviceName("svc").build(),
+        srClient,
+        false) {
+      @Override
+      protected Set<MicroserviceInstance> mergeInstances(List<MicroserviceInstance> pulledInstances) {
+        throw new IllegalStateException("a mock exception");
+      }
+    };
+
+    List<MicroserviceInstance> oldInstanceList = microserviceCache.getInstances();
+    Assert.assertEquals(MicroserviceCacheStatus.INIT, microserviceCache.getStatus());
+
+    microserviceCache.refresh();
+
+    Assert.assertEquals(MicroserviceCacheStatus.SETTING_CACHE_ERROR, microserviceCache.getStatus());
+    List<MicroserviceInstance> newInstanceList = microserviceCache.getInstances();
+    Assert.assertEquals(0, newInstanceList.size());
+    Assert.assertSame(oldInstanceList, newInstanceList);
+  }
+
+  @Test
+  public void refresh_safe_mode() {
+    microserviceCache.instances = new ArrayList<>();
+    MicroserviceInstance instance0 = new MicroserviceInstance();
+    instance0.setInstanceId("instanceId0");
+    microserviceCache.instances.add(instance0);
+
+    pulledInstances = new ArrayList<>();
+    MicroserviceInstance instance1 = new MicroserviceInstance();
+    instance1.setInstanceId("instanceId1");
+    pulledInstances.add(instance1);
+
+    microserviceCache.refresh();
+
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+    Assert.assertEquals(1, microserviceCache.getInstances().size());
+    Assert.assertEquals("instanceId1", microserviceCache.getInstances().get(0).getInstanceId());
+
+    // enter safe mode
+    microserviceCache.onSafeModeChanged(new SafeModeChangeEvent(true));
+
+    pulledInstances = new ArrayList<>();
+    MicroserviceInstance instance2 = new MicroserviceInstance();
+    instance2.setInstanceId("instanceId2");
+    pulledInstances.add(instance2);
+
+    microserviceCache.refresh();
+
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+    Assert.assertEquals(2, microserviceCache.getInstances().size());
+    Assert.assertEquals("instanceId2", microserviceCache.getInstances().get(0).getInstanceId());
+    Assert.assertEquals("instanceId1", microserviceCache.getInstances().get(1).getInstanceId());
+
+    // exit safe mode
+    microserviceCache.onSafeModeChanged(new SafeModeChangeEvent(false));
+
+    pulledInstances = new ArrayList<>();
+    MicroserviceInstance instance3 = new MicroserviceInstance();
+    instance3.setInstanceId("instanceId3");
+    pulledInstances.add(instance3);
+
+    microserviceCache.refresh();
+
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+    Assert.assertEquals(1, microserviceCache.getInstances().size());
+    Assert.assertEquals("instanceId3", microserviceCache.getInstances().get(0).getInstanceId());
+  }
+
+  @Test
+  public void refresh_empty_instance_protection_disabled() {
+    microserviceCache.instances = new ArrayList<>();
+    MicroserviceInstance instance0 = new MicroserviceInstance();
+    instance0.setInstanceId("instanceId0");
+    microserviceCache.instances.add(instance0);
+
+    pulledInstances = new ArrayList<>();
+    microserviceCache.refresh();
+
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+    Assert.assertEquals(0, microserviceCache.getInstances().size());
+  }
+
+  @Test
+  public void refresh_empty_instance_protection_enabled() {
+    microserviceCache.setEmptyInstanceProtectionEnabled(true);
+    microserviceCache.instancePing = new MicroserviceInstancePing() {
+      @Override
+      public int getOrder() {
+        return 0;
+      }
+
+      @Override
+      public boolean ping(MicroserviceInstance instance) {
+        return true;
+      }
+    };
+    microserviceCache.instances = new ArrayList<>();
+    MicroserviceInstance instance0 = new MicroserviceInstance();
+    instance0.setInstanceId("instanceId0");
+    microserviceCache.instances.add(instance0);
+
+    pulledInstances = new ArrayList<>();
+    microserviceCache.refresh();
+
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+    Assert.assertEquals(1, microserviceCache.getInstances().size());
+    Assert.assertEquals("instanceId0", microserviceCache.getInstances().get(0).getInstanceId());
+  }
+
+  @Test
+  public void set_consumer_service_id() {
+    Holder<Integer> assertCounter = new Holder<>(0);
+    Function<Object[], MicroserviceInstances> preservedLogic = findServiceInstancesOprHolder.value;
+    findServiceInstancesOprHolder.value = params -> {
+      Assert.assertEquals("consumerId", params[0]);
+      assertCounter.value++;
+      return preservedLogic.apply(params);
+    };
+    microserviceCache.refresh();
+
+    consumerService.setServiceId("consumerId2");
+
+    findServiceInstancesOprHolder.value = params -> {
+      Assert.assertEquals("consumerId2", params[0]);
+      assertCounter.value++;
+      return preservedLogic.apply(params);
+    };
+    microserviceCache.refresh();
+    Assert.assertEquals(Integer.valueOf(2), assertCounter.value);
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableServiceRegistryCacheTest.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableServiceRegistryCacheTest.java
@@ -1,0 +1,211 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.serviceregistry.registry.cache;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.function.Function;
+
+import org.apache.servicecomb.foundation.common.Holder;
+import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
+import org.apache.servicecomb.serviceregistry.api.response.FindInstancesResponse;
+import org.apache.servicecomb.serviceregistry.client.http.MicroserviceInstances;
+import org.apache.servicecomb.serviceregistry.registry.cache.MicroserviceCache.MicroserviceCacheStatus;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RefreshableServiceRegistryCacheTest {
+
+  private Holder<Function<String, MicroserviceInstances>> pullInstanceFromServiceCenterLogic = new Holder<>(
+      rev -> {
+        MicroserviceInstances microserviceInstances = new MicroserviceInstances();
+        microserviceInstances.setMicroserviceNotExist(false);
+        microserviceInstances.setNeedRefresh(true);
+        microserviceInstances.setRevision(rev);
+        FindInstancesResponse instancesResponse = new FindInstancesResponse();
+        instancesResponse.setInstances(new ArrayList<>());
+        microserviceInstances.setInstancesResponse(instancesResponse);
+        return microserviceInstances;
+      }
+  );
+
+  private RefreshableServiceRegistryCache serviceRegistryCache;
+
+  private Microservice consumerService;
+
+  @Before
+  public void setUp() throws Exception {
+    serviceRegistryCache = new RefreshableServiceRegistryCache(consumerService, null) {
+      @Override
+      RefreshableMicroserviceCache createMicroserviceCache(MicroserviceCacheKey microserviceCacheKey) {
+        return new RefreshableMicroserviceCache(consumerService, microserviceCacheKey, null, false) {
+          @Override
+          MicroserviceInstances pullInstanceFromServiceCenter(String revisionId) {
+            return pullInstanceFromServiceCenterLogic.value.apply(revisionId);
+          }
+        };
+      }
+    };
+    consumerService = new Microservice();
+    consumerService.setServiceId("testConsumer");
+  }
+
+  @Test
+  public void find_service_instances() {
+    MicroserviceCache microserviceCache = serviceRegistryCache
+        .findServiceCache(MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build());
+
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, microserviceCache.getStatus());
+    Assert.assertEquals(0, microserviceCache.getInstances().size());
+    Assert.assertEquals(1, serviceRegistryCache.microserviceCache.size());
+    Entry<MicroserviceCacheKey, RefreshableMicroserviceCache> cacheEntry =
+        serviceRegistryCache.microserviceCache.entrySet().iterator().next();
+    Assert.assertEquals(MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build(),
+        cacheEntry.getKey());
+  }
+
+  @Test
+  public void clear_cache_revision() {
+    RefreshableMicroserviceCache microserviceCache = new RefreshableMicroserviceCache(
+        consumerService,
+        MicroserviceCacheKey.builder().serviceName("svc").appId("appId").env("env").build(),
+        null, false);
+    RefreshableMicroserviceCache microserviceCache2 = new RefreshableMicroserviceCache(
+        consumerService,
+        MicroserviceCacheKey.builder().serviceName("svc2").appId("appId").env("env").build(),
+        null, false);
+    serviceRegistryCache.microserviceCache.put(microserviceCache.getKey(), microserviceCache);
+    serviceRegistryCache.microserviceCache.put(microserviceCache2.getKey(), microserviceCache2);
+
+    microserviceCache.revisionId = "rev";
+    microserviceCache2.revisionId = "rev";
+
+    serviceRegistryCache.clearRevisionId(
+        MicroserviceCacheKey.builder().serviceName("svc").env("env").appId("appId").build());
+
+    Assert.assertNull(microserviceCache.revisionId);
+    Assert.assertEquals("rev", microserviceCache2.revisionId);
+
+    microserviceCache.revisionId = "rev";
+
+    serviceRegistryCache.clearAllRevisionId();
+    Assert.assertNull(microserviceCache.revisionId);
+    Assert.assertNull(microserviceCache2.revisionId);
+  }
+
+  @Test
+  public void refreshCache() {
+    RefreshableMicroserviceCache microserviceCache = new RefreshableMicroserviceCache(
+        consumerService,
+        MicroserviceCacheKey.builder().serviceName("svc").appId("appId").env("env").build(),
+        null, false) {
+      @Override
+      void refresh() {
+        this.status = MicroserviceCacheStatus.REFRESHED;
+      }
+    };
+    RefreshableMicroserviceCache microserviceCache2 = new RefreshableMicroserviceCache(
+        consumerService,
+        MicroserviceCacheKey.builder().serviceName("svc2").appId("appId").env("env").build(),
+        null, false);
+    RefreshableMicroserviceCache microserviceCache3 = new RefreshableMicroserviceCache(
+        consumerService,
+        MicroserviceCacheKey.builder().serviceName("svc3").appId("appId").env("env").build(),
+        null, false) {
+      @Override
+      void refresh() {
+        this.status = MicroserviceCacheStatus.SERVICE_NOT_FOUND;
+      }
+    };
+
+    serviceRegistryCache.microserviceCache.put(microserviceCache.getKey(), microserviceCache);
+    serviceRegistryCache.microserviceCache.put(microserviceCache2.getKey(), microserviceCache2);
+    serviceRegistryCache.microserviceCache.put(microserviceCache3.getKey(), microserviceCache3);
+
+    List<MicroserviceCache> refreshedCaches = new ArrayList<>();
+    serviceRegistryCache.setCacheRefreshedWatcher(refreshedCaches::addAll);
+
+    serviceRegistryCache.refreshCache();
+
+    Assert.assertEquals(2, refreshedCaches.size());
+    Assert.assertSame(microserviceCache.getKey(), refreshedCaches.get(0).getKey());
+    Assert.assertSame(microserviceCache3.getKey(), refreshedCaches.get(1).getKey());
+    Assert.assertEquals(2, serviceRegistryCache.microserviceCache.size());
+    Assert.assertSame(microserviceCache, serviceRegistryCache.microserviceCache.get(microserviceCache.getKey()));
+    Assert.assertSame(microserviceCache2, serviceRegistryCache.microserviceCache.get(microserviceCache2.getKey()));
+  }
+
+  @Test
+  public void findServiceCache_normal() {
+    mockServiceRegistryHolder().value = MicroserviceCacheStatus.REFRESHED;
+
+    MicroserviceCacheKey cacheKey = MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build();
+    MicroserviceCache serviceCache = serviceRegistryCache.findServiceCache(cacheKey);
+
+    Assert.assertSame(cacheKey, serviceCache.getKey());
+    Assert.assertEquals(MicroserviceCacheStatus.REFRESHED, serviceCache.getStatus());
+    Assert.assertEquals(1, serviceRegistryCache.microserviceCache.size());
+    Assert.assertSame(serviceCache, serviceRegistryCache.microserviceCache.get(cacheKey));
+  }
+
+  @Test
+  public void findServiceCache_client_error() {
+    mockServiceRegistryHolder().value = MicroserviceCacheStatus.CLIENT_ERROR;
+
+    MicroserviceCacheKey cacheKey = MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build();
+    MicroserviceCache serviceCache = serviceRegistryCache.findServiceCache(cacheKey);
+
+    Assert.assertSame(cacheKey, serviceCache.getKey());
+    Assert.assertEquals(MicroserviceCacheStatus.CLIENT_ERROR, serviceCache.getStatus());
+    Assert.assertEquals(1, serviceRegistryCache.microserviceCache.size());
+    Assert.assertSame(serviceCache, serviceRegistryCache.microserviceCache.get(cacheKey));
+  }
+
+  @Test
+  public void findServiceCache_service_not_found() {
+    mockServiceRegistryHolder().value = MicroserviceCacheStatus.SERVICE_NOT_FOUND;
+
+    MicroserviceCacheKey cacheKey = MicroserviceCacheKey.builder().serviceName("svc").appId("app").env("env").build();
+    MicroserviceCache serviceCache = serviceRegistryCache.findServiceCache(cacheKey);
+
+    Assert.assertSame(cacheKey, serviceCache.getKey());
+    Assert.assertEquals(MicroserviceCacheStatus.SERVICE_NOT_FOUND, serviceCache.getStatus());
+    Assert.assertTrue(serviceRegistryCache.microserviceCache.isEmpty());
+  }
+
+  private Holder<MicroserviceCacheStatus> mockServiceRegistryHolder() {
+    Holder<MicroserviceCacheStatus> statusHolder = new Holder<>();
+    serviceRegistryCache = new RefreshableServiceRegistryCache(consumerService, null) {
+      @Override
+      RefreshableMicroserviceCache createMicroserviceCache(MicroserviceCacheKey microserviceCacheKey) {
+        return new RefreshableMicroserviceCache(
+            consumerService,
+            microserviceCacheKey,
+            null, false) {
+          @Override
+          void refresh() {
+            this.status = statusHolder.value;
+          }
+        };
+      }
+    };
+    return statusHolder;
+  }
+}

--- a/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/swagger/TestSwaggerLoader.java
+++ b/service-registry/src/test/java/org/apache/servicecomb/serviceregistry/swagger/TestSwaggerLoader.java
@@ -40,6 +40,7 @@ import org.apache.servicecomb.foundation.common.Holder;
 import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
 import org.apache.servicecomb.foundation.common.utils.JvmUtils;
 import org.apache.servicecomb.foundation.common.utils.ResourceUtil;
+import org.apache.servicecomb.serviceregistry.RegistryUtils;
 import org.apache.servicecomb.serviceregistry.TestRegistryBase;
 import org.apache.servicecomb.serviceregistry.api.registry.Microservice;
 import org.apache.servicecomb.swagger.SwaggerUtils;
@@ -62,11 +63,11 @@ public class TestSwaggerLoader extends TestRegistryBase {
   @Test
   public void registerSwagger() {
     Swagger swagger = SwaggerGenerator.generate(Hello.class);
-    serviceRegistry.getSwaggerLoader().registerSwagger("default:ms2", schemaId, swagger);
+    RegistryUtils.getSwaggerLoader().registerSwagger("default:ms2", schemaId, swagger);
 
     Microservice microservice = appManager.getOrCreateMicroserviceVersions(appId, serviceName)
         .getVersions().values().iterator().next().getMicroservice();
-    Assert.assertSame(swagger, serviceRegistry.getSwaggerLoader().loadSwagger(microservice, schemaId));
+    Assert.assertSame(swagger, RegistryUtils.getSwaggerLoader().loadSwagger(microservice, schemaId));
   }
 
   @Test
@@ -79,11 +80,11 @@ public class TestSwaggerLoader extends TestRegistryBase {
       }
     };
 
-    serviceRegistry.getSwaggerLoader().unregisterSwagger(appId, serviceName, schemaId);
+    RegistryUtils.getSwaggerLoader().unregisterSwagger(appId, serviceName, schemaId);
 
     Microservice microservice = appManager.getOrCreateMicroserviceVersions(appId, serviceName)
         .getVersions().values().iterator().next().getMicroservice();
-    Swagger loadedSwagger = serviceRegistry.getSwaggerLoader().loadSwagger(microservice, schemaId);
+    Swagger loadedSwagger = RegistryUtils.getSwaggerLoader().loadSwagger(microservice, schemaId);
     Assert.assertNotSame(swagger, loadedSwagger);
     Assert.assertEquals(swagger, loadedSwagger);
   }
@@ -93,11 +94,11 @@ public class TestSwaggerLoader extends TestRegistryBase {
     Swagger swagger = SwaggerGenerator.generate(Hello.class);
     mockLocalResource(swagger, String.format("microservices/%s/%s.yaml", serviceName, schemaId));
 
-    serviceRegistry.getSwaggerLoader().unregisterSwagger(appId, serviceName, schemaId);
+    RegistryUtils.getSwaggerLoader().unregisterSwagger(appId, serviceName, schemaId);
 
     Microservice microservice = appManager.getOrCreateMicroserviceVersions(appId, serviceName)
         .getVersions().values().iterator().next().getMicroservice();
-    Swagger loadedSwagger = serviceRegistry.getSwaggerLoader().loadSwagger(microservice, schemaId);
+    Swagger loadedSwagger = RegistryUtils.getSwaggerLoader().loadSwagger(microservice, schemaId);
     Assert.assertNotSame(swagger, loadedSwagger);
     Assert.assertEquals(swagger, loadedSwagger);
   }
@@ -107,11 +108,11 @@ public class TestSwaggerLoader extends TestRegistryBase {
     Swagger swagger = SwaggerGenerator.generate(Hello.class);
     mockLocalResource(swagger, String.format("applications/%s/%s/%s.yaml", appId, serviceName, schemaId));
 
-    serviceRegistry.getSwaggerLoader().unregisterSwagger(appId, serviceName, schemaId);
+    RegistryUtils.getSwaggerLoader().unregisterSwagger(appId, serviceName, schemaId);
 
     Microservice microservice = appManager.getOrCreateMicroserviceVersions(appId, serviceName)
         .getVersions().values().iterator().next().getMicroservice();
-    Swagger loadedSwagger = serviceRegistry.getSwaggerLoader().loadSwagger(microservice, schemaId);
+    Swagger loadedSwagger = RegistryUtils.getSwaggerLoader().loadSwagger(microservice, schemaId);
     Assert.assertNotSame(swagger, loadedSwagger);
     Assert.assertEquals(swagger, loadedSwagger);
   }
@@ -127,7 +128,7 @@ public class TestSwaggerLoader extends TestRegistryBase {
     expectedException.expect(IllegalStateException.class);
     expectedException.expectMessage(
         "no schema in local, and can not get schema from service center, appId=other, microserviceName=ms3, version=1.0, serviceId=003, schemaId=hello.");
-    serviceRegistry.getSwaggerLoader().loadSwagger(microservice, schemaId);
+    RegistryUtils.getSwaggerLoader().loadSwagger(microservice, schemaId);
   }
 
   @Test
@@ -137,7 +138,7 @@ public class TestSwaggerLoader extends TestRegistryBase {
 
     Microservice microservice = appManager.getOrCreateMicroserviceVersions("other", "ms3")
         .getVersions().values().iterator().next().getMicroservice();
-    Swagger loadedSwagger = serviceRegistry.getSwaggerLoader().loadSwagger(microservice, schemaId);
+    Swagger loadedSwagger = RegistryUtils.getSwaggerLoader().loadSwagger(microservice, schemaId);
     Assert.assertNotSame(swagger, loadedSwagger);
     Assert.assertEquals(swagger, loadedSwagger);
   }
@@ -195,16 +196,16 @@ public class TestSwaggerLoader extends TestRegistryBase {
 
   @Test
   public void should_ignore_not_exist_location_when_register_swagger_in_location() {
-    Map<String, Object> apps = Deencapsulation.getField(serviceRegistry.getSwaggerLoader(), "apps");
+    Map<String, Object> apps = Deencapsulation.getField(RegistryUtils.getSwaggerLoader(), "apps");
     apps.clear();
-    serviceRegistry.getSwaggerLoader().registerSwaggersInLocation("notExistPath");
+    RegistryUtils.getSwaggerLoader().registerSwaggersInLocation("notExistPath");
     assertThat(apps).isEmpty();
   }
 
   @Test
   public void should_ignore_non_yaml_file_when_register_swagger_in_location() {
-    serviceRegistry.getSwaggerLoader().registerSwaggersInLocation("swagger-del");
-    assertThat(serviceRegistry.getSwaggerLoader().loadFromMemory(appId, serviceName, "other")).isNull();
+    RegistryUtils.getSwaggerLoader().registerSwaggersInLocation("swagger-del");
+    assertThat(RegistryUtils.getSwaggerLoader().loadFromMemory(appId, serviceName, "other")).isNull();
   }
 
   @Test
@@ -248,12 +249,12 @@ public class TestSwaggerLoader extends TestRegistryBase {
       }
     };
 
-    serviceRegistry.getSwaggerLoader().registerSwaggersInLocation("location");
+    RegistryUtils.getSwaggerLoader().registerSwaggersInLocation("location");
   }
 
   @Test
   public void should_correct_register_swagger_in_location() {
-    serviceRegistry.getSwaggerLoader().registerSwaggersInLocation("swagger-del");
-    assertThat(serviceRegistry.getSwaggerLoader().loadFromMemory(appId, serviceName, "hello")).isNotNull();
+    RegistryUtils.getSwaggerLoader().registerSwaggersInLocation("swagger-del");
+    assertThat(RegistryUtils.getSwaggerLoader().loadFromMemory(appId, serviceName, "hello")).isNotNull();
   }
 }


### PR DESCRIPTION
main features:
- one microservice instance can hold multiple `ServiceRegistry` instances, which are managed in `RegistryUtils`, so that one instance can connect to multiple service center clusters
- when microservice instance is shutdown, the corresponding instance record in service center is switched to `DOWN` status and the shutdown precedure is blocked for a while, so that consumer can get enough time to get notified that this instance is stopping. The block period length is determined by the config item `servicecomb.boot.turnDown.waitInSeconds`