### PR TITLE
[SCB-2336] re-add watch idle timeout configuration

### DIFF
--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RegistryWatchHttpClientOptionsSPI.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RegistryWatchHttpClientOptionsSPI.java
@@ -63,4 +63,15 @@ public class RegistryWatchHttpClientOptionsSPI extends RegistryHttpClientOptions
   public boolean isProxyEnable() {
     return false;
   }
+
+  /**
+   * getIdleTimeoutInSeconds configure watch idle timeout
+   * more information see: https://github.com/apache/servicecomb-java-chassis/issues/2571
+   * @return watch idle timeout in seconds
+   */
+  @Override
+  public int getIdleTimeoutInSeconds() {
+    return serviceRegistryConfig.getIdleWatchConnectionTimeout();
+  }
+
 }

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfig.java
@@ -82,6 +82,8 @@ public class ServiceRegistryConfig {
 
   private int idleConnectionTimeout;
 
+  private int idleWatchConnectionTimeout;
+
   private int requestTimeout;
 
   //Set the timeout of the heartbeat request
@@ -222,6 +224,15 @@ public class ServiceRegistryConfig {
 
   public ServiceRegistryConfig setIdleConnectionTimeout(int idleConnectionTimeout) {
     this.idleConnectionTimeout = idleConnectionTimeout;
+    return this;
+  }
+
+  public int getIdleWatchConnectionTimeout() {
+    return idleWatchConnectionTimeout;
+  }
+
+  public ServiceRegistryConfig setIdleWatchConnectionTimeout(int idleWatchConnectionTimeout) {
+    this.idleWatchConnectionTimeout = idleWatchConnectionTimeout;
     return this;
   }
 

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigBuilder.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigBuilder.java
@@ -56,6 +56,7 @@ class ServiceRegistryConfigBuilder {
         .setWatchClientName(RegistryWatchHttpClientOptionsSPI.CLIENT_NAME)
         .setConnectionTimeout(getConnectionTimeout())
         .setIdleConnectionTimeout(getIdleConnectionTimeout())
+        .setIdleWatchConnectionTimeout(getIdleWatchTimeout())
         .setRequestTimeout(getRequestTimeout())
         .setHeartBeatRequestTimeout(getHeartBeatRequestTimeout())
         .setHeartbeatInterval(getHeartbeatInterval())
@@ -145,6 +146,16 @@ class ServiceRegistryConfigBuilder {
         DynamicPropertyFactory.getInstance()
             .getIntProperty("servicecomb.service.registry.client.timeout.idle",
                 ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2);
+    int timeout = property.get();
+    return timeout < 1 ? ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2 : timeout;
+  }
+
+  public int getIdleWatchTimeout() {
+    // watch idle timeout based on SC PING/PONG interval. SC default value is 30.
+    DynamicIntProperty property =
+            DynamicPropertyFactory.getInstance()
+                    .getIntProperty("servicecomb.service.registry.client.timeout.watch",
+                            ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2);
     int timeout = property.get();
     return timeout < 1 ? ServiceRegistryConfig.DEFAULT_TIMEOUT_IN_SECONDS * 2 : timeout;
   }

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/config/TestServiceRegistryConfig.java
@@ -66,5 +66,6 @@ public class TestServiceRegistryConfig {
     Assert.assertEquals(8080, oConfig.getProxyPort());
     Assert.assertNull(oConfig.getProxyUsername());
     Assert.assertNull(oConfig.getProxyPasswd());
+    Assert.assertEquals(60,  oConfig.getIdleWatchConnectionTimeout());
   }
 }

--- a/service-registry/registry-service-center/src/test/resources/microservice.yaml
+++ b/service-registry/registry-service-center/src/test/resources/microservice.yaml
@@ -44,6 +44,7 @@ servicecomb:
         timeout:
           connection: 30000
           idle: 30000
+          watch: 60
       instance:
         watch: true
         preferIpAddress: false


### PR DESCRIPTION
2.x delete watch idle timeout accidentally, re-add it. 

More info about see issue https://github.com/apache/servicecomb-java-chassis/issues/2571