### PR TITLE
[SCB-1858] rest模式下与prometheus集成可以不占用单独的端口

### DIFF
--- a/metrics/metrics-integration/metrics-prometheus/src/main/java/org/apache/servicecomb/metrics/prometheus/PrometheusBootListener.java
+++ b/metrics/metrics-integration/metrics-prometheus/src/main/java/org/apache/servicecomb/metrics/prometheus/PrometheusBootListener.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.metrics.prometheus;
+
+import org.apache.servicecomb.core.BootListener;
+import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
+import org.apache.servicecomb.foundation.metrics.MetricsInitializer;
+
+public class PrometheusBootListener implements BootListener {
+    @Override
+    public void onBeforeProducerProvider(BootEvent event) {
+        if (PrometheusPublisher.METRICS_PROMETHEUS_REST.get()) {
+            PrometheusPublisher prometheusPublisher =
+                    SPIServiceUtils.getTargetService(MetricsInitializer.class, PrometheusPublisher.class);
+            event.getScbEngine().getProducerProviderManager().registerSchema("prometheus", prometheusPublisher);
+        }
+    }
+}

--- a/metrics/metrics-integration/metrics-prometheus/src/main/resources/META-INF/services/org.apache.servicecomb.core.BootListener
+++ b/metrics/metrics-integration/metrics-prometheus/src/main/resources/META-INF/services/org.apache.servicecomb.core.BootListener
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.servicecomb.metrics.prometheus.PrometheusBootListener

--- a/metrics/metrics-integration/metrics-prometheus/src/test/java/org/apache/servicecomb/metrics/prometheus/TestPrometheusPublisher.java
+++ b/metrics/metrics-integration/metrics-prometheus/src/test/java/org/apache/servicecomb/metrics/prometheus/TestPrometheusPublisher.java
@@ -23,6 +23,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
+import io.prometheus.client.CollectorRegistry;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.servicecomb.foundation.common.exceptions.ServiceCombException;
@@ -90,6 +91,7 @@ public class TestPrometheusPublisher {
         result = "testAppId";
       }
     };
+    CollectorRegistry.defaultRegistry.clear();
     ArchaiusUtils.setProperty(PrometheusPublisher.METRICS_PROMETHEUS_ADDRESS, "localhost:0");
     publisher.init(globalRegistry, null, null);
 
@@ -122,6 +124,7 @@ public class TestPrometheusPublisher {
         result = "testAppId";
       }
     };
+    CollectorRegistry.defaultRegistry.clear();
     ArchaiusUtils.setProperty(PrometheusPublisher.METRICS_PROMETHEUS_REST.getName(), true);
     publisher.init(globalRegistry, null, null);
 


### PR DESCRIPTION
当配置servicecomb.metrics.prometheus.rest=true时，会注册一个/prometheus，访问此接口时，直接返回Prometheus格式的统计数据