### PR TITLE
[SCB-2058] fix SpringMVC provider not support non-file-type RequestPart problem

### DIFF
--- a/integration-tests/it-producer/src/main/java/org/apache/servicecomb/it/schema/UploadJaxrsSchema.java
+++ b/integration-tests/it-producer/src/main/java/org/apache/servicecomb/it/schema/UploadJaxrsSchema.java
@@ -18,8 +18,11 @@ package org.apache.servicecomb.it.schema;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.servlet.http.Part;
 import javax.ws.rs.FormParam;
@@ -30,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.servicecomb.provider.rest.common.RestSchema;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestSchema(schemaId = "uploadJaxrsSchema")
 @Path("/v1/uploadJaxrsSchema")
@@ -137,5 +141,31 @@ public class UploadJaxrsSchema {
       e.printStackTrace();
     }
     return "";
+  }
+
+  @Path("/uploadMultiformMix")
+  @POST
+  public Map<String, String> uploadMultiformMix(@FormParam("file") MultipartFile file,
+      @FormParam("fileList") List<MultipartFile> fileList,
+      @FormParam("str") String str,
+      @FormParam("strList") List<String> strList) throws IOException {
+    HashMap<String, String> map = new HashMap<>();
+    map.put("file", new String(file.getBytes(), StandardCharsets.UTF_8.name()));
+    map.put("fileList", _fileUpload(fileList));
+    map.put("str", str);
+    map.put("strList", strList.toString());
+    return map;
+  }
+
+  private static String _fileUpload(List<MultipartFile> fileList) {
+    StringBuilder stringBuilder = new StringBuilder();
+    try {
+      for (MultipartFile multipartFile : fileList) {
+        stringBuilder.append(IOUtils.toString(multipartFile.getBytes(), StandardCharsets.UTF_8.name()));
+      }
+    } catch (IOException e) {
+      throw new IllegalArgumentException(e);
+    }
+    return stringBuilder.toString();
   }
 }

--- a/integration-tests/it-producer/src/main/java/org/apache/servicecomb/it/schema/UploadSpringmvcSchema.java
+++ b/integration-tests/it-producer/src/main/java/org/apache/servicecomb/it/schema/UploadSpringmvcSchema.java
@@ -20,7 +20,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.servicecomb.provider.rest.common.RestSchema;
@@ -94,6 +96,19 @@ public class UploadSpringmvcSchema {
     List<MultipartFile> multipartFileList = Arrays.asList(file2);
     file1.addAll(multipartFileList);
     return _fileUpload(file1) + name;
+  }
+
+  @RequestMapping(path = "/uploadMultiformMix", method = RequestMethod.POST, consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+  public Map<String, String> uploadMultiformMix(@RequestPart(name = "file") MultipartFile file,
+      @RequestPart(name = "fileList") List<MultipartFile> fileList,
+      @RequestPart("str") String str,
+      @RequestPart("strList") List<String> strList) throws IOException {
+    HashMap<String, String> map = new HashMap<>();
+    map.put("file", new String(file.getBytes(), StandardCharsets.UTF_8.name()));
+    map.put("fileList", _fileUpload(fileList));
+    map.put("str", str);
+    map.put("strList", strList.toString());
+    return map;
   }
 
   private static String _fileUpload(List<MultipartFile> fileList) {

--- a/swagger/swagger-generator/generator-springmvc/src/main/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessor.java
+++ b/swagger/swagger-generator/generator-springmvc/src/main/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessor.java
@@ -19,22 +19,13 @@ package org.apache.servicecomb.swagger.generator.springmvc.processor.annotation;
 
 import java.lang.reflect.Type;
 
-import org.apache.servicecomb.swagger.generator.ParameterProcessor;
 import org.apache.servicecomb.swagger.generator.core.model.HttpParameterType;
 import org.springframework.web.bind.annotation.RequestPart;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.type.TypeFactory;
-
-import io.swagger.converter.ModelConverters;
-import io.swagger.models.Operation;
-import io.swagger.models.Swagger;
 import io.swagger.models.parameters.FormParameter;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.Property;
 
-public class RequestPartAnnotationProcessor implements
-    ParameterProcessor<FormParameter, RequestPart> {
+public class RequestPartAnnotationProcessor extends
+    AbstractSpringmvcSerializableParameterProcessor<FormParameter, RequestPart> {
   @Override
   public Type getProcessType() {
     return RequestPart.class;
@@ -55,36 +46,12 @@ public class RequestPartAnnotationProcessor implements
   }
 
   @Override
-  public void fillParameter(Swagger swagger, Operation operation, FormParameter formParameter, Type type,
-      RequestPart requestPart) {
-    Property property = resolveParamProperty(type);
-
-    formParameter.setProperty(property);
-    formParameter.setRequired(requestPart.required());
+  protected boolean readRequired(RequestPart requestPart) {
+    return requestPart.required();
   }
 
-  private Property resolveParamProperty(Type type) {
-    JavaType javaType = TypeFactory.defaultInstance().constructType(type);
-    if (javaType.isContainerType()) {
-      return resolvePropertyAsContainerType(javaType);
-    }
-    return ModelConverters.getInstance().readAsProperty(type);
-  }
-
-  private Property resolvePropertyAsContainerType(JavaType javaType) {
-    // At present, only array and collection of Part params are supported,
-    // but Map type is also a kind of container type.
-    // Although Map is not supported now, we still consider to take the type of value to generate a property.
-    // Therefore, here we use lastContainedTypeIndex to get the contained type.
-    int lastContainedTypeIndex = javaType.containedTypeCount() - 1;
-    JavaType containedItemType;
-    if (lastContainedTypeIndex < 0) {
-      // javaType may be an array
-      containedItemType = javaType.getContentType();
-    } else {
-      containedItemType = javaType.containedType(lastContainedTypeIndex);
-    }
-    Property containedItemProperty = ModelConverters.getInstance().readAsProperty(containedItemType);
-    return new ArrayProperty(containedItemProperty);
+  @Override
+  protected String pureReadDefaultValue(RequestPart requestPart) {
+    return null;
   }
 }

--- a/swagger/swagger-generator/generator-springmvc/src/main/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessor.java
+++ b/swagger/swagger-generator/generator-springmvc/src/main/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessor.java
@@ -23,13 +23,14 @@ import org.apache.servicecomb.swagger.generator.ParameterProcessor;
 import org.apache.servicecomb.swagger.generator.core.model.HttpParameterType;
 import org.springframework.web.bind.annotation.RequestPart;
 
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
+import io.swagger.converter.ModelConverters;
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 import io.swagger.models.parameters.FormParameter;
 import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.FileProperty;
 import io.swagger.models.properties.Property;
 
 public class RequestPartAnnotationProcessor implements
@@ -56,11 +57,34 @@ public class RequestPartAnnotationProcessor implements
   @Override
   public void fillParameter(Swagger swagger, Operation operation, FormParameter formParameter, Type type,
       RequestPart requestPart) {
-    Property property = new FileProperty();
-    if (TypeFactory.defaultInstance().constructType(type).isContainerType()) {
-      property = new ArrayProperty(new FileProperty());
-    }
+    Property property = resolveParamProperty(type);
+
     formParameter.setProperty(property);
     formParameter.setRequired(requestPart.required());
+  }
+
+  private Property resolveParamProperty(Type type) {
+    JavaType javaType = TypeFactory.defaultInstance().constructType(type);
+    if (javaType.isContainerType()) {
+      return resolvePropertyAsContainerType(javaType);
+    }
+    return ModelConverters.getInstance().readAsProperty(type);
+  }
+
+  private Property resolvePropertyAsContainerType(JavaType javaType) {
+    // At present, only array and collection of Part params are supported,
+    // but Map type is also a kind of container type.
+    // Although Map is not supported now, we still consider to take the type of value to generate a property.
+    // Therefore, here we use lastContainedTypeIndex to get the contained type.
+    int lastContainedTypeIndex = javaType.containedTypeCount() - 1;
+    JavaType containedItemType;
+    if (lastContainedTypeIndex < 0) {
+      // javaType may be an array
+      containedItemType = javaType.getContentType();
+    } else {
+      containedItemType = javaType.containedType(lastContainedTypeIndex);
+    }
+    Property containedItemProperty = ModelConverters.getInstance().readAsProperty(containedItemType);
+    return new ArrayProperty(containedItemProperty);
   }
 }

--- a/swagger/swagger-generator/generator-springmvc/src/main/java/org/apache/servicecomb/swagger/generator/springmvc/property/creator/MultipartFilePropertyCreator.java
+++ b/swagger/swagger-generator/generator-springmvc/src/main/java/org/apache/servicecomb/swagger/generator/springmvc/property/creator/MultipartFilePropertyCreator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.swagger.generator.springmvc.property.creator;
+
+import org.apache.servicecomb.swagger.extend.property.creator.PropertyCreator;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.Property;
+
+public class MultipartFilePropertyCreator implements PropertyCreator {
+  private final Class<?>[] classes = {MultipartFile.class};
+
+  @Override
+  public Property createProperty() {
+    return new FileProperty();
+  }
+
+  @Override
+  public Class<?>[] classes() {
+    return classes;
+  }
+}

--- a/swagger/swagger-generator/generator-springmvc/src/main/resources/META-INF/services/org.apache.servicecomb.swagger.extend.property.creator.PropertyCreator
+++ b/swagger/swagger-generator/generator-springmvc/src/main/resources/META-INF/services/org.apache.servicecomb.swagger.extend.property.creator.PropertyCreator
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.servicecomb.swagger.generator.springmvc.property.creator.MultipartFilePropertyCreator

--- a/swagger/swagger-generator/generator-springmvc/src/test/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessorTest.java
+++ b/swagger/swagger-generator/generator-springmvc/src/test/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessorTest.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.swagger.generator.springmvc.processor.annotation;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.List;
+
+import org.apache.servicecomb.swagger.generator.core.model.HttpParameterType;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.models.parameters.FormParameter;
+import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.StringProperty;
+
+public class RequestPartAnnotationProcessorTest {
+  private static Method producerMethod;
+
+  private static RequestPartAnnotationProcessor requestPartAnnotationProcessor = new RequestPartAnnotationProcessor();
+
+  @BeforeClass
+  public static void beforeClass() {
+    for (Method method : DemoRest.class.getDeclaredMethods()) {
+      if (method.getName().equals("fun")) {
+        producerMethod = method;
+        break;
+      }
+    }
+  }
+
+  @Test
+  public void getProcessType() {
+    Assert.assertEquals(requestPartAnnotationProcessor.getProcessType(),
+        RequestPart.class);
+  }
+
+  @Test
+  public void getParameterName_fromValue() {
+    Parameter[] parameters = producerMethod.getParameters();
+
+    Parameter stringParam = parameters[0];
+    RequestPart stringParamAnnotation = stringParam.getAnnotation(RequestPart.class);
+    Assert.assertThat(requestPartAnnotationProcessor.getParameterName(stringParamAnnotation),
+        Matchers.is("stringParam"));
+  }
+
+  @Test
+  public void getParameterName_fromName() {
+    Parameter[] parameters = producerMethod.getParameters();
+
+    Parameter intParam = parameters[1];
+    RequestPart intParamAnnotation = intParam.getAnnotation(RequestPart.class);
+    Assert.assertThat(requestPartAnnotationProcessor.getParameterName(intParamAnnotation),
+        Matchers.is("intParam"));
+  }
+
+  @Test
+  public void getHttpParameterType() {
+    Assert.assertThat(requestPartAnnotationProcessor.getHttpParameterType(null),
+        Matchers.is(HttpParameterType.FORM));
+  }
+
+  @Test
+  public void fillParameter_simpleType() {
+    Parameter param = producerMethod.getParameters()[0];
+    RequestPart requestPartAnnotation = param.getAnnotation(RequestPart.class);
+    FormParameter formParameter = new FormParameter();
+    requestPartAnnotationProcessor
+        .fillParameter(null, null, formParameter, param.getParameterizedType(), requestPartAnnotation);
+
+    Assert.assertThat(formParameter.getIn(), Matchers.is("formData"));
+    Assert.assertThat(formParameter.getType(), Matchers.is("string"));
+  }
+
+  @Test
+  public void fillParameter_simpleType_arrayPart() {
+    Parameter param = producerMethod.getParameters()[2];
+    RequestPart requestPartAnnotation = param.getAnnotation(RequestPart.class);
+    FormParameter formParameter = new FormParameter();
+    requestPartAnnotationProcessor
+        .fillParameter(null, null, formParameter, param.getParameterizedType(), requestPartAnnotation);
+
+    Assert.assertThat(formParameter.getIn(), Matchers.is("formData"));
+    Assert.assertThat(formParameter.getType(), Matchers.is("array"));
+    Assert.assertThat(formParameter.getItems(), Matchers.instanceOf(StringProperty.class));
+  }
+
+  @Test
+  public void fillParameter_simpleType_collectionPart() {
+    Parameter param = producerMethod.getParameters()[3];
+    RequestPart requestPartAnnotation = param.getAnnotation(RequestPart.class);
+    FormParameter formParameter = new FormParameter();
+    requestPartAnnotationProcessor
+        .fillParameter(null, null, formParameter, param.getParameterizedType(), requestPartAnnotation);
+
+    Assert.assertThat(formParameter.getIn(), Matchers.is("formData"));
+    Assert.assertThat(formParameter.getType(), Matchers.is("array"));
+    Assert.assertThat(formParameter.getItems(), Matchers.instanceOf(StringProperty.class));
+  }
+
+  @Test
+  public void fillParameter_uploadFile() {
+    Parameter param = producerMethod.getParameters()[4];
+    RequestPart requestPartAnnotation = param.getAnnotation(RequestPart.class);
+    FormParameter formParameter = new FormParameter();
+    requestPartAnnotationProcessor
+        .fillParameter(null, null, formParameter, param.getParameterizedType(), requestPartAnnotation);
+
+    Assert.assertThat(formParameter.getIn(), Matchers.is("formData"));
+    Assert.assertThat(formParameter.getType(), Matchers.is("file"));
+  }
+
+  @Test
+  public void fillParameter_uploadFile_arrayPart() {
+    Parameter param = producerMethod.getParameters()[5];
+    RequestPart requestPartAnnotation = param.getAnnotation(RequestPart.class);
+    FormParameter formParameter = new FormParameter();
+    requestPartAnnotationProcessor
+        .fillParameter(null, null, formParameter, param.getParameterizedType(), requestPartAnnotation);
+
+    Assert.assertThat(formParameter.getIn(), Matchers.is("formData"));
+    Assert.assertThat(formParameter.getType(), Matchers.is("array"));
+    Assert.assertThat(formParameter.getItems(), Matchers.instanceOf(FileProperty.class));
+  }
+
+  @Test
+  public void fillParameter_uploadFile_collectionPart() {
+    Parameter param = producerMethod.getParameters()[6];
+    RequestPart requestPartAnnotation = param.getAnnotation(RequestPart.class);
+    FormParameter formParameter = new FormParameter();
+    requestPartAnnotationProcessor
+        .fillParameter(null, null, formParameter, param.getParameterizedType(), requestPartAnnotation);
+
+    Assert.assertThat(formParameter.getIn(), Matchers.is("formData"));
+    Assert.assertThat(formParameter.getType(), Matchers.is("array"));
+    Assert.assertThat(formParameter.getItems(), Matchers.instanceOf(FileProperty.class));
+  }
+
+  public static class DemoRest {
+    public void fun(@RequestPart("stringParam") String stringParam,
+        @RequestPart(name = "intParam") int intParam,
+        @RequestPart("stringParamArray") String[] stringParamArray,
+        @RequestPart("stringParamCollection") List<String> stringParamCollection,
+        @RequestPart("file") MultipartFile file,
+        @RequestPart("fileArray") MultipartFile[] fileArray,
+        @RequestPart("fileCollection") List<MultipartFile> fileCollection) {
+    }
+  }
+}

--- a/swagger/swagger-generator/generator-springmvc/src/test/java/org/apache/servicecomb/swagger/generator/springmvc/property/creator/MultipartFilePropertyCreatorTest.java
+++ b/swagger/swagger-generator/generator-springmvc/src/test/java/org/apache/servicecomb/swagger/generator/springmvc/property/creator/MultipartFilePropertyCreatorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.swagger.generator.springmvc.property.creator;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.models.properties.FileProperty;
+import io.swagger.models.properties.Property;
+
+public class MultipartFilePropertyCreatorTest {
+  private MultipartFilePropertyCreator multipartFilePropertyCreator = new MultipartFilePropertyCreator();
+
+  @Test
+  public void createProperty() {
+    Property property = multipartFilePropertyCreator.createProperty();
+    Assert.assertThat(property, Matchers.instanceOf(FileProperty.class));
+  }
+
+  @Test
+  public void classes() {
+    Class<?>[] classes = multipartFilePropertyCreator.classes();
+    Assert.assertThat(classes, Matchers.arrayContaining(MultipartFile.class));
+  }
+}


### PR DESCRIPTION
- add MultipartFilePropertyCreator to enable ModelConverters resolving MultipartFile param
- make RequestPartAnnotationProcessor recognize non-file-type RequestPart param

See details in https://github.com/apache/servicecomb-java-chassis/issues/1902