### PR TITLE
SCB-2182 upgrade jackson from 2.12.0 to 2.12.1

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -60,7 +60,7 @@
     <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
     <httpcomponents.version>4.5.7</httpcomponents.version>
     <hystrix.version>1.5.18</hystrix.version>
-    <jackson.version>2.12.0</jackson.version>
+    <jackson.version>2.12.1</jackson.version>
     <javakaffee.version>0.26</javakaffee.version>
     <javax-annotation.version>1.3.2</javax-annotation.version>
     <javax-inject.version>1</javax-inject.version>


### PR DESCRIPTION
# jackson2.12..x抛弃原来的jason加速模块afterBurner,切换成blackBird了，2.12.0有bug，切成blackBird场景会触发该问题。afterBurner也有bug.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
