### PR TITLE
[SCB-2329] when consumer sends a request without setting any Accept header, default set Accept header "*/*"

### DIFF
--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseHttpMessageConverter.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseHttpMessageConverter.java
@@ -36,7 +36,7 @@ public class CseHttpMessageConverter implements GenericHttpMessageConverter<Obje
 
   @Override
   public boolean canRead(Class<?> clazz, MediaType mediaType) {
-    return false;
+    return true;
   }
 
   @Override
@@ -72,7 +72,7 @@ public class CseHttpMessageConverter implements GenericHttpMessageConverter<Obje
 
   @Override
   public boolean canRead(Type type, @Nullable Class<?> contextClass, @Nullable MediaType mediaType) {
-    return false;
+    return true;
   }
 
   @Override

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
@@ -26,14 +26,8 @@ import static org.apache.servicecomb.swagger.generator.SwaggerGeneratorUtils.pos
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.core.MediaType;
@@ -100,6 +94,8 @@ public abstract class AbstractOperationGenerator implements OperationGenerator {
   // 根据方法上独立的ResponseHeader(s)标注生成的数据
   // 如果Response中不存在对应的header，则会将这些header补充进去
   protected Map<String, Property> methodResponseHeaders = new LinkedHashMap<>();
+
+  private static List<String> NOT_NULL_ANNOTATIONS = Arrays.asList("NotBlank", "NotEmpty");
 
   public AbstractOperationGenerator(AbstractSwaggerGenerator swaggerGenerator, Method method) {
     this.swaggerGenerator = swaggerGenerator;
@@ -383,6 +379,11 @@ public abstract class AbstractOperationGenerator implements OperationGenerator {
 
     if (parameter instanceof AbstractSerializableParameter) {
       io.swagger.util.ParameterProcessor.applyAnnotations(swagger, parameter, type, annotations);
+      annotations.stream().forEach(annotation -> {
+        if (NOT_NULL_ANNOTATIONS.contains(annotation.annotationType().getSimpleName())){
+          parameter.setRequired(true);
+        }
+      });
       return;
     }
 
@@ -405,8 +406,31 @@ public abstract class AbstractOperationGenerator implements OperationGenerator {
       }
     }
 
+    // swagger 2.0 do not support NotBlank and NotEmpty annotations, fix it
+    if (((JavaType)type).getBindings().getTypeParameters().isEmpty()){
+      convertAnnotationProperty(((JavaType)type).getRawClass());
+    } else {
+      ((JavaType)type).getBindings().getTypeParameters().stream().
+          forEach(javaType -> convertAnnotationProperty(javaType.getRawClass()));
+    }
+
     mergeBodyParameter((BodyParameter) parameter, newBodyParameter);
   }
+
+  private void convertAnnotationProperty(Class<?> beanClass) {
+    Map<String, Model> definitions = swagger.getDefinitions();
+    if (definitions == null) {
+      return;
+    }
+    Model model = definitions.get(beanClass.getSimpleName());
+    Arrays.stream(beanClass.getDeclaredFields()).forEach(field -> {
+      boolean requireItem = Arrays.stream(field.getAnnotations()).anyMatch(annotation -> NOT_NULL_ANNOTATIONS.contains(annotation.annotationType().getSimpleName()));
+      if (requireItem) {
+        model.getProperties().get(field.getName()).setRequired(true);
+      }
+    });
+  }
+
 
   private void mergeBodyParameter(BodyParameter bodyParameter, BodyParameter fromBodyParameter) {
     if (fromBodyParameter.getExamples() != null) {

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/processor/annotation/ApiOperationProcessorTest.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/processor/annotation/ApiOperationProcessorTest.java
@@ -20,9 +20,14 @@ package org.apache.servicecomb.swagger.generator.core.processor.annotation;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.core.MediaType;
 
+import io.swagger.models.properties.Property;
 import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperation;
 import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperations;
 import org.hamcrest.Matchers;
@@ -30,6 +35,9 @@ import org.junit.AfterClass;
 import org.junit.Test;
 
 import io.swagger.annotations.ApiOperation;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Map;
 
 public class ApiOperationProcessorTest {
   static SwaggerOperations swaggerOperations = SwaggerOperations.generate(TestClass.class);
@@ -63,6 +71,48 @@ public class ApiOperationProcessorTest {
     @ApiOperation(value = "testBlankMediaType", consumes = "", produces = "")
     public String testBlankMediaType(String input) {
       return input;
+    }
+
+    @ApiOperation(value = "testBodyParam")
+    public String testBodyParam(@RequestBody TestBodyBean user) {
+      return user.toString();
+    }
+  }
+
+
+  private static class TestBodyBean {
+
+    @NotBlank
+    private String age;
+
+    @NotNull
+    private String name;
+
+    @NotEmpty
+    private String sexes;
+
+    public String getAge() {
+      return age;
+    }
+
+    public void setAge(String age) {
+      this.age = age;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getSexes() {
+      return sexes;
+    }
+
+    public void setSexes(String sexes) {
+      this.sexes = sexes;
     }
   }
 
@@ -99,4 +149,15 @@ public class ApiOperationProcessorTest {
     assertThat(swaggerOperation.getOperation().getConsumes(), Matchers.contains(MediaType.TEXT_HTML));
     assertThat(swaggerOperation.getOperation().getProduces(), Matchers.contains(MediaType.TEXT_HTML));
   }
+
+
+  @Test
+  public void testBodyParam() {
+    SwaggerOperation swaggerOperation = swaggerOperations.findOperation("testBodyParam");
+    Map<String, Property> properties = swaggerOperation.getSwagger().getDefinitions().get("testBodyParam").getProperties();
+    assertTrue("Support NotBlank annotation", properties.get("age").getRequired());
+    assertTrue("Support NotEmpty annotation", properties.get("sexes").getRequired());
+    assertTrue("Original support NotNull annotation", properties.get("name").getRequired());
+  }
+
 }


### PR DESCRIPTION
Current Java-chassis version consumer sends a request to provider without any Accept header field, Accept header of provider receiving is empty string.