### PR TITLE
Set limitProperty default value

### DIFF
--- a/handlers/handler-flowcontrol-qps/src/main/java/org/apache/servicecomb/qps/QpsControllerManager.java
+++ b/handlers/handler-flowcontrol-qps/src/main/java/org/apache/servicecomb/qps/QpsControllerManager.java
@@ -185,9 +185,9 @@ public class QpsControllerManager {
       updateObjMap(configKey);
     });
     limitProperty.addCallback(() -> {
-      qpsStrategy.setQpsLimit(limitProperty.getLong());
+      qpsStrategy.setQpsLimit(limitProperty.getLong((long) Integer.MAX_VALUE));
       LOGGER.info("Qps limit updated, configKey = [{}], value = [{}]", configKey,
-          limitProperty.getString());
+              limitProperty.getLong((long) Integer.MAX_VALUE));
       updateObjMap(configKey);
     });
     bucketProperty.addCallback(() -> {


### PR DESCRIPTION
When qpsStrategy is deleted from the configuration center, the service will report a null pointer exception, so set a default value
