### PR TITLE
A request without any Accept header field implies that the user agent…

### DIFF
--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/RestTemplateCopyHeaderFilter.java
@@ -54,6 +54,11 @@ public class RestTemplateCopyHeaderFilter implements HttpClientFilter {
           LOGGER.debug("header value is null, key = [{}]. Will not set this header into request", key);
           continue;
         }
+
+        if (HttpHeaders.ACCEPT.equals(key) && value.isEmpty()) {
+          LOGGER.debug("header value is empty, key = [{}]. Will not set this header into request", key);
+          continue;
+        }
         requestEx.addHeader(key, value);
       }
     });

--- a/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/TestRestTemplateCopyHeaderFilter.java
+++ b/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/TestRestTemplateCopyHeaderFilter.java
@@ -63,6 +63,7 @@ public class TestRestTemplateCopyHeaderFilter {
     httpHeaders.add("headerName0", "headerValue0");
     httpHeaders.add("headerName1", null);
     httpHeaders.add("headerName2", "headerValue2");
+    httpHeaders.add("Accept", "");
     new Expectations() {
       {
         invocation.getHandlerContext();
@@ -75,6 +76,7 @@ public class TestRestTemplateCopyHeaderFilter {
     Assert.assertEquals("headerValue0", requestEx.getHeader("headerName0"));
     Assert.assertEquals("headerValue2", requestEx.getHeader("headerName2"));
     Assert.assertNull(requestEx.getHeader("headerName1"));
+    Assert.assertNull(requestEx.getHeader("Accept"));
   }
 
   @Test

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
@@ -26,12 +26,16 @@ import static org.apache.servicecomb.swagger.generator.SwaggerGeneratorUtils.pos
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang3.StringUtils;
@@ -323,37 +327,12 @@ public abstract class AbstractOperationGenerator implements OperationGenerator {
           parameterGenerator.getParameterName(),
           parameterGenerator.getGenericType(),
           parameterGenerator.getAnnotations());
-
-      if (parameterGenerator.getGenericType().getBindings().getTypeParameters().isEmpty()){
-        convertAnnotationProperty(parameterGenerator.getGenericType().getRawClass());
-      } else {
-        parameterGenerator.getGenericType().getBindings().getTypeParameters().
-            stream().forEach(javaType -> convertAnnotationProperty(javaType.getRawClass()));
-      }
-
     } catch (Throwable e) {
       throw new IllegalStateException(
           String.format("failed to fill parameter, parameterName=%s.",
               parameterGenerator.getParameterName()),
           e);
     }
-  }
-
-  private void convertAnnotationProperty(Class<?> beanClass){
-    if (beanClass == null) {
-      return;
-    }
-    String simpleName = beanClass.getSimpleName();
-    Arrays.stream(beanClass.getDeclaredFields()).forEach(field -> {
-      NotBlank notBlank = field.getAnnotation(NotBlank.class);
-      NotEmpty notEmpty = field.getAnnotation(NotEmpty.class);
-      if (notBlank != null || notEmpty != null){
-        Model model = swagger.getDefinitions().get(simpleName);
-        if (model != null) {
-          model.getProperties().get(field.getName()).setRequired(true);
-        }
-      }
-    });
   }
 
   protected Parameter createParameter(ParameterGenerator parameterGenerator) {

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
@@ -26,16 +26,12 @@ import static org.apache.servicecomb.swagger.generator.SwaggerGeneratorUtils.pos
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.core.MediaType;
 
 import org.apache.commons.lang3.StringUtils;
@@ -327,12 +323,37 @@ public abstract class AbstractOperationGenerator implements OperationGenerator {
           parameterGenerator.getParameterName(),
           parameterGenerator.getGenericType(),
           parameterGenerator.getAnnotations());
+
+      if (parameterGenerator.getGenericType().getBindings().getTypeParameters().isEmpty()){
+        convertAnnotationProperty(parameterGenerator.getGenericType().getRawClass());
+      } else {
+        parameterGenerator.getGenericType().getBindings().getTypeParameters().
+            stream().forEach(javaType -> convertAnnotationProperty(javaType.getRawClass()));
+      }
+
     } catch (Throwable e) {
       throw new IllegalStateException(
           String.format("failed to fill parameter, parameterName=%s.",
               parameterGenerator.getParameterName()),
           e);
     }
+  }
+
+  private void convertAnnotationProperty(Class<?> beanClass){
+    if (beanClass == null) {
+      return;
+    }
+    String simpleName = beanClass.getSimpleName();
+    Arrays.stream(beanClass.getDeclaredFields()).forEach(field -> {
+      NotBlank notBlank = field.getAnnotation(NotBlank.class);
+      NotEmpty notEmpty = field.getAnnotation(NotEmpty.class);
+      if (notBlank != null || notEmpty != null){
+        Model model = swagger.getDefinitions().get(simpleName);
+        if (model != null) {
+          model.getProperties().get(field.getName()).setRequired(true);
+        }
+      }
+    });
   }
 
   protected Parameter createParameter(ParameterGenerator parameterGenerator) {


### PR DESCRIPTION
A request without any Accept header field implies that the user agent will accept any media type in response。

when consumer sends a request to provider without without any Accept header field, serviceomb-java-chassis SDK will set Accept header empty.

According to RFC regulation, A request without any Accept header field implies that the user agent will accept any media type in response,
so if a consumer sends a request to provider without without any Accept header field,  it is more reasonable that serviceomb-java-chassis SDK not set Accept header.
