### PR TITLE
[SCB-2445] make junit only test dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -56,21 +56,16 @@
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>servicecomb-governance</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-codegen</artifactId>
       <scope>provided</scope>
     </dependency>
+    <!-- test -->
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>provided</scope>
+      <groupId>org.apache.servicecomb</groupId>
+      <artifactId>foundation-test-scaffolding</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -81,15 +76,6 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.servicecomb</groupId>
-      <artifactId>foundation-test-scaffolding</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.vertx</groupId>
-      <artifactId>vertx-codegen</artifactId>
-      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
we don't need to mark junit to scope `provide`,  we only need to mark junit to scope `test`. Sine it's already done on parent pom, we just need to delete the `provider` dep.