### PR TITLE
[SCB-2082] add separated switches for metricsEndpoint and healthEndpoint

### DIFF
--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/HealthBootListener.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/HealthBootListener.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.metrics.core;
+
+import javax.inject.Inject;
+
+import org.apache.servicecomb.core.BootListener;
+import org.apache.servicecomb.core.definition.schema.ProducerSchemaFactory;
+import org.apache.servicecomb.metrics.core.publish.HealthCheckerRestPublisher;
+import org.springframework.stereotype.Component;
+
+import com.netflix.config.DynamicPropertyFactory;
+
+@Component
+public class HealthBootListener implements BootListener {
+  @Inject
+  ProducerSchemaFactory producerSchemaFactory;
+
+  @Override
+  public void onBootEvent(BootEvent event) {
+    if (event.getEventType() == EventType.BEFORE_PRODUCER_PROVIDER) {
+      registerSchemas();
+    }
+  }
+
+  private void registerSchemas() {
+    if (!DynamicPropertyFactory.getInstance().getBooleanProperty("servicecomb.health.endpoint.enabled", true).get()) {
+      return;
+    }
+
+    producerSchemaFactory.getOrCreateProducerSchema("healthEndpoint",
+        HealthCheckerRestPublisher.class,
+        new HealthCheckerRestPublisher());
+  }
+}

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MetricsBootListener.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MetricsBootListener.java
@@ -25,10 +25,11 @@ import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import org.apache.servicecomb.foundation.metrics.MetricsBootstrap;
 import org.apache.servicecomb.foundation.metrics.MetricsInitializer;
 import org.apache.servicecomb.foundation.metrics.registry.GlobalRegistry;
-import org.apache.servicecomb.metrics.core.publish.HealthCheckerRestPublisher;
 import org.apache.servicecomb.metrics.core.publish.MetricsRestPublisher;
 import org.apache.servicecomb.metrics.core.publish.SlowInvocationLogger;
 import org.springframework.stereotype.Component;
+
+import com.netflix.config.DynamicPropertyFactory;
 
 @Component
 public class MetricsBootListener implements BootListener {
@@ -66,9 +67,9 @@ public class MetricsBootListener implements BootListener {
   }
 
   private void registerSchemas() {
-    producerSchemaFactory.getOrCreateProducerSchema("healthEndpoint",
-        HealthCheckerRestPublisher.class,
-        new HealthCheckerRestPublisher());
+    if (!DynamicPropertyFactory.getInstance().getBooleanProperty("servicecomb.metrics.endpoint.enabled", true).get()) {
+      return;
+    }
 
     MetricsRestPublisher metricsRestPublisher =
         SPIServiceUtils.getTargetService(MetricsInitializer.class, MetricsRestPublisher.class);


### PR DESCRIPTION
on branch 1.3.x

- add config item `servicecomb.health.endpoint.enabled` as the switch of healthEndpoint
- add config item `servicecomb.metrics.endpoint.enabled` as the switch of metricsEndpoint
- the default value of these two item is `true`