### PR TITLE
[SCB-2082] add separated switches for metricsEndpoint and healthEndpoint

### DIFF
--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/HealthBootListener.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/HealthBootListener.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.metrics.core;
+
+import org.apache.servicecomb.core.BootListener;
+import org.apache.servicecomb.metrics.core.publish.HealthCheckerRestPublisher;
+import org.springframework.stereotype.Component;
+
+import com.netflix.config.DynamicPropertyFactory;
+
+@Component
+public class HealthBootListener implements BootListener {
+  @Override
+  public void onBeforeProducerProvider(BootEvent event) {
+    if (!DynamicPropertyFactory.getInstance().getBooleanProperty("servicecomb.health.endpoint.enabled", true).get()) {
+      return;
+    }
+
+    event.getScbEngine().getProducerProviderManager()
+        .addProducerMeta("healthEndpoint", new HealthCheckerRestPublisher());
+  }
+}

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MetricsBootListener.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MetricsBootListener.java
@@ -22,7 +22,6 @@ import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.foundation.metrics.MetricsBootstrap;
 import org.apache.servicecomb.foundation.metrics.MetricsInitializer;
 import org.apache.servicecomb.foundation.metrics.registry.GlobalRegistry;
-import org.apache.servicecomb.metrics.core.publish.HealthCheckerRestPublisher;
 import org.apache.servicecomb.metrics.core.publish.MetricsRestPublisher;
 import org.apache.servicecomb.metrics.core.publish.SlowInvocationLogger;
 
@@ -46,9 +45,6 @@ public class MetricsBootListener implements BootListener {
     if (!DynamicPropertyFactory.getInstance().getBooleanProperty("servicecomb.metrics.endpoint.enabled", true).get()) {
       return;
     }
-
-    event.getScbEngine().getProducerProviderManager()
-        .addProducerMeta("healthEndpoint", new HealthCheckerRestPublisher());
 
     MetricsRestPublisher metricsRestPublisher =
         SPIServiceUtils.getTargetService(MetricsInitializer.class, MetricsRestPublisher.class);

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestHealthBootListener.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestHealthBootListener.java
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.servicecomb.metrics.core;
 
 import java.util.ArrayList;
@@ -24,14 +25,15 @@ import org.apache.servicecomb.core.SCBEngine;
 import org.apache.servicecomb.core.provider.producer.ProducerMeta;
 import org.apache.servicecomb.core.provider.producer.ProducerProviderManager;
 import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
-import org.apache.servicecomb.metrics.core.publish.MetricsRestPublisher;
+import org.apache.servicecomb.metrics.core.publish.HealthCheckerRestPublisher;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-public class TestMetricsBootListener {
+public class TestHealthBootListener {
+
   @Before
   public void setUp() {
     ArchaiusUtils.resetConfig();
@@ -43,8 +45,8 @@ public class TestMetricsBootListener {
   }
 
   @Test
-  public void onBeforeProducerProvider_metrics_endpoint_enabled_by_default() {
-    final MetricsBootListener listener = new MetricsBootListener();
+  public void onBeforeProducerProvider_health_endpoint_enabled_by_default() {
+    final HealthBootListener listener = new HealthBootListener();
 
     final List<ProducerMeta> producerMetas = new ArrayList<>();
     final BootEvent event = new BootEvent();
@@ -69,14 +71,14 @@ public class TestMetricsBootListener {
     listener.onBeforeProducerProvider(event);
 
     Assert.assertThat(producerMetas, Matchers.contains(producerMeta));
-    Assert.assertThat(producerMeta.getSchemaId(), Matchers.equalTo("metricsEndpoint"));
-    Assert.assertThat(producerMeta.getInstance(), Matchers.instanceOf(MetricsRestPublisher.class));
+    Assert.assertThat(producerMeta.getSchemaId(), Matchers.equalTo("healthEndpoint"));
+    Assert.assertThat(producerMeta.getInstance(), Matchers.instanceOf(HealthCheckerRestPublisher.class));
   }
 
   @Test
-  public void onBeforeProducerProvider_metrics_endpoint_disabled() {
-    ArchaiusUtils.setProperty("servicecomb.metrics.endpoint.enabled", false);
-    final MetricsBootListener listener = new MetricsBootListener();
+  public void onBeforeProducerProvider_health_endpoint_disabled() {
+    ArchaiusUtils.setProperty("servicecomb.health.endpoint.enabled", false);
+    final HealthBootListener listener = new HealthBootListener();
 
     final List<ProducerMeta> producerMetas = new ArrayList<>();
     final BootEvent event = new BootEvent();


### PR DESCRIPTION
- add config item `servicecomb.health.endpoint.enabled` as the switch of healthEndpoint
- add config item `servicecomb.metrics.endpoint.enabled` as the switch of metricsEndpoint
- the default value of these two item is `true`
