### PR TITLE
[SCB-2329] when consumer sends a request without setting any Accept header, default set Accept header */*

### DIFF
--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseHttpMessageConverter.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseHttpMessageConverter.java
@@ -36,7 +36,7 @@ public class CseHttpMessageConverter implements GenericHttpMessageConverter<Obje
 
   @Override
   public boolean canRead(Class<?> clazz, MediaType mediaType) {
-    return false;
+    return true;
   }
 
   @Override
@@ -72,7 +72,7 @@ public class CseHttpMessageConverter implements GenericHttpMessageConverter<Obje
 
   @Override
   public boolean canRead(Type type, @Nullable Class<?> contextClass, @Nullable MediaType mediaType) {
-    return false;
+    return true;
   }
 
   @Override


### PR DESCRIPTION
Current Java-chassis version consumer sends a request to provider without any Accept header field, Accept header of provider receiving is empty string.