### PR TITLE
[SCB-2431] use StandardCharsets instead of Charset Forname

### DIFF
--- a/clients/config-common/src/main/java/org/apache/servicecomb/config/common/ConfigConverter.java
+++ b/clients/config-common/src/main/java/org/apache/servicecomb/config/common/ConfigConverter.java
@@ -17,7 +17,7 @@
 
 package org.apache.servicecomb.config.common;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -74,7 +74,7 @@ public class ConfigConverter {
 
   private Map<String, Object> createFileSource(Object v) {
     YamlPropertiesFactoryBean yamlFactory = new YamlPropertiesFactoryBean();
-    yamlFactory.setResources(new ByteArrayResource(v.toString().getBytes(Charset.forName("UTF-8"))));
+    yamlFactory.setResources(new ByteArrayResource(v.toString().getBytes(StandardCharsets.UTF_8)));
     return propertiesToMap(yamlFactory.getObject());
   }
 

--- a/common/common-protobuf/src/test/java/org/apache/servicecomb/codec/protobuf/internal/converter/TestSwaggerToProtoGenerator.java
+++ b/common/common-protobuf/src/test/java/org/apache/servicecomb/codec/protobuf/internal/converter/TestSwaggerToProtoGenerator.java
@@ -18,6 +18,7 @@ package org.apache.servicecomb.codec.protobuf.internal.converter;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.servicecomb.codec.protobuf.internal.converter.model.ProtoSchema;
@@ -32,7 +33,7 @@ public class TestSwaggerToProtoGenerator {
   @Test
   public void convert() throws IOException {
     URL url = TestSwaggerToProtoGenerator.class.getClassLoader().getResource("ProtoSchema.proto");
-    String protoContent = IOUtils.toString(url, "UTF-8");
+    String protoContent = IOUtils.toString(url, StandardCharsets.UTF_8);
     int idx = protoContent.indexOf("syntax = ");
     protoContent = protoContent.substring(idx);
 

--- a/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLOption.java
+++ b/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLOption.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Properties;
 
@@ -434,7 +434,7 @@ public final class SSLOption {
     Reader reader = null;
     try {
       reader =
-          new InputStreamReader(inputStream, Charset.forName("UTF-8"));
+          new InputStreamReader(inputStream, StandardCharsets.UTF_8);
       props.load(reader);
       fromProperty(props);
     } catch (IOException e) {

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpParser.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpParser.java
@@ -17,7 +17,7 @@
 
 package org.apache.servicecomb.foundation.vertx.server;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 
 import io.netty.buffer.ByteBuf;
 import io.vertx.core.Handler;
@@ -35,11 +35,7 @@ public class TcpParser implements Handler<Buffer> {
   public static final int TCP_HEADER_LENGTH = 23;
 
   static {
-    try {
-      TCP_MAGIC = "CSE.TCP".getBytes("UTF-8");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
+    TCP_MAGIC = "CSE.TCP".getBytes(StandardCharsets.UTF_8);
   }
 
   enum ParseStatus {

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/stream/TestBufferInputStream.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/stream/TestBufferInputStream.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.foundation.vertx.stream;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
@@ -77,14 +77,14 @@ public class TestBufferInputStream {
   }
 
   @Test
-  public void testReadByteArray() throws UnsupportedEncodingException {
-    byte[] b = "csr".getBytes("UTF-8");
+  public void testReadByteArray() {
+    byte[] b = "csr".getBytes(StandardCharsets.UTF_8);
     Assert.assertEquals(-1, instance.read(b));
   }
 
   @Test
-  public void testReadByteArrayIntInt() throws UnsupportedEncodingException {
-    byte[] b = "csr".getBytes("UTF-8");
+  public void testReadByteArrayIntInt() {
+    byte[] b = "csr".getBytes(StandardCharsets.UTF_8);
     Assert.assertEquals(-1, instance.read(b, 1, 0));
   }
 

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchRule.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchRule.java
@@ -17,7 +17,7 @@
 
 package org.apache.servicecomb.darklaunch;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -47,7 +47,7 @@ public class DarklaunchRule {
 
     try {
       DarklaunchRuleJson ruleJson = JsonUtils
-          .readValue(ruleStr.getBytes(Charset.forName("UTF-8")), DarklaunchRuleJson.class);
+          .readValue(ruleStr.getBytes(StandardCharsets.UTF_8), DarklaunchRuleJson.class);
       DarklaunchRule rule = new DarklaunchRule(ruleJson.getPolicyType());
       for (DarklaunchRuleItemJson itemJson : ruleJson.getRuleItems()) {
         DarklaunchRuleItem item = new DarklaunchRuleItem(itemJson.getGroupName());


### PR DESCRIPTION
Since we support java version is java1.8+, we can use StandardCharsets insteadof `Charset.Forname`