### PR TITLE
[SCB-2426] upgrade springboot version to 2.6.6

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -98,7 +98,7 @@
     <snakeyaml.version>1.27</snakeyaml.version>
     <spectator.version>0.83.0</spectator.version>
     <spring.version>5.3.18</spring.version>
-    <spring-boot.version>2.5.12</spring-boot.version>
+    <spring-boot.version>2.6.6</spring-boot.version>
     <stax2-api.version>4.2</stax2-api.version>
     <swagger.version>1.6.2</swagger.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>


### PR DESCRIPTION
upgrade springboot version to 2.6.2
springboot version 2.6.2 depends on spring version 5.3.14, also updates