### PR TITLE
[SCB-1860] 在InvocationContext与线程绑定时设置TraceId MDC

### DIFF
--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/ContextUtils.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/ContextUtils.java
@@ -17,12 +17,18 @@
 
 package org.apache.servicecomb.swagger.invocation.context;
 
+import org.slf4j.MDC;
+
 import java.util.concurrent.CompletableFuture;
 
 /**
  * 传递调用过程的上下文数据
  */
 public final class ContextUtils {
+  public static final String TRACE_ID_NAME = "X-B3-TraceId";
+
+  public static final String KEY_TRACE_ID = "SERVICECOMB_TRACE_ID";
+
   private ContextUtils() {
   }
 
@@ -35,16 +41,19 @@ public final class ContextUtils {
   public static InvocationContext getAndRemoveInvocationContext() {
     InvocationContext context = contextMgr.get();
     if (context != null) {
+      MDC.remove(KEY_TRACE_ID);
       contextMgr.remove();
     }
     return context;
   }
 
   public static void setInvocationContext(InvocationContext invocationContext) {
+    MDC.put(KEY_TRACE_ID, invocationContext.getContext(TRACE_ID_NAME));
     contextMgr.set(invocationContext);
   }
 
   public static void removeInvocationContext() {
+    MDC.remove(KEY_TRACE_ID);
     contextMgr.remove();
   }
 

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/ContextUtils.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/ContextUtils.java
@@ -48,7 +48,10 @@ public final class ContextUtils {
   }
 
   public static void setInvocationContext(InvocationContext invocationContext) {
-    MDC.put(KEY_TRACE_ID, invocationContext.getContext(TRACE_ID_NAME));
+    String traceId = invocationContext.getContext(TRACE_ID_NAME);
+    if (traceId != null) {
+      MDC.put(KEY_TRACE_ID, traceId);
+    }
     contextMgr.set(invocationContext);
   }
 


### PR DESCRIPTION
因为模块依赖关系，所以在ContextUtils重新定义了TraceId的两个常量。
另外没有与TraceIdLogger一样设置InvocationId，因为Context中没有并且目前看并不需要