### PR TITLE
[SCB-2428] add jakarta dependency in foundation-config

### DIFF
--- a/foundations/foundation-config/pom.xml
+++ b/foundations/foundation-config/pom.xml
@@ -52,6 +52,10 @@
       <artifactId>snakeyaml</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>


### PR DESCRIPTION
java later version has removed `javax.annotation` dependency. If we need to support multi java versions, we need to add `jakarta` dependecy