### PR TITLE
[SCB-2455] [MINOR] make field final

### DIFF
--- a/clients/config-center-client/src/main/java/org/apache/servicecomb/config/center/client/ConfigCenterClient.java
+++ b/clients/config-center-client/src/main/java/org/apache/servicecomb/config/center/client/ConfigCenterClient.java
@@ -48,9 +48,9 @@ public class ConfigCenterClient implements ConfigCenterOperation {
 
   public static final String DARK_LAUNCH = "darklaunch@";
 
-  private HttpTransport httpTransport;
+  private final HttpTransport httpTransport;
 
-  private AddressManager addressManager;
+  private final AddressManager addressManager;
 
   public ConfigCenterClient(AddressManager addressManager, HttpTransport httpTransport) {
     this.addressManager = addressManager;

--- a/clients/config-center-client/src/main/java/org/apache/servicecomb/config/center/client/ConfigCenterManager.java
+++ b/clients/config-center-client/src/main/java/org/apache/servicecomb/config/center/client/ConfigCenterManager.java
@@ -36,13 +36,13 @@ public class ConfigCenterManager extends AbstractTask {
 
   private static final long POLL_INTERVAL = 15000;
 
-  private ConfigCenterClient configCenterClient;
+  private final ConfigCenterClient configCenterClient;
 
   private final EventBus eventBus;
 
   private QueryConfigurationsRequest queryConfigurationsRequest;
 
-  private ConfigConverter configConverter;
+  private final ConfigConverter configConverter;
 
   public ConfigCenterManager(ConfigCenterClient configCenterClient, EventBus eventBus,
       ConfigConverter configConverter) {

--- a/clients/config-kie-client/src/main/java/org/apache/servicecomb/config/kie/client/KieConfigManager.java
+++ b/clients/config-kie-client/src/main/java/org/apache/servicecomb/config/kie/client/KieConfigManager.java
@@ -39,19 +39,19 @@ public class KieConfigManager extends AbstractTask {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KieConfigManager.class);
 
-  private static long LONG_POLLING_INTERVAL = 1000;
+  private static final long LONG_POLLING_INTERVAL = 1000;
 
-  private static long POLLING_INTERVAL = 15000;
+  private static final long POLLING_INTERVAL = 15000;
 
-  private KieConfigOperation configKieClient;
+  private final KieConfigOperation configKieClient;
 
   private final EventBus eventBus;
 
-  private ConfigConverter configConverter;
+  private final ConfigConverter configConverter;
 
-  private List<ConfigurationsRequest> configurationsRequests;
+  private final List<ConfigurationsRequest> configurationsRequests;
 
-  private KieConfiguration kieConfiguration;
+  private final KieConfiguration kieConfiguration;
 
   public KieConfigManager(KieConfigOperation configKieClient, EventBus eventBus,
       KieConfiguration kieConfiguration,

--- a/clients/config-kie-client/src/test/java/org/apache/servicecomb/config/kie/client/model/KieAddressManagerTest.java
+++ b/clients/config-kie-client/src/test/java/org/apache/servicecomb/config/kie/client/model/KieAddressManagerTest.java
@@ -32,7 +32,7 @@ import mockit.Deencapsulation;
 
 class KieAddressManagerTest {
 
-  private static List<String> addresses = new ArrayList<>();
+  private static final List<String> addresses = new ArrayList<>();
 
   private static KieAddressManager addressManager1;
 

--- a/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/AbstractAddressManager.java
+++ b/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/AbstractAddressManager.java
@@ -62,28 +62,28 @@ public class AbstractAddressManager {
 
   private String projectName;
 
-  private Map<String, Boolean> categoryMap = new HashMap<>();
+  private final Map<String, Boolean> categoryMap = new HashMap<>();
 
-  private Map<String, Integer> recodeStatus = new ConcurrentHashMap<>();
+  private final Map<String, Integer> recodeStatus = new ConcurrentHashMap<>();
 
-  private Map<String, Boolean> history = new ConcurrentHashMap<>();
+  private final Map<String, Boolean> history = new ConcurrentHashMap<>();
 
   private volatile List<String> availableZone = new ArrayList<>();
 
   private volatile List<String> availableRegion = new ArrayList<>();
 
-  private volatile List<String> defaultAddress = new ArrayList<>();
+  private final List<String> defaultAddress = new ArrayList<>();
 
   private boolean isAddressRefresh = false;
 
   private final Object lock = new Object();
 
-  private ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1,
+  private final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1,
       new ThreadFactoryBuilder()
           .setNameFormat("check-available-address-%d")
           .build());
 
-  private Cache<String, Boolean> cacheAddress = CacheBuilder.newBuilder()
+  private final Cache<String, Boolean> cacheAddress = CacheBuilder.newBuilder()
       .maximumSize(100)
       .expireAfterWrite(10, TimeUnit.MINUTES)
       .build();

--- a/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/HttpRequest.java
+++ b/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/HttpRequest.java
@@ -41,11 +41,11 @@ public class HttpRequest {
 
   private String method;
 
-  private String url;
+  private final String url;
 
   private Map<String, String> headers;
 
-  private String content;
+  private final String content;
 
   public HttpRequest(String url, Map<String, String> headers, String content, String method) {
     this.url = url;

--- a/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/HttpTransportImpl.java
+++ b/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/HttpTransportImpl.java
@@ -38,7 +38,7 @@ public class HttpTransportImpl implements HttpTransport {
 
   private Map<String, String> globalHeaders;
 
-  private RequestAuthHeaderProvider requestAuthHeaderProvider;
+  private final RequestAuthHeaderProvider requestAuthHeaderProvider;
 
   public HttpTransportImpl(HttpClient httpClient, RequestAuthHeaderProvider requestAuthHeaderProvider) {
     this.httpClient = httpClient;

--- a/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/SSLSocketFactoryExt.java
+++ b/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/SSLSocketFactoryExt.java
@@ -24,11 +24,11 @@ import java.net.Socket;
 import java.net.UnknownHostException;
 
 public class SSLSocketFactoryExt extends SSLSocketFactory {
-  private SSLSocketFactory sslSocketFactory;
+  private final SSLSocketFactory sslSocketFactory;
 
-  private String host;
+  private final String host;
 
-  private int port;
+  private final int port;
 
   public SSLSocketFactoryExt(SSLSocketFactory factory, String host, int port) {
     this.sslSocketFactory = factory;

--- a/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/URLEndPoint.java
+++ b/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/URLEndPoint.java
@@ -34,13 +34,13 @@ public class URLEndPoint {
 
   private static final String HTTPS_KEY = "https://";
 
-  private boolean sslEnabled;
+  private final boolean sslEnabled;
 
-  private Map<String, List<String>> querys;
+  private final Map<String, List<String>> querys;
 
-  private String hostOrIp;
+  private final String hostOrIp;
 
-  private int port;
+  private final int port;
 
   public URLEndPoint(String endpoint) {
     URI uri = URI.create(endpoint);

--- a/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/WebSocketTransport.java
+++ b/clients/http-client-common/src/main/java/org/apache/servicecomb/http/client/common/WebSocketTransport.java
@@ -31,7 +31,7 @@ import org.java_websocket.handshake.ServerHandshake;
 public class WebSocketTransport extends WebSocketClient {
   public static final int CONNECT_TIMEOUT = 5000;
 
-  private WebSocketListener webSocketListener;
+  private final WebSocketListener webSocketListener;
 
   public WebSocketTransport(String serverUri, HttpConfiguration.SSLProperties sslProperties,
       Map<String, String> headers, WebSocketListener webSocketListener)

--- a/clients/http-client-common/src/test/java/org/apache/servicecomb/http/client/common/AbstractAddressManagerTest.java
+++ b/clients/http-client-common/src/test/java/org/apache/servicecomb/http/client/common/AbstractAddressManagerTest.java
@@ -39,7 +39,7 @@ import mockit.Expectations;
 
 public class AbstractAddressManagerTest {
 
-  private static List<String> addresses = new ArrayList<>();
+  private static final List<String> addresses = new ArrayList<>();
 
   private static AbstractAddressManager addressManager1;
 

--- a/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/DiscoveryEvents.java
+++ b/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/DiscoveryEvents.java
@@ -23,11 +23,11 @@ import org.apache.servicecomb.service.center.client.model.MicroserviceInstance;
 
 public abstract class DiscoveryEvents {
   public static class InstanceChangedEvent extends DiscoveryEvents {
-    private String appName;
+    private final String appName;
 
-    private String serviceName;
+    private final String serviceName;
 
-    private List<MicroserviceInstance> instances;
+    private final List<MicroserviceInstance> instances;
 
     public InstanceChangedEvent(String appName, String serviceName, List<MicroserviceInstance> instances) {
       this.appName = appName;

--- a/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterClient.java
+++ b/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterClient.java
@@ -64,7 +64,7 @@ public class ServiceCenterClient implements ServiceCenterOperation {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceCenterClient.class);
 
-  private ServiceCenterRawClient httpClient;
+  private final ServiceCenterRawClient httpClient;
 
   private EventBus eventBus;
 

--- a/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterDiscovery.java
+++ b/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterDiscovery.java
@@ -90,7 +90,7 @@ public class ServiceCenterDiscovery extends AbstractTask {
 
   private final Map<SubscriptionKey, SubscriptionValue> instancesCache = new ConcurrentHashMap<>();
 
-  private List<SubscriptionKey> failedInstances = new ArrayList<>();
+  private final List<SubscriptionKey> failedInstances = new ArrayList<>();
 
   private final Map<String, Microservice> microserviceCache = new ConcurrentHashMap<>();
 

--- a/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterRawClient.java
+++ b/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterRawClient.java
@@ -32,11 +32,11 @@ public class ServiceCenterRawClient {
 
   private static final String HEADER_TENANT_NAME = "x-domain-name";
 
-  private String tenantName;
+  private final String tenantName;
 
-  private HttpTransport httpTransport;
+  private final HttpTransport httpTransport;
 
-  private AddressManager addressManager;
+  private final AddressManager addressManager;
 
   private ServiceCenterRawClient(String tenantName, HttpTransport httpTransport,
       AddressManager addressManager) {

--- a/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterRegistration.java
+++ b/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/ServiceCenterRegistration.java
@@ -56,7 +56,7 @@ public class ServiceCenterRegistration extends AbstractTask {
 
   private List<SchemaInfo> schemaInfos;
 
-  private ServiceCenterConfiguration serviceCenterConfiguration;
+  private final ServiceCenterConfiguration serviceCenterConfiguration;
 
   private long heartBeatInterval = 15000;
 

--- a/clients/service-center-client/src/test/java/org/apache/servicecomb/service/center/client/AddressManagerTest.java
+++ b/clients/service-center-client/src/test/java/org/apache/servicecomb/service/center/client/AddressManagerTest.java
@@ -32,7 +32,7 @@ import mockit.Deencapsulation;
 
 class AddressManagerTest {
 
-  private static List<String> addresses = new ArrayList<>();
+  private static final List<String> addresses = new ArrayList<>();
 
   private static AddressManager addressManager1;
 

--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/AccessLogBootListener.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/AccessLogBootListener.java
@@ -22,7 +22,7 @@ import org.apache.servicecomb.foundation.common.event.EventManager;
 
 public class AccessLogBootListener implements BootListener {
 
-  private AccessLogBootstrap accessLogBootstrap = new AccessLogBootstrap();
+  private final AccessLogBootstrap accessLogBootstrap = new AccessLogBootstrap();
 
   @Override
   public void onAfterRegistry(BootEvent event) {

--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/AccessLogBootstrap.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/AccessLogBootstrap.java
@@ -22,7 +22,7 @@ import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 import com.google.common.eventbus.EventBus;
 
 public class AccessLogBootstrap {
-  private static AccessLogConfig config = AccessLogConfig.INSTANCE;
+  private static final AccessLogConfig config = AccessLogConfig.INSTANCE;
 
   private EventBus eventBus;
 

--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/client/ClientDefaultInitializer.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/client/ClientDefaultInitializer.java
@@ -31,7 +31,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
 public class ClientDefaultInitializer implements AccessLogInitializer {
-  private static Logger LOGGER = LoggerFactory.getLogger("requestlog");
+  private static final Logger LOGGER = LoggerFactory.getLogger("requestlog");
 
   private AccessLogGenerator accessLogGenerator;
 

--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/AccessLogGenerator.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/AccessLogGenerator.java
@@ -38,9 +38,9 @@ public class AccessLogGenerator {
   /*
    * traversal this array to generate access log segment.
    */
-  private AccessLogItem<RoutingContext>[] accessLogItems;
+  private final AccessLogItem<RoutingContext>[] accessLogItems;
 
-  private AccessLogPatternParser<RoutingContext> logPatternParser = new VertxRestAccessLogPatternParser();
+  private final AccessLogPatternParser<RoutingContext> logPatternParser = new VertxRestAccessLogPatternParser();
 
   @SuppressWarnings("unchecked")
   public AccessLogGenerator(String rawPattern) {

--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/element/impl/HttpStatusAccessItem.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/element/impl/HttpStatusAccessItem.java
@@ -28,7 +28,7 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
 
 public class HttpStatusAccessItem implements AccessLogItem<RoutingContext> {
-  private static Logger LOGGER = LoggerFactory.getLogger(HttpStatusAccessItem.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(HttpStatusAccessItem.class);
 
   public static final String EMPTY_RESULT = "-";
 

--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/parser/impl/VertxRestAccessLogPatternParser.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/parser/impl/VertxRestAccessLogPatternParser.java
@@ -60,7 +60,7 @@ public class VertxRestAccessLogPatternParser implements AccessLogPatternParser<R
         : result;
   };
 
-  private List<VertxRestAccessLogItemMeta> metaList = new ArrayList<>();
+  private final List<VertxRestAccessLogItemMeta> metaList = new ArrayList<>();
 
   public VertxRestAccessLogPatternParser() {
     List<VertxRestAccessLogItemMeta> loadedMeta = loadVertxRestLogItemMeta();

--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/server/ServerDefaultInitializer.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/server/ServerDefaultInitializer.java
@@ -31,7 +31,7 @@ import com.google.common.eventbus.Subscribe;
 
 public class ServerDefaultInitializer implements AccessLogInitializer {
 
-  private static Logger LOGGER = LoggerFactory.getLogger("accesslog");
+  private static final Logger LOGGER = LoggerFactory.getLogger("accesslog");
 
   private AccessLogGenerator accessLogGenerator;
 

--- a/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/InvocationContextItemTest.java
+++ b/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/InvocationContextItemTest.java
@@ -41,7 +41,7 @@ public class InvocationContextItemTest {
 
   public static final String INVOCATION_CONTEXT_VALUE = "testValue";
 
-  private static InvocationContextAccessItem ITEM = new InvocationContextAccessItem(INVOCATION_CONTEXT_KEY);
+  private static final InvocationContextAccessItem ITEM = new InvocationContextAccessItem(INVOCATION_CONTEXT_KEY);
 
   private StringBuilder strBuilder;
 

--- a/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/TraceIdItemTest.java
+++ b/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/TraceIdItemTest.java
@@ -51,7 +51,7 @@ public class TraceIdItemTest {
 
   private Invocation invocation;
 
-  private Map<String, String> clientContext = new HashMap<>();
+  private final Map<String, String> clientContext = new HashMap<>();
 
   @Before
   public void initStrBuilder() {

--- a/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/UserDefinedAccessLogItem.java
+++ b/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/UserDefinedAccessLogItem.java
@@ -28,7 +28,7 @@ import io.vertx.ext.web.RoutingContext;
  * For access log extension test
  */
 public class UserDefinedAccessLogItem implements AccessLogItem<RoutingContext> {
-  private String config;
+  private final String config;
 
   public UserDefinedAccessLogItem(String config) {
     this.config = config;

--- a/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/parser/impl/VertxRestAccessLogPatternParserTest.java
+++ b/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/parser/impl/VertxRestAccessLogPatternParserTest.java
@@ -71,7 +71,7 @@ public class VertxRestAccessLogPatternParserTest {
       + "%{ctx}SCB-ctx"
       + "%SCB-transport";
 
-  private static VertxRestAccessLogPatternParser logPatternParser = new VertxRestAccessLogPatternParser();
+  private static final VertxRestAccessLogPatternParser logPatternParser = new VertxRestAccessLogPatternParser();
 
   private ServerAccessLogEvent accessLogEvent;
 

--- a/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/RequestRootDeserializer.java
+++ b/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/RequestRootDeserializer.java
@@ -24,11 +24,11 @@ import org.apache.servicecomb.foundation.protobuf.RootDeserializer;
 import org.apache.servicecomb.foundation.protobuf.internal.bean.PropertyWrapper;
 
 public class RequestRootDeserializer<T> {
-  private boolean wrapArgument;
+  private final boolean wrapArgument;
 
-  private String parameterName;
+  private final String parameterName;
 
-  private RootDeserializer<T> rootDeserializer;
+  private final RootDeserializer<T> rootDeserializer;
 
   public RequestRootDeserializer(RootDeserializer<T> rootDeserializer, boolean wrapArgument, String parameterName) {
     this.rootDeserializer = rootDeserializer;

--- a/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/RequestRootSerializer.java
+++ b/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/RequestRootSerializer.java
@@ -24,11 +24,11 @@ import org.apache.servicecomb.foundation.protobuf.RootSerializer;
 import io.vertx.core.json.JsonObject;
 
 public class RequestRootSerializer {
-  private RootSerializer rootSerializer;
+  private final RootSerializer rootSerializer;
 
-  private boolean noTypesInfo;
+  private final boolean noTypesInfo;
 
-  private boolean isWrap;
+  private final boolean isWrap;
 
   public RequestRootSerializer(RootSerializer serializer, boolean isWrapp, boolean noTypesInfo) {
     this.rootSerializer = serializer;

--- a/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/ResponseRootDeserializer.java
+++ b/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/ResponseRootDeserializer.java
@@ -26,9 +26,9 @@ import org.apache.servicecomb.foundation.protobuf.internal.bean.PropertyWrapper;
 import com.fasterxml.jackson.databind.JavaType;
 
 public class ResponseRootDeserializer<T> {
-  private RootDeserializer<T> rootDeserializer;
+  private final RootDeserializer<T> rootDeserializer;
 
-  private boolean empty;
+  private final boolean empty;
 
   public ResponseRootDeserializer(RootDeserializer<T> rootDeserializer, boolean empty) {
     this.rootDeserializer = rootDeserializer;

--- a/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/ResponseRootSerializer.java
+++ b/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/definition/ResponseRootSerializer.java
@@ -23,11 +23,11 @@ import java.util.Map;
 import org.apache.servicecomb.foundation.protobuf.RootSerializer;
 
 public class ResponseRootSerializer {
-  private RootSerializer rootSerializer;
+  private final RootSerializer rootSerializer;
 
-  private boolean noTypesInfo;
+  private final boolean noTypesInfo;
 
-  private boolean isWrap;
+  private final boolean isWrap;
 
   public ResponseRootSerializer(RootSerializer serializer, boolean isWrapp, boolean noTypesInfo) {
     this.rootSerializer = serializer;

--- a/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/utils/ScopedProtobufSchemaManager.java
+++ b/common/common-protobuf/src/main/java/org/apache/servicecomb/codec/protobuf/utils/ScopedProtobufSchemaManager.java
@@ -36,7 +36,7 @@ import io.swagger.models.Swagger;
  */
 public class ScopedProtobufSchemaManager {
   // Because this class belongs to each SchemaMeta, the key is the schema id.
-  private Map<String, ProtoMapper> mapperCache = new ConcurrentHashMapEx<>();
+  private final Map<String, ProtoMapper> mapperCache = new ConcurrentHashMapEx<>();
 
   public ScopedProtobufSchemaManager() {
 

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/HttpTransportContext.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/HttpTransportContext.java
@@ -22,11 +22,11 @@ import org.apache.servicecomb.foundation.vertx.http.HttpServletResponseEx;
 import org.apache.servicecomb.swagger.invocation.context.TransportContext;
 
 public class HttpTransportContext implements TransportContext {
-  private HttpServletRequestEx requestEx;
+  private final HttpServletRequestEx requestEx;
 
-  private HttpServletResponseEx responseEx;
+  private final HttpServletResponseEx responseEx;
 
-  private ProduceProcessor produceProcessor;
+  private final ProduceProcessor produceProcessor;
 
   public HttpTransportContext(HttpServletRequestEx requestEx, HttpServletResponseEx responseEx,
       ProduceProcessor produceProcessor) {

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/VertxHttpTransportContext.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/VertxHttpTransportContext.java
@@ -26,9 +26,9 @@ import io.vertx.core.Vertx;
 import io.vertx.ext.web.RoutingContext;
 
 public class VertxHttpTransportContext extends HttpTransportContext implements VertxTransportContext {
-  private RoutingContext routingContext;
+  private final RoutingContext routingContext;
 
-  private Context vertxContext;
+  private final Context vertxContext;
 
   public VertxHttpTransportContext(RoutingContext routingContext, HttpServletRequestEx requestEx,
       HttpServletResponseEx responseEx, ProduceProcessor produceProcessor) {

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/RestObjectMapperFactory.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/RestObjectMapperFactory.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class RestObjectMapperFactory {
   private static AbstractRestObjectMapper defaultMapper = new RestObjectMapper();
 
-  private static AbstractRestObjectMapper viewMapper = new RestObjectMapper();
+  private static final AbstractRestObjectMapper viewMapper = new RestObjectMapper();
 
   private static AbstractRestObjectMapper consumerWriterMapper = defaultMapper;
 

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/BodyProcessorCreator.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/BodyProcessorCreator.java
@@ -61,7 +61,7 @@ public class BodyProcessorCreator implements ParamValueProcessorCreator {
   private static final JavaType OBJECT_TYPE = SimpleType.constructUnsafe(Object.class);
 
   // This configuration is used for temporary use only. Do not use it if you are sure how it works. And may be deleted in future.
-  private static boolean decodeAsObject = DynamicPropertyFactory.getInstance()
+  private static final boolean decodeAsObject = DynamicPropertyFactory.getInstance()
       .getBooleanProperty("servicecomb.rest.parameter.decodeAsObject", false).get();
 
   public static class BodyProcessor implements ParamValueProcessor {
@@ -69,7 +69,7 @@ public class BodyProcessorCreator implements ParamValueProcessorCreator {
 
     protected Class<?> serialViewClass;
 
-    private boolean isString;
+    private final boolean isString;
 
     protected boolean isRequired;
 

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/FormProcessorCreator.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/FormProcessorCreator.java
@@ -47,7 +47,7 @@ public class FormProcessorCreator implements ParamValueProcessorCreator {
   public static final String PARAMTYPE = "formData";
 
   public static class FormProcessor extends AbstractParamProcessor {
-    private boolean repeatedType;
+    private final boolean repeatedType;
 
     public FormProcessor(FormParameter formParameter, JavaType targetType) {
       super(formParameter.getName(), targetType, formParameter.getDefaultValue(), formParameter.getRequired());
@@ -119,23 +119,23 @@ public class FormProcessorCreator implements ParamValueProcessorCreator {
   }
 
   public static class PartProcessor extends AbstractParamProcessor {
-    private static Type partListType = Types.newParameterizedType(List.class, Part.class);
+    private static final Type partListType = Types.newParameterizedType(List.class, Part.class);
 
     // key is target type
-    private static Map<Type, Converter> partsToTargetConverters = SPIServiceUtils.getSortedService(Converter.class)
+    private static final Map<Type, Converter> partsToTargetConverters = SPIServiceUtils.getSortedService(Converter.class)
         .stream()
         .filter(c -> partListType.equals(c.getSrcType()))
         .collect(Collectors.toMap(Converter::getTargetType, Function.identity()));
 
     // key is target type
-    private static Map<Type, Converter> partToTargetConverters = SPIServiceUtils.getSortedService(Converter.class)
+    private static final Map<Type, Converter> partToTargetConverters = SPIServiceUtils.getSortedService(Converter.class)
         .stream()
         .filter(c -> c.getSrcType() instanceof Class && Part.class.isAssignableFrom((Class<?>) c.getSrcType()))
         .collect(Collectors.toMap(Converter::getTargetType, Function.identity()));
 
-    private boolean repeatedType;
+    private final boolean repeatedType;
 
-    private Type genericParamType;
+    private final Type genericParamType;
 
     private Converter converter;
 

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/HeaderProcessorCreator.java
@@ -45,10 +45,10 @@ public class HeaderProcessorCreator implements ParamValueProcessorCreator {
 
   public static class HeaderProcessor extends AbstractParamProcessor {
     // This configuration is used for temporary use only. Do not use it if you are sure how it works. And may be deleted in future.
-    private boolean ignoreRequiredCheck = DynamicPropertyFactory.getInstance()
+    private final boolean ignoreRequiredCheck = DynamicPropertyFactory.getInstance()
         .getBooleanProperty("servicecomb.rest.parameter.header.ignoreRequiredCheck", false).get();
 
-    private boolean repeatedType;
+    private final boolean repeatedType;
 
     public HeaderProcessor(HeaderParameter headerParameter, JavaType targetType) {
       super(headerParameter.getName(), targetType, headerParameter.getDefaultValue(), headerParameter.getRequired());

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/QueryProcessorCreator.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/param/QueryProcessorCreator.java
@@ -41,20 +41,20 @@ public class QueryProcessorCreator implements ParamValueProcessorCreator {
 
   public static class QueryProcessor extends AbstractParamProcessor {
     // This configuration is used for temporary use only. Do not use it if you are sure how it works. And may be deleted in future.
-    private boolean emptyAsNull = DynamicPropertyFactory.getInstance()
+    private final boolean emptyAsNull = DynamicPropertyFactory.getInstance()
         .getBooleanProperty("servicecomb.rest.parameter.query.emptyAsNull", false).get();
 
     // This configuration is used for temporary use only. Do not use it if you are sure how it works. And may be deleted in future.
-    private boolean ignoreDefaultValue = DynamicPropertyFactory.getInstance()
+    private final boolean ignoreDefaultValue = DynamicPropertyFactory.getInstance()
         .getBooleanProperty("servicecomb.rest.parameter.query.ignoreDefaultValue", false).get();
 
     // This configuration is used for temporary use only. Do not use it if you are sure how it works. And may be deleted in future.
-    private boolean ignoreRequiredCheck = DynamicPropertyFactory.getInstance()
+    private final boolean ignoreRequiredCheck = DynamicPropertyFactory.getInstance()
         .getBooleanProperty("servicecomb.rest.parameter.query.ignoreRequiredCheck", false).get();
 
-    private boolean repeatedType;
+    private final boolean repeatedType;
 
-    private QueryCodec queryCodec;
+    private final QueryCodec queryCodec;
 
     public QueryProcessor(QueryParameter queryParameter, JavaType targetType) {
       super(queryParameter.getName(), targetType, queryParameter.getDefaultValue(), queryParameter.getRequired());

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceProcessorManager.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceProcessorManager.java
@@ -43,13 +43,13 @@ public final class ProduceProcessorManager extends RegisterManager<String, Map<S
 
   public static final ProduceProcessorManager INSTANCE = new ProduceProcessorManager();
 
-  private Map<String, ProduceProcessor> nonSerialViewMap = new HashMap<>();
+  private final Map<String, ProduceProcessor> nonSerialViewMap = new HashMap<>();
 
-  private Map<String, ProduceProcessor> jsonProcessorMap;
+  private final Map<String, ProduceProcessor> jsonProcessorMap;
 
-  private Map<String, ProduceProcessor> plainProcessorMap;
+  private final Map<String, ProduceProcessor> plainProcessorMap;
 
-  private Map<String, ProduceProcessor> defaultProcessorMap;
+  private final Map<String, ProduceProcessor> defaultProcessorMap;
 
   private ProduceProcessorManager() {
     super(NAME);

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/RestOperationMeta.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/RestOperationMeta.java
@@ -76,7 +76,7 @@ public class RestOperationMeta {
   protected List<String> fileKeys = new ArrayList<>();
 
   // key为数据类型，比如json之类
-  private Map<String, ProduceProcessor> produceProcessorMap = new LinkedHashMap<>();
+  private final Map<String, ProduceProcessor> produceProcessorMap = new LinkedHashMap<>();
 
   // 不一定等于mgr中的default，因为本operation可能不支持mgr中的default
   private ProduceProcessor defaultProcessor;

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/path/StaticUrlParamWriter.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/path/StaticUrlParamWriter.java
@@ -23,7 +23,7 @@ import org.apache.servicecomb.common.rest.definition.path.URLPathBuilder.URLPath
 
 public class StaticUrlParamWriter implements UrlParamWriter {
 
-  private String staticPath;
+  private final String staticPath;
 
   public StaticUrlParamWriter(String staticPath) {
     this.staticPath = staticPath;

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/path/URLPathBuilder.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/path/URLPathBuilder.java
@@ -31,9 +31,9 @@ import org.apache.servicecomb.common.rest.definition.RestParam;
  */
 public class URLPathBuilder {
 
-  private List<UrlParamWriter> pathParamWriterList = new ArrayList<>();
+  private final List<UrlParamWriter> pathParamWriterList = new ArrayList<>();
 
-  private List<UrlParamWriter> queryParamWriterList = new ArrayList<>();
+  private final List<UrlParamWriter> queryParamWriterList = new ArrayList<>();
 
   private static final String SLASH = "/";
 
@@ -120,7 +120,7 @@ public class URLPathBuilder {
   }
 
   public static class URLPathStringBuilder {
-    private StringBuilder stringBuilder = new StringBuilder();
+    private final StringBuilder stringBuilder = new StringBuilder();
 
     private boolean queryPrefixNotWrite = true;
 

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/filter/HttpServerFilterBeforeSendResponseExecutor.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/filter/HttpServerFilterBeforeSendResponseExecutor.java
@@ -23,15 +23,15 @@ import org.apache.servicecomb.core.Invocation;
 import org.apache.servicecomb.foundation.vertx.http.HttpServletResponseEx;
 
 public class HttpServerFilterBeforeSendResponseExecutor {
-  private List<HttpServerFilter> httpServerFilters;
+  private final List<HttpServerFilter> httpServerFilters;
 
-  private Invocation invocation;
+  private final Invocation invocation;
 
-  private HttpServletResponseEx responseEx;
+  private final HttpServletResponseEx responseEx;
 
   private int currentIndex;
 
-  private CompletableFuture<Void> future = new CompletableFuture<Void>();
+  private final CompletableFuture<Void> future = new CompletableFuture<Void>();
 
   public HttpServerFilterBeforeSendResponseExecutor(List<HttpServerFilter> httpServerFilters, Invocation invocation,
       HttpServletResponseEx responseEx) {

--- a/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/TestAbstractRestInvocation.java
+++ b/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/TestAbstractRestInvocation.java
@@ -477,7 +477,7 @@ public class TestAbstractRestInvocation {
   }
 
   public static class SendResponseQuietlyNormalEventHandler {
-    private Holder<InvocationFinishEvent> eventHolder;
+    private final Holder<InvocationFinishEvent> eventHolder;
 
     public SendResponseQuietlyNormalEventHandler(Holder<InvocationFinishEvent> eventHolder) {
       this.eventHolder = eventHolder;
@@ -590,7 +590,7 @@ public class TestAbstractRestInvocation {
 
     Map<String, Object> result = new HashMap<>();
     responseEx = new MockUp<HttpServletResponseEx>() {
-      private Map<String, Object> attributes = new HashMap<>();
+      private final Map<String, Object> attributes = new HashMap<>();
 
       @Mock
       public void setAttribute(String key, Object value) {
@@ -644,7 +644,7 @@ public class TestAbstractRestInvocation {
 
     MultiMap resultHeaders = MultiMap.caseInsensitiveMultiMap();
     responseEx = new MockUp<HttpServletResponseEx>() {
-      private Map<String, Object> attributes = new HashMap<>();
+      private final Map<String, Object> attributes = new HashMap<>();
 
       @Mock
       public void setAttribute(String key, Object value) {
@@ -688,7 +688,7 @@ public class TestAbstractRestInvocation {
 
     MultiMap resultHeaders = MultiMap.caseInsensitiveMultiMap();
     responseEx = new MockUp<HttpServletResponseEx>() {
-      private Map<String, Object> attributes = new HashMap<>();
+      private final Map<String, Object> attributes = new HashMap<>();
 
       @Mock
       public void setAttribute(String key, Object value) {
@@ -728,7 +728,7 @@ public class TestAbstractRestInvocation {
 
     Buffer buffer = Buffer.buffer();
     responseEx = new MockUp<HttpServletResponseEx>() {
-      private Map<String, Object> attributes = new HashMap<>();
+      private final Map<String, Object> attributes = new HashMap<>();
 
       @Mock
       public void setAttribute(String key, Object value) {
@@ -773,7 +773,7 @@ public class TestAbstractRestInvocation {
 
     Buffer buffer = Buffer.buffer();
     responseEx = new MockUp<HttpServletResponseEx>() {
-      private Map<String, Object> attributes = new HashMap<>();
+      private final Map<String, Object> attributes = new HashMap<>();
 
       @Mock
       public void setAttribute(String key, Object value) {
@@ -957,7 +957,7 @@ public class TestAbstractRestInvocation {
   }
 
   public static class ScheduleInvocationEventHandler {
-    private Holder<InvocationStartEvent> eventHolder;
+    private final Holder<InvocationStartEvent> eventHolder;
 
     public ScheduleInvocationEventHandler(Holder<InvocationStartEvent> eventHolder) {
       this.eventHolder = eventHolder;

--- a/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/codec/TestRestCodec.java
+++ b/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/codec/TestRestCodec.java
@@ -48,7 +48,7 @@ public class TestRestCodec {
 
   private static RestOperationMeta restOperation;
 
-  private static Map<String, String> header = new HashMap<>();
+  private static final Map<String, String> header = new HashMap<>();
 
   private static RestClientRequest clientRequest = new RestClientRequestImpl(null, null, null) {
     public void putHeader(String name, String value) {

--- a/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/codec/param/TestRestClientRequestImpl.java
+++ b/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/codec/param/TestRestClientRequestImpl.java
@@ -64,7 +64,7 @@ public class TestRestClientRequestImpl {
   public void testCookie() throws Exception {
     HttpClientRequest request = new MockUp<HttpClientRequest>() {
 
-      MultiMap map = MultiMap.caseInsensitiveMultiMap();
+      final MultiMap map = MultiMap.caseInsensitiveMultiMap();
 
       @Mock
       public HttpClientRequest putHeader(CharSequence key, CharSequence val) {

--- a/core/src/main/java/org/apache/servicecomb/core/Invocation.java
+++ b/core/src/main/java/org/apache/servicecomb/core/Invocation.java
@@ -84,7 +84,7 @@ public class Invocation extends SwaggerInvocation {
   private Endpoint endpoint;
 
   // 只用于handler之间传递数据，是本地数据
-  private Map<String, Object> handlerContext = localContext;
+  private final Map<String, Object> handlerContext = localContext;
 
   // handler链，是arrayList，可以高效地通过index访问
   private List<Handler> handlerList;
@@ -97,7 +97,7 @@ public class Invocation extends SwaggerInvocation {
 
   private boolean sync = true;
 
-  private InvocationStageTrace invocationStageTrace = new InvocationStageTrace(this);
+  private final InvocationStageTrace invocationStageTrace = new InvocationStageTrace(this);
 
   private HttpServletRequestEx requestEx;
 

--- a/core/src/main/java/org/apache/servicecomb/core/NonSwaggerInvocation.java
+++ b/core/src/main/java/org/apache/servicecomb/core/NonSwaggerInvocation.java
@@ -20,13 +20,13 @@ package org.apache.servicecomb.core;
 import org.apache.servicecomb.swagger.invocation.AsyncResponse;
 
 public class NonSwaggerInvocation extends Invocation {
-  private String appId;
+  private final String appId;
 
-  private String microserviceName;
+  private final String microserviceName;
 
-  private String versionRule;
+  private final String versionRule;
 
-  private Handler nextHandler;
+  private final Handler nextHandler;
 
   public NonSwaggerInvocation(String appId, String microserviceName, String versionRule, Handler nextHandler) {
     this.appId = appId;

--- a/core/src/main/java/org/apache/servicecomb/core/SCBEngine.java
+++ b/core/src/main/java/org/apache/servicecomb/core/SCBEngine.java
@@ -93,9 +93,9 @@ public class SCBEngine {
 
   private FilterChainsManager filterChainsManager;
 
-  private ConsumerHandlerManager consumerHandlerManager = new ConsumerHandlerManager();
+  private final ConsumerHandlerManager consumerHandlerManager = new ConsumerHandlerManager();
 
-  private ProducerHandlerManager producerHandlerManager = new ProducerHandlerManager();
+  private final ProducerHandlerManager producerHandlerManager = new ProducerHandlerManager();
 
   private ProducerProviderManager producerProviderManager;
 
@@ -105,7 +105,7 @@ public class SCBEngine {
 
   private TransportManager transportManager = new TransportManager();
 
-  private List<BootListener> bootListeners = new ArrayList<>(
+  private final List<BootListener> bootListeners = new ArrayList<>(
       SPIServiceUtils.getOrLoadSortedService(BootListener.class));
 
   private final AtomicLong invocationStartedCounter = new AtomicLong();
@@ -114,7 +114,7 @@ public class SCBEngine {
 
   private volatile SCBStatus status = SCBStatus.DOWN;
 
-  private EventBus eventBus;
+  private final EventBus eventBus;
 
   private ExecutorManager executorManager = new ExecutorManager();
 
@@ -123,11 +123,11 @@ public class SCBEngine {
   protected List<BootUpInformationCollector> bootUpInformationCollectors = SPIServiceUtils
       .getSortedService(BootUpInformationCollector.class);
 
-  private ServiceRegistryListener serviceRegistryListener;
+  private final ServiceRegistryListener serviceRegistryListener;
 
-  private SwaggerEnvironment swaggerEnvironment = new SwaggerEnvironment();
+  private final SwaggerEnvironment swaggerEnvironment = new SwaggerEnvironment();
 
-  private VendorExtensions vendorExtensions = new VendorExtensions();
+  private final VendorExtensions vendorExtensions = new VendorExtensions();
 
   private Thread shutdownHook;
 
@@ -617,7 +617,7 @@ public class SCBEngine {
   }
 
   public static class AfterRegistryEventHanlder {
-    private SCBEngine engine;
+    private final SCBEngine engine;
 
     public AfterRegistryEventHanlder(SCBEngine engine) {
       this.engine = engine;

--- a/core/src/main/java/org/apache/servicecomb/core/definition/ConsumerMicroserviceVersionsMeta.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/ConsumerMicroserviceVersionsMeta.java
@@ -20,7 +20,7 @@ import org.apache.servicecomb.core.SCBEngine;
 import org.apache.servicecomb.registry.consumer.MicroserviceVersions;
 
 public class ConsumerMicroserviceVersionsMeta extends MicroserviceVersionsMeta {
-  private MicroserviceVersions microserviceVersions;
+  private final MicroserviceVersions microserviceVersions;
 
   public ConsumerMicroserviceVersionsMeta(SCBEngine scbEngine, MicroserviceVersions microserviceVersions) {
     super(scbEngine, microserviceVersions.getMicroserviceName());

--- a/core/src/main/java/org/apache/servicecomb/core/definition/InvocationRuntimeType.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/InvocationRuntimeType.java
@@ -40,7 +40,7 @@ public class InvocationRuntimeType {
 
   private Method associatedMethod;
 
-  private ResponsesMeta responsesMeta;
+  private final ResponsesMeta responsesMeta;
 
   private ArgumentsMapper argumentsMapper;
 

--- a/core/src/main/java/org/apache/servicecomb/core/definition/MicroserviceMeta.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/MicroserviceMeta.java
@@ -41,29 +41,29 @@ public class MicroserviceMeta {
 
   private MicroserviceVersionsMeta microserviceVersionsMeta;
 
-  private String appId;
+  private final String appId;
 
   // always not include appId
-  private String shortName;
+  private final String shortName;
 
   // inside app: equals to shortName
   // cross app: appId:shortName
-  private String microserviceName;
+  private final String microserviceName;
 
   // key is schemaId, this is all schemas
-  private Map<String, SchemaMeta> schemaMetas = new HashMap<>();
+  private final Map<String, SchemaMeta> schemaMetas = new HashMap<>();
 
   // key is schema interface
   // only when list have only one element, then allow query by interface
   // otherwise must query by schemaId
   //
   // value is synchronizedList, only for low frequency query
-  private Map<Class<?>, List<SchemaMeta>> intfSchemaMetas = new HashMap<>();
+  private final Map<Class<?>, List<SchemaMeta>> intfSchemaMetas = new HashMap<>();
 
   // key is OperationMeta.getMicroserviceQualifiedName()
-  private Map<String, OperationMeta> operationMetas = new HashMap<>();
+  private final Map<String, OperationMeta> operationMetas = new HashMap<>();
 
-  private boolean consumer;
+  private final boolean consumer;
 
   private List<Handler> handlerChain = Collections.singletonList((invocation, ar) -> ar.success(null));
 
@@ -75,7 +75,7 @@ public class MicroserviceMeta {
   // providerQpsFlowControlHandlerSearched is a temporary field, only for internal usage
   private boolean providerQpsFlowControlHandlerSearched;
 
-  private VendorExtensions vendorExtensions = new VendorExtensions();
+  private final VendorExtensions vendorExtensions = new VendorExtensions();
 
   public MicroserviceMeta(SCBEngine scbEngine, String microserviceName, boolean consumer) {
     this.scbEngine = scbEngine;

--- a/core/src/main/java/org/apache/servicecomb/core/definition/OperationConfig.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/OperationConfig.java
@@ -81,7 +81,7 @@ public class OperationConfig {
   /**
    * producer wait in thread pool timeout
    */
-  private Map<String, Long> nanoRequestWaitInPoolTimeoutByTransport = new HashMap<>();
+  private final Map<String, Long> nanoRequestWaitInPoolTimeoutByTransport = new HashMap<>();
 
   @InjectProperty(keys = "Provider.requestWaitInPoolTimeout${op-priority}", defaultValue = "30000")
   private long msDefaultRequestWaitInPoolTimeout;

--- a/core/src/main/java/org/apache/servicecomb/core/definition/OperationMeta.java
+++ b/core/src/main/java/org/apache/servicecomb/core/definition/OperationMeta.java
@@ -45,11 +45,11 @@ public class OperationMeta {
   // run in this executor
   private Executor executor;
 
-  private ResponsesMeta responsesMeta = new ResponsesMeta();
+  private final ResponsesMeta responsesMeta = new ResponsesMeta();
 
   private OperationConfig config;
 
-  private VendorExtensions vendorExtensions = new VendorExtensions();
+  private final VendorExtensions vendorExtensions = new VendorExtensions();
 
   public OperationMeta init(SchemaMeta schemaMeta, SwaggerOperation swaggerOperation) {
     this.schemaMeta = schemaMeta;

--- a/core/src/main/java/org/apache/servicecomb/core/event/InvocationBaseEvent.java
+++ b/core/src/main/java/org/apache/servicecomb/core/event/InvocationBaseEvent.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.core.event;
 import org.apache.servicecomb.core.Invocation;
 
 public class InvocationBaseEvent {
-  private Invocation invocation;
+  private final Invocation invocation;
 
   public InvocationBaseEvent(Invocation invocation) {
     this.invocation = invocation;

--- a/core/src/main/java/org/apache/servicecomb/core/event/InvocationFinishEvent.java
+++ b/core/src/main/java/org/apache/servicecomb/core/event/InvocationFinishEvent.java
@@ -20,7 +20,7 @@ import org.apache.servicecomb.core.Invocation;
 import org.apache.servicecomb.swagger.invocation.Response;
 
 public class InvocationFinishEvent extends InvocationWithResponseEvent {
-  private long nanoCurrent;
+  private final long nanoCurrent;
 
   public InvocationFinishEvent(Invocation invocation, Response response) {
     super(invocation, response);

--- a/core/src/main/java/org/apache/servicecomb/core/executor/ExecutorManager.java
+++ b/core/src/main/java/org/apache/servicecomb/core/executor/ExecutorManager.java
@@ -37,7 +37,7 @@ public class ExecutorManager {
 
   public static final String EXECUTOR_DEFAULT = EXECUTOR_GROUP_THREADPOOL;
 
-  private Map<String, Executor> executors = new ConcurrentHashMapEx<>();
+  private final Map<String, Executor> executors = new ConcurrentHashMapEx<>();
 
   public ExecutorManager() {
     registerExecutor(EXECUTOR_REACTIVE, new ReactiveExecutor());

--- a/core/src/main/java/org/apache/servicecomb/core/executor/GroupExecutor.java
+++ b/core/src/main/java/org/apache/servicecomb/core/executor/GroupExecutor.java
@@ -64,13 +64,13 @@ public class GroupExecutor implements Executor, Closeable {
   protected int maxQueueSize;
 
   // to avoid multiple network thread conflicted when put tasks to executor queue
-  private List<ExecutorService> executorList = new ArrayList<>();
+  private final List<ExecutorService> executorList = new ArrayList<>();
 
   // for bind network thread to one executor
   // it's impossible that has too many network thread, so index will not too big that less than 0
-  private AtomicInteger index = new AtomicInteger();
+  private final AtomicInteger index = new AtomicInteger();
 
-  private Map<Long, Executor> threadExecutorMap = new ConcurrentHashMapEx<>();
+  private final Map<Long, Executor> threadExecutorMap = new ConcurrentHashMapEx<>();
 
   public GroupExecutor init() {
     return init("group");

--- a/core/src/main/java/org/apache/servicecomb/core/executor/ThreadPoolExecutorEx.java
+++ b/core/src/main/java/org/apache/servicecomb/core/executor/ThreadPoolExecutorEx.java
@@ -24,11 +24,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class ThreadPoolExecutorEx extends ThreadPoolExecutor {
-  private AtomicInteger submittedCount = new AtomicInteger();
+  private final AtomicInteger submittedCount = new AtomicInteger();
 
-  private AtomicInteger finishedCount = new AtomicInteger();
+  private final AtomicInteger finishedCount = new AtomicInteger();
 
-  private AtomicInteger rejectedCount = new AtomicInteger();
+  private final AtomicInteger rejectedCount = new AtomicInteger();
 
   public ThreadPoolExecutorEx(int coreThreads, int maxThreads, int maxIdleInSecond, TimeUnit timeUnit,
       BlockingQueue<Runnable> queue, ThreadFactory threadFactory) {

--- a/core/src/main/java/org/apache/servicecomb/core/filter/config/TransportChainsConfig.java
+++ b/core/src/main/java/org/apache/servicecomb/core/filter/config/TransportChainsConfig.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 public class TransportChainsConfig {
-  private Map<String, List<String>> chainByTransport = new HashMap<>();
+  private final Map<String, List<String>> chainByTransport = new HashMap<>();
 
   public Map<String, List<String>> getChainByTransport() {
     return chainByTransport;

--- a/core/src/main/java/org/apache/servicecomb/core/filter/impl/TransportFilters.java
+++ b/core/src/main/java/org/apache/servicecomb/core/filter/impl/TransportFilters.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
 public class TransportFilters implements InternalFilter {
   public static final String NAME = "transport-filters";
 
-  private Map<String, FilterNode> chainByTransport = new HashMap<>();
+  private final Map<String, FilterNode> chainByTransport = new HashMap<>();
 
   @Nonnull
   @Override

--- a/core/src/main/java/org/apache/servicecomb/core/governance/RetryContext.java
+++ b/core/src/main/java/org/apache/servicecomb/core/governance/RetryContext.java
@@ -25,7 +25,7 @@ public class RetryContext {
 
   private int triedCount;
 
-  private int retryOnSame;
+  private final int retryOnSame;
 
   public RetryContext(int retryOnSame) {
     this.retryOnSame = retryOnSame;

--- a/core/src/main/java/org/apache/servicecomb/core/governance/ServiceCombInvocationContext.java
+++ b/core/src/main/java/org/apache/servicecomb/core/governance/ServiceCombInvocationContext.java
@@ -28,7 +28,7 @@ import org.springframework.stereotype.Component;
 public class ServiceCombInvocationContext implements InvocationContext {
   private static final String CONTEXT_KEY = "x-servicecomb-governance-match";
 
-  private static ThreadLocal<org.apache.servicecomb.swagger.invocation.context.InvocationContext> contextMgr = new ThreadLocal<>();
+  private static final ThreadLocal<org.apache.servicecomb.swagger.invocation.context.InvocationContext> contextMgr = new ThreadLocal<>();
 
   public static void setInvocationContext(
       org.apache.servicecomb.swagger.invocation.context.InvocationContext invocationContext) {

--- a/core/src/main/java/org/apache/servicecomb/core/handler/config/Config.java
+++ b/core/src/main/java/org/apache/servicecomb/core/handler/config/Config.java
@@ -30,7 +30,7 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 @JacksonXmlRootElement
 public class Config {
   // key为handler id
-  private Map<String, Class<Handler>> handlerClassMap = new HashMap<>();
+  private final Map<String, Class<Handler>> handlerClassMap = new HashMap<>();
 
   public void mergeFrom(Config otherConfig) {
     handlerClassMap.putAll(otherConfig.handlerClassMap);

--- a/core/src/main/java/org/apache/servicecomb/core/handler/impl/SimpleLoadBalanceHandler.java
+++ b/core/src/main/java/org/apache/servicecomb/core/handler/impl/SimpleLoadBalanceHandler.java
@@ -41,10 +41,10 @@ import org.slf4j.LoggerFactory;
 public class SimpleLoadBalanceHandler implements Handler {
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleLoadBalanceHandler.class);
 
-  private DiscoveryTree discoveryTree = new DiscoveryTree();
+  private final DiscoveryTree discoveryTree = new DiscoveryTree();
 
   // key为grouping filter qualified name
-  private volatile Map<String, AtomicInteger> indexMap = new ConcurrentHashMapEx<>();
+  private final Map<String, AtomicInteger> indexMap = new ConcurrentHashMapEx<>();
 
   public SimpleLoadBalanceHandler() {
     discoveryTree.loadFromSPI(DiscoveryFilter.class);

--- a/core/src/main/java/org/apache/servicecomb/core/invocation/InvocationStageTrace.java
+++ b/core/src/main/java/org/apache/servicecomb/core/invocation/InvocationStageTrace.java
@@ -85,7 +85,7 @@ public class InvocationStageTrace {
 
   public static final String PRODUCER_SEND_RESPONSE = "send response";
 
-  private Invocation invocation;
+  private final Invocation invocation;
 
   // current time for start invocation
   private long startTimeMillis;

--- a/core/src/main/java/org/apache/servicecomb/core/provider/consumer/ConsumerProviderManager.java
+++ b/core/src/main/java/org/apache/servicecomb/core/provider/consumer/ConsumerProviderManager.java
@@ -24,7 +24,7 @@ import org.apache.servicecomb.core.ConsumerProvider;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 
 public class ConsumerProviderManager {
-  private List<ConsumerProvider> consumerProviderList = new ArrayList<>(
+  private final List<ConsumerProvider> consumerProviderList = new ArrayList<>(
       SPIServiceUtils.getOrLoadSortedService(ConsumerProvider.class));
 
   public List<ConsumerProvider> getConsumerProviderList() {

--- a/core/src/main/java/org/apache/servicecomb/core/provider/consumer/SyncResponseExecutor.java
+++ b/core/src/main/java/org/apache/servicecomb/core/provider/consumer/SyncResponseExecutor.java
@@ -33,7 +33,7 @@ import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
  * 将应答流程包装为Runnable，先唤醒业务线程，再在业务线程中执行runnable
  */
 public class SyncResponseExecutor implements Executor {
-  private CountDownLatch latch;
+  private final CountDownLatch latch;
 
   private Runnable cmd;
 

--- a/core/src/main/java/org/apache/servicecomb/core/provider/producer/ProducerProviderManager.java
+++ b/core/src/main/java/org/apache/servicecomb/core/provider/producer/ProducerProviderManager.java
@@ -45,12 +45,12 @@ import io.swagger.models.Swagger;
 public class ProducerProviderManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProducerProviderManager.class);
 
-  private List<ProducerProvider> producerProviderList = new ArrayList<>(
+  private final List<ProducerProvider> producerProviderList = new ArrayList<>(
       SPIServiceUtils.getOrLoadSortedService(ProducerProvider.class));
 
-  private SCBEngine scbEngine;
+  private final SCBEngine scbEngine;
 
-  private List<ProducerMeta> producerMetas = new ArrayList<>();
+  private final List<ProducerMeta> producerMetas = new ArrayList<>();
 
   public ProducerProviderManager(SCBEngine scbEngine) {
     this.scbEngine = scbEngine;

--- a/core/src/main/java/org/apache/servicecomb/core/transport/TransportManager.java
+++ b/core/src/main/java/org/apache/servicecomb/core/transport/TransportManager.java
@@ -36,9 +36,9 @@ import org.slf4j.LoggerFactory;
 public class TransportManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(TransportManager.class);
 
-  private List<Transport> transports = new ArrayList<>(SPIServiceUtils.getOrLoadSortedService(Transport.class));
+  private final List<Transport> transports = new ArrayList<>(SPIServiceUtils.getOrLoadSortedService(Transport.class));
 
-  private Map<String, Transport> transportMap = new HashMap<>();
+  private final Map<String, Transport> transportMap = new HashMap<>();
 
   public void clearTransportBeforeInit() {
     transports.clear();

--- a/core/src/test/java/org/apache/servicecomb/core/Utils.java
+++ b/core/src/test/java/org/apache/servicecomb/core/Utils.java
@@ -24,7 +24,7 @@ import org.springframework.util.ReflectionUtils;
 import com.netflix.config.DynamicProperty;
 
 public class Utils {
-  private static Method updatePropertyMethod =
+  private static final Method updatePropertyMethod =
       ReflectionUtils.findMethod(DynamicProperty.class, "updateProperty", String.class, Object.class);
 
   static {

--- a/core/src/test/java/org/apache/servicecomb/core/transport/TestAbstractTransport.java
+++ b/core/src/test/java/org/apache/servicecomb/core/transport/TestAbstractTransport.java
@@ -39,7 +39,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 
 public class TestAbstractTransport {
-  private Method updatePropertyMethod =
+  private final Method updatePropertyMethod =
       ReflectionUtils.findMethod(DynamicProperty.class, "updateProperty", String.class, Object.class);
 
   private void updateProperty(String key, Object value) {

--- a/deployment/src/main/java/org/apache/servicecomb/deployment/Deployment.java
+++ b/deployment/src/main/java/org/apache/servicecomb/deployment/Deployment.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 
 public class Deployment {
-  private static List<DeploymentProvider> providerList = SPIServiceUtils.getSortedService(DeploymentProvider.class);
+  private static final List<DeploymentProvider> providerList = SPIServiceUtils.getSortedService(DeploymentProvider.class);
 
   public static SystemBootstrapInfo getSystemBootStrapInfo(String systemKey) {
     for (DeploymentProvider provider : providerList) {

--- a/dynamic-config/config-apollo/src/main/java/org/apache/servicecomb/config/archaius/sources/ApolloConfigurationSourceImpl.java
+++ b/dynamic-config/config-apollo/src/main/java/org/apache/servicecomb/config/archaius/sources/ApolloConfigurationSourceImpl.java
@@ -45,7 +45,7 @@ public class ApolloConfigurationSourceImpl implements ConfigCenterConfigurationS
 
   private final Map<String, Object> valueCache = new ConcurrentHashMap<>();
 
-  private List<WatchedUpdateListener> listeners = new CopyOnWriteArrayList<>();
+  private final List<WatchedUpdateListener> listeners = new CopyOnWriteArrayList<>();
 
   private static final String APOLLO_CONFIG_URL_KEY = "apollo.config.serverUri";
 

--- a/dynamic-config/config-cc/src/test/java/org/apache/servicecomb/config/center/client/AddressManagerTest.java
+++ b/dynamic-config/config-cc/src/test/java/org/apache/servicecomb/config/center/client/AddressManagerTest.java
@@ -31,7 +31,7 @@ import com.google.common.eventbus.EventBus;
 import mockit.Deencapsulation;
 
 class AddressManagerTest {
-  private static List<String> addresses = new ArrayList<>();
+  private static final List<String> addresses = new ArrayList<>();
 
   private static AddressManager addressManager1;
 

--- a/dynamic-config/config-kie/src/main/java/org/apache/servicecomb/config/kie/KieConfigurationSourceImpl.java
+++ b/dynamic-config/config-kie/src/main/java/org/apache/servicecomb/config/kie/KieConfigurationSourceImpl.java
@@ -58,7 +58,7 @@ public class KieConfigurationSourceImpl implements ConfigCenterConfigurationSour
 
   private static final Logger LOGGER = LoggerFactory.getLogger(KieConfigurationSourceImpl.class);
 
-  private List<WatchedUpdateListener> listeners = new CopyOnWriteArrayList<>();
+  private final List<WatchedUpdateListener> listeners = new CopyOnWriteArrayList<>();
 
   private KieConfigManager kieConfigManager;
 

--- a/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/nacos/archaius/sources/NacosConfigurationSourceImpl.java
+++ b/dynamic-config/config-nacos/src/main/java/org/apache/servicecomb/config/nacos/archaius/sources/NacosConfigurationSourceImpl.java
@@ -45,7 +45,7 @@ public class NacosConfigurationSourceImpl implements ConfigCenterConfigurationSo
 
   private final Map<String, Object> valueCache = new ConcurrentHashMap<>();
 
-  private List<WatchedUpdateListener> listeners = new CopyOnWriteArrayList<>();
+  private final List<WatchedUpdateListener> listeners = new CopyOnWriteArrayList<>();
 
   public NacosConfigurationSourceImpl() {
   }

--- a/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/CompatiblePathVersionMapper.java
+++ b/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/CompatiblePathVersionMapper.java
@@ -28,7 +28,7 @@ import org.apache.servicecomb.registry.version.VersionRuleUtils;
 public class CompatiblePathVersionMapper {
   // v1 -> 1.0.0-2.0.0
   // v2 -> 2.0.0-3.0.0
-  private Map<String, VersionRule> mapper = new ConcurrentHashMapEx<>();
+  private final Map<String, VersionRule> mapper = new ConcurrentHashMapEx<>();
 
   public VersionRule getOrCreate(String pathVersion) {
     return mapper.computeIfAbsent(pathVersion, this::createVersionRule);

--- a/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/DefaultEdgeDispatcher.java
+++ b/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/DefaultEdgeDispatcher.java
@@ -52,7 +52,7 @@ public class DefaultEdgeDispatcher extends AbstractEdgeDispatcher {
 
   public static final String VERSION = "param1";
 
-  private CompatiblePathVersionMapper versionMapper = new CompatiblePathVersionMapper();
+  private final CompatiblePathVersionMapper versionMapper = new CompatiblePathVersionMapper();
 
   private String prefix;
 

--- a/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/EdgeAddHeaderFilter.java
+++ b/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/EdgeAddHeaderFilter.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class EdgeAddHeaderFilter implements ConsumerFilter {
   public static final String NAME = "edge-add-headers";
 
-  private EdgeAddHeaderClientFilter filter = new EdgeAddHeaderClientFilter();
+  private final EdgeAddHeaderClientFilter filter = new EdgeAddHeaderClientFilter();
 
   @Nonnull
   @Override

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/RegisterManager.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/RegisterManager.java
@@ -27,13 +27,13 @@ import org.slf4j.LoggerFactory;
 public class RegisterManager<KEY, VALUE> {
   private static final Logger LOGGER = LoggerFactory.getLogger(RegisterManager.class);
 
-  private String name;
+  private final String name;
 
   private String registerErrorFmt = "Not allow register repeat data, name=%s, key=%s";
 
-  private Map<KEY, VALUE> objMap = new ConcurrentHashMap<>();
+  private final Map<KEY, VALUE> objMap = new ConcurrentHashMap<>();
 
-  private Object lockObj = new Object();
+  private final Object lockObj = new Object();
 
   protected Map<KEY, VALUE> getObjMap() {
     return objMap;

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/VendorExtensions.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/VendorExtensions.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
 
 public class VendorExtensions {
-  private Map<Object, Object> store = new ConcurrentHashMapEx<>();
+  private final Map<Object, Object> store = new ConcurrentHashMapEx<>();
 
   public Map<Object, Object> getStore() {
     return store;

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/base/DynamicEnum.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/base/DynamicEnum.java
@@ -22,7 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public abstract class DynamicEnum<T> {
-  private T value;
+  private final T value;
 
   @JsonIgnore
   private boolean dynamic = false;

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/config/PaaSResourceUtils.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/config/PaaSResourceUtils.java
@@ -34,7 +34,7 @@ import org.springframework.core.io.support.ResourcePatternResolver;
 public class PaaSResourceUtils extends org.springframework.util.ResourceUtils {
   public static final String PROPERTIES_SUFFIX = ".properties";
 
-  private static ResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
+  private static final ResourcePatternResolver resourcePatternResolver = new PathMatchingResourcePatternResolver();
 
   /**
    * 失败，则返回空数组

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/config/impl/PropertiesLoader.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/config/impl/PropertiesLoader.java
@@ -25,7 +25,7 @@ import org.apache.servicecomb.foundation.common.config.PaaSResourceUtils;
 import org.springframework.core.io.Resource;
 
 public class PropertiesLoader extends AbstractLoader {
-  private List<Resource> foundResList = new ArrayList<>();
+  private final List<Resource> foundResList = new ArrayList<>();
 
   public PropertiesLoader(List<String> locationPatternList) {
     super(locationPatternList);

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/config/impl/XmlLoaderUtils.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/config/impl/XmlLoaderUtils.java
@@ -38,7 +38,7 @@ public final class XmlLoaderUtils {
   private XmlLoaderUtils() {
   }
 
-  private static ObjectMapper xmlMapper = new XmlMapper();
+  private static final ObjectMapper xmlMapper = new XmlMapper();
 
   @SuppressWarnings("unchecked")
   public static <T> T load(Resource res, Class<?> cls) throws Exception {

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/event/SimpleSubscriber.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/event/SimpleSubscriber.java
@@ -29,13 +29,13 @@ import com.google.common.eventbus.AllowConcurrentEvents;
 public class SimpleSubscriber {
   private static final Logger LOGGER = LoggerFactory.getLogger(SimpleSubscriber.class);
 
-  private Object instance;
+  private final Object instance;
 
-  private Method method;
+  private final Method method;
 
   private int order;
 
-  private boolean enableExceptionPropagation;
+  private final boolean enableExceptionPropagation;
 
   // generated from method
   private Consumer<Object> lambda;

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/http/HttpStatusManager.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/http/HttpStatusManager.java
@@ -25,7 +25,7 @@ import javax.ws.rs.core.Response.StatusType;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 
 public class HttpStatusManager {
-  private Map<Integer, StatusType> statusMap = new ConcurrentHashMap<>();
+  private final Map<Integer, StatusType> statusMap = new ConcurrentHashMap<>();
 
   public HttpStatusManager() {
     for (Status status : Status.values()) {

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/net/URIEndpointObject.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/net/URIEndpointObject.java
@@ -37,11 +37,11 @@ public class URIEndpointObject extends IpPort {
 
   private static final String HTTP2 = "http2";
 
-  private boolean sslEnabled;
+  private final boolean sslEnabled;
 
   private boolean http2Enabled;
 
-  private Map<String, List<String>> querys;
+  private final Map<String, List<String>> querys;
 
   public URIEndpointObject(String endpoint) {
     URI uri = URI.create(endpoint);

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/part/AbstractPart.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/part/AbstractPart.java
@@ -26,7 +26,7 @@ import javax.servlet.http.Part;
 import javax.ws.rs.core.MediaType;
 
 public class AbstractPart implements Part {
-  private static MimetypesFileTypeMap mimetypesFileTypeMap = new MimetypesFileTypeMap();
+  private static final MimetypesFileTypeMap mimetypesFileTypeMap = new MimetypesFileTypeMap();
 
   protected String name;
 

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/part/FilePart.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/part/FilePart.java
@@ -25,7 +25,7 @@ import java.io.InputStream;
 import org.apache.commons.io.FileUtils;
 
 public class FilePart extends AbstractPart implements FilePartForSend {
-  private File file;
+  private final File file;
 
   private boolean deleteAfterFinished;
 

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/part/ResourcePart.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/part/ResourcePart.java
@@ -23,7 +23,7 @@ import java.io.InputStream;
 import org.springframework.core.io.Resource;
 
 public class ResourcePart extends AbstractPart {
-  private Resource resource;
+  private final Resource resource;
 
   public ResourcePart(String name, Resource resource) {
     this.name = name;

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/FilePerm.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/FilePerm.java
@@ -84,7 +84,7 @@ public final class FilePerm {
    */
   public static final int FILE_PERM_MASK = 511;
 
-  private static AclEntryPermission[] permList = new AclEntryPermission[] {
+  private static final AclEntryPermission[] permList = new AclEntryPermission[] {
       AclEntryPermission.READ_DATA,
       AclEntryPermission.READ_ATTRIBUTES,
       AclEntryPermission.READ_NAMED_ATTRS,

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/FortifyUtils.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/FortifyUtils.java
@@ -36,9 +36,9 @@ import javax.xml.parsers.ParserConfigurationException;
  */
 public final class FortifyUtils {
 
-  private static Method getMessageMethod;
+  private static final Method getMessageMethod;
 
-  private static Method printStackTraceMethod;
+  private static final Method printStackTraceMethod;
 
   static {
     try {

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/RSAKeyPairEntry.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/RSAKeyPairEntry.java
@@ -21,11 +21,11 @@ import java.security.PublicKey;
 
 public final class RSAKeyPairEntry {
 
-  private PrivateKey privateKey;
+  private final PrivateKey privateKey;
 
-  private PublicKey publicKey;
+  private final PublicKey publicKey;
 
-  private String publicKeyEncoded;
+  private final String publicKeyEncoded;
 
   public RSAKeyPairEntry(PrivateKey privateKey, PublicKey publicKey, String publicKeyEncoded) {
     this.privateKey = privateKey;

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/RSAUtils.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/RSAUtils.java
@@ -43,9 +43,9 @@ public class RSAUtils {
 
   private final static int KEY_SIZE = 2048;
 
-  private static Base64.Encoder encoder = Base64.getEncoder();
+  private static final Base64.Encoder encoder = Base64.getEncoder();
 
-  private static Base64.Decoder decoder = Base64.getDecoder();
+  private static final Base64.Decoder decoder = Base64.getDecoder();
 
   private static KeyFactory kf = null;
 

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/bean/MapGetter.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/bean/MapGetter.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.foundation.common.utils.bean;
 import java.util.Map;
 
 public class MapGetter<K, V> implements Getter<Map<K, V>, V> {
-  private K key;
+  private final K key;
 
   public MapGetter(K key) {
     this.key = key;

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/bean/MapSetter.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/bean/MapSetter.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.foundation.common.utils.bean;
 import java.util.Map;
 
 public class MapSetter<K, V> implements Setter<Map<K, V>, V> {
-  private K key;
+  private final K key;
 
   public MapSetter(K key) {
     this.key = key;

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/cache/TestVersionedCache.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/cache/TestVersionedCache.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 import mockit.Deencapsulation;
 
 public class TestVersionedCache {
-  private static AtomicInteger VERSION = Deencapsulation.getField(VersionedCache.class, "VERSION");
+  private static final AtomicInteger VERSION = Deencapsulation.getField(VersionedCache.class, "VERSION");
 
   @Test
   public void construct() {

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/event/TestEventBus.java
@@ -28,12 +28,12 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
 public class TestEventBus {
-  private EventBus eventBus = new SimpleEventBus();
+  private final EventBus eventBus = new SimpleEventBus();
 
-  private List<Object> events = new ArrayList<>();
+  private final List<Object> events = new ArrayList<>();
 
   public static class SubscriberForTest {
-    private List<Object> events;
+    private final List<Object> events;
 
     public SubscriberForTest( List<Object> events) {
       this.events = events;
@@ -51,7 +51,7 @@ public class TestEventBus {
   }
 
   public static class SubscriberWithOrderForTest {
-    private List<Object> events;
+    private final List<Object> events;
 
     public SubscriberWithOrderForTest( List<Object> events) {
       this.events = events;

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/net/TestNetUtils.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/net/TestNetUtils.java
@@ -67,8 +67,8 @@ public class TestNetUtils {
     Assert.assertEquals(8080, NetUtils.parseIpPort("127.0.0.1:8080").getPort());
     Assert.assertEquals("127.0.0.1", NetUtils.parseIpPort("127.0.0.1").getHostOrIp());
     Assert.assertEquals(-1, NetUtils.parseIpPort("127.0.0.1").getPort());
-    Assert.assertEquals(null, NetUtils.parseIpPort((String) null));
-    Assert.assertEquals(null, NetUtils.parseIpPortFromURI(null));
+    Assert.assertNull(NetUtils.parseIpPort((String) null));
+    Assert.assertNull(NetUtils.parseIpPortFromURI(null));
     Assert.assertEquals("127.0.0.1", NetUtils.parseIpPortFromURI("rest://127.0.0.1:8080").getHostOrIp());
     Assert.assertEquals(8080, NetUtils.parseIpPortFromURI("http://127.0.0.1:8080").getPort());
     Assert.assertEquals(80, NetUtils.parseIpPortFromURI("http://127.0.0.1").getPort());

--- a/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/ConfigMapping.java
+++ b/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/ConfigMapping.java
@@ -40,7 +40,7 @@ import com.google.common.annotations.VisibleForTesting;
  * Created by   on 2017/1/5.
  */
 public final class ConfigMapping {
-  private static Map<String, Object> configMap;
+  private static final Map<String, Object> configMap;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ConfigMapping.class);
 

--- a/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/spi/ConfigCenterConfigurationSourceLoader.java
+++ b/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/spi/ConfigCenterConfigurationSourceLoader.java
@@ -23,7 +23,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 
 public class ConfigCenterConfigurationSourceLoader {
-  private static List<ConfigCenterConfigurationSource> configCenterConfigurationSources =
+  private static final List<ConfigCenterConfigurationSource> configCenterConfigurationSources =
       SPIServiceUtils.getSortedService(ConfigCenterConfigurationSource.class);
 
   public static ConfigCenterConfigurationSource getConfigCenterConfigurationSource(Configuration localConfiguration) {

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/MetricsBootstrap.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/MetricsBootstrap.java
@@ -38,7 +38,7 @@ public class MetricsBootstrap {
 
   private EventBus eventBus;
 
-  private MetricsBootstrapConfig config = new MetricsBootstrapConfig();
+  private final MetricsBootstrapConfig config = new MetricsBootstrapConfig();
 
   private ScheduledExecutorService executorService;
 

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyDistributionConfig.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyDistributionConfig.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public class LatencyDistributionConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(LatencyDistributionConfig.class);
 
-  private List<LatencyScopeConfig> scopeConfigs = new ArrayList<>();
+  private final List<LatencyScopeConfig> scopeConfigs = new ArrayList<>();
 
   /**
    *

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyDistributionMeter.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyDistributionMeter.java
@@ -23,7 +23,7 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 
 public class LatencyDistributionMeter extends AbstractPeriodMeter {
-  private List<LatencyScopeMeter> latencyScopeMeters = new ArrayList<>();
+  private final List<LatencyScopeMeter> latencyScopeMeters = new ArrayList<>();
 
   public LatencyDistributionMeter(Id id, String config) {
     this.id = id;

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyScopeConfig.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyScopeConfig.java
@@ -20,9 +20,9 @@ public class LatencyScopeConfig {
   // [min, max)
   // even max equals Long.MAX_VALUE, still not include it
   // because it will never happened in real cases
-  private long msMin;
+  private final long msMin;
 
-  private long msMax;
+  private final long msMax;
 
   public LatencyScopeConfig(long msMin, long msMax) {
     this.msMin = msMin;

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyScopeMeter.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/meter/LatencyScopeMeter.java
@@ -23,15 +23,15 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 
 public class LatencyScopeMeter {
-  private Id scopeId;
+  private final Id scopeId;
 
-  private LongAdder times = new LongAdder();
+  private final LongAdder times = new LongAdder();
 
   private long lastTimes = 0L;
 
-  private long nanoMin;
+  private final long nanoMin;
 
-  private long nanoMax;
+  private final long nanoMax;
 
   public LatencyScopeMeter(Id latencyDistributionId, LatencyScopeConfig config) {
     nanoMin = TimeUnit.MILLISECONDS.toNanos(config.getMsMin());

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/spectator/DefaultTagFinder.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/spectator/DefaultTagFinder.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.foundation.metrics.publish.spectator;
 import com.netflix.spectator.api.Tag;
 
 public class DefaultTagFinder implements TagFinder {
-  private String tagKey;
+  private final String tagKey;
 
   private boolean skipOnNull;
 

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/spectator/MeasurementGroupConfig.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/spectator/MeasurementGroupConfig.java
@@ -24,7 +24,7 @@ import java.util.stream.Collectors;
 
 public class MeasurementGroupConfig {
   // key is measurement id name
-  private Map<String, List<TagFinder>> groups = new HashMap<>();
+  private final Map<String, List<TagFinder>> groups = new HashMap<>();
 
   public MeasurementGroupConfig() {
   }

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/spectator/MeasurementNode.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/publish/spectator/MeasurementNode.java
@@ -24,9 +24,9 @@ import java.util.Map;
 import com.netflix.spectator.api.Measurement;
 
 public class MeasurementNode implements Comparable<MeasurementNode> {
-  private String name;
+  private final String name;
 
-  private List<Measurement> measurements = new ArrayList<>();
+  private final List<Measurement> measurements = new ArrayList<>();
 
   private Map<String, MeasurementNode> children;
 

--- a/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/registry/GlobalRegistry.java
+++ b/foundations/foundation-metrics/src/main/java/org/apache/servicecomb/foundation/metrics/registry/GlobalRegistry.java
@@ -30,9 +30,9 @@ import com.netflix.spectator.api.Registry;
 import com.netflix.spectator.api.SpectatorUtils;
 
 public class GlobalRegistry {
-  private Clock clock;
+  private final Clock clock;
 
-  private List<Registry> registries = new CopyOnWriteArrayList<>();
+  private final List<Registry> registries = new CopyOnWriteArrayList<>();
 
   private Registry defaultRegistry;
 

--- a/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/health/TestHealthCheckerManager.java
+++ b/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/health/TestHealthCheckerManager.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 public class TestHealthCheckerManager {
 
-  private HealthChecker good = new HealthChecker() {
+  private final HealthChecker good = new HealthChecker() {
     @Override
     public String getName() {
       return "testBad";
@@ -37,7 +37,7 @@ public class TestHealthCheckerManager {
     }
   };
 
-  private HealthChecker bad = new HealthChecker() {
+  private final HealthChecker bad = new HealthChecker() {
     @Override
     public String getName() {
       return "testGood";

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/ProtoMapperFactory.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/ProtoMapperFactory.java
@@ -28,11 +28,11 @@ import io.protostuff.compiler.model.Proto;
 public class ProtoMapperFactory {
   // 1.to support "any" type
   // 2.to find bean properties
-  private ObjectMapper jsonMapper = new ObjectMapper();
+  private final ObjectMapper jsonMapper = new ObjectMapper();
 
-  private BeanDescriptorManager beanDescriptorManager;
+  private final BeanDescriptorManager beanDescriptorManager;
 
-  private ProtoParser protoParser = new ProtoParser();
+  private final ProtoParser protoParser = new ProtoParser();
 
   public ProtoMapperFactory() {
     jsonMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/RootSerializer.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/RootSerializer.java
@@ -23,7 +23,7 @@ import io.protostuff.ProtobufOutputEx;
 import io.protostuff.SchemaEx;
 
 public class RootSerializer {
-  private SchemaEx<Object> schema;
+  private final SchemaEx<Object> schema;
 
   public RootSerializer(SchemaEx<Object> schema) {
     this.schema = schema;

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/bean/ArgumentsBeanDescriptor.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/bean/ArgumentsBeanDescriptor.java
@@ -21,7 +21,7 @@ import com.fasterxml.jackson.databind.type.SimpleType;
 public class ArgumentsBeanDescriptor extends SimpleType {
   private static final long serialVersionUID = 1L;
 
-  private BeanDescriptor beanDescriptor;
+  private final BeanDescriptor beanDescriptor;
 
   public ArgumentsBeanDescriptor(BeanDescriptor beanDescriptor) {
     super(ArgumentsBeanDescriptor.class);

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/bean/BeanDescriptor.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/bean/BeanDescriptor.java
@@ -33,7 +33,7 @@ public class BeanDescriptor {
 
   private JavaType javaType;
 
-  private Map<String, PropertyDescriptor> propertyDescriptors = new HashMap<>();
+  private final Map<String, PropertyDescriptor> propertyDescriptors = new HashMap<>();
 
   public JavaType getJavaType() {
     return javaType;

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/bean/BeanDescriptorManager.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/bean/BeanDescriptorManager.java
@@ -26,9 +26,9 @@ import com.fasterxml.jackson.databind.SerializationConfig;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 
 public class BeanDescriptorManager {
-  private SerializationConfig serializationConfig;
+  private final SerializationConfig serializationConfig;
 
-  private Map<Type, BeanDescriptor> beanDescriptors = new ConcurrentHashMapEx<>();
+  private final Map<Type, BeanDescriptor> beanDescriptors = new ConcurrentHashMapEx<>();
 
   public BeanDescriptorManager(SerializationConfig serializationConfig) {
     this.serializationConfig = serializationConfig;

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/parser/ContentFileReader.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/parser/ContentFileReader.java
@@ -24,8 +24,8 @@ import org.antlr.v4.runtime.CharStreams;
 import io.protostuff.compiler.parser.FileReader;
 
 public class ContentFileReader implements FileReader {
-  private FileReader importReader;
-  private String content;
+  private final FileReader importReader;
+  private final String content;
 
   private boolean contentReaded;
 

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/parser/ProtoParser.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/parser/ProtoParser.java
@@ -34,13 +34,13 @@ import io.protostuff.compiler.parser.ProtoContext;
 public class ProtoParser {
   private static final String DEFAULT_PROTO_NAME = "default.proto";
 
-  private Injector injector = Guice.createInjector(new ParserModule());
+  private final Injector injector = Guice.createInjector(new ParserModule());
 
-  private FileReaderFactory fileReaderFactory = injector.getInstance(FileReaderFactory.class);
+  private final FileReaderFactory fileReaderFactory = injector.getInstance(FileReaderFactory.class);
 
-  private FileReader defaultReader = fileReaderFactory.create(Collections.emptyList());
+  private final FileReader defaultReader = fileReaderFactory.create(Collections.emptyList());
 
-  private FileDescriptorLoader loader = injector.getInstance(FileDescriptorLoader.class);
+  private final FileDescriptorLoader loader = injector.getInstance(FileDescriptorLoader.class);
 
   public Proto parseFromContent(String content) {
     // io.protostuff.compiler.parser.ClasspathFileReader will use ContextClassLoader load resource, but in some environment,

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/EnumMeta.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/EnumMeta.java
@@ -26,11 +26,11 @@ import io.protostuff.compiler.model.EnumConstant;
 import io.protostuff.compiler.model.Field;
 
 public class EnumMeta {
-  private Map<String, Integer> enumNameToValueMap = new HashMap<>();
+  private final Map<String, Integer> enumNameToValueMap = new HashMap<>();
 
   // key is idl defined enum value
   // value is Enum<?> or null
-  private Map<Integer, Enum<?>> enumValues = new HashMap<>();
+  private final Map<Integer, Enum<?>> enumValues = new HashMap<>();
 
   public EnumMeta(Field protoField, JavaType javaType) {
     io.protostuff.compiler.model.Enum enumType = (io.protostuff.compiler.model.Enum) protoField.getType();

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/any/AnyEntrySchema.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/any/AnyEntrySchema.java
@@ -50,7 +50,7 @@ public class AnyEntrySchema implements SchemaEx<Object> {
 
   private final int valueTag = WireFormat.makeTag(2, WireFormat.WIRETYPE_LENGTH_DELIMITED);
 
-  private Type anyTargetType;
+  private final Type anyTargetType;
 
   public AnyEntrySchema(ProtoMapper protoMapper, Type type) {
     this.protoMapper = protoMapper;

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/deserializer/MessageReadSchema.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/deserializer/MessageReadSchema.java
@@ -58,7 +58,7 @@ public class MessageReadSchema<T> implements SchemaEx<T> {
 
   private FieldMapEx<T> fieldMap;
 
-  private Instantiator<T> instantiator;
+  private final Instantiator<T> instantiator;
 
   private JavaType javaType;
 

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/deserializer/repeated/PrimitiveArrayBuilderWrapper.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/deserializer/repeated/PrimitiveArrayBuilderWrapper.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.foundation.protobuf.internal.schema.deserializer.
 import com.fasterxml.jackson.databind.util.PrimitiveArrayBuilder;
 
 public class PrimitiveArrayBuilderWrapper<T> {
-  private PrimitiveArrayBuilder<T> builder;
+  private final PrimitiveArrayBuilder<T> builder;
 
   private T array;
 

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/serializer/MessageWriteSchema.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/serializer/MessageWriteSchema.java
@@ -53,7 +53,7 @@ public class MessageWriteSchema<T> implements SchemaEx<T> {
 
   protected Message message;
 
-  private JavaType javaType;
+  private final JavaType javaType;
 
   // mostly, one message only relate to one pojo
   private final Class<T> mainPojoCls;

--- a/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/serializer/scalar/EnumWriteSchemas.java
+++ b/foundations/foundation-protobuf/src/main/java/org/apache/servicecomb/foundation/protobuf/internal/schema/serializer/scalar/EnumWriteSchemas.java
@@ -39,7 +39,7 @@ public class EnumWriteSchemas {
   }
 
   private static class EnumDynamicSchema<T> extends FieldSchema<T> {
-    private EnumMeta enumMeta;
+    private final EnumMeta enumMeta;
 
     public EnumDynamicSchema(Field protoField, PropertyDescriptor propertyDescriptor) {
       super(protoField, propertyDescriptor.getJavaType());

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/RegistrationManager.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/RegistrationManager.java
@@ -63,7 +63,7 @@ public class RegistrationManager {
 
   private static final String PUBLISH_PORT = "servicecomb.{transport_name}.publishPort";
 
-  private static SwaggerLoader swaggerLoader = new SwaggerLoader();
+  private static final SwaggerLoader swaggerLoader = new SwaggerLoader();
 
   public static RegistrationManager INSTANCE = new RegistrationManager();
 
@@ -331,7 +331,7 @@ public class RegistrationManager {
   }
 
   public static class AfterServiceInstanceRegistryHandler {
-    private AtomicInteger instanceRegisterCounter;
+    private final AtomicInteger instanceRegisterCounter;
 
     AfterServiceInstanceRegistryHandler(int counter) {
       instanceRegisterCounter = new AtomicInteger(counter);

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/CreateMicroserviceEvent.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/CreateMicroserviceEvent.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.registry.api.event;
 import org.apache.servicecomb.registry.consumer.MicroserviceVersions;
 
 public class CreateMicroserviceEvent {
-  private MicroserviceVersions microserviceVersions;
+  private final MicroserviceVersions microserviceVersions;
 
   public CreateMicroserviceEvent(MicroserviceVersions microserviceVersions) {
     this.microserviceVersions = microserviceVersions;

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/CreateMicroserviceVersionEvent.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/CreateMicroserviceVersionEvent.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.registry.api.event;
 import org.apache.servicecomb.registry.consumer.MicroserviceVersion;
 
 public class CreateMicroserviceVersionEvent {
-  private MicroserviceVersion microserviceVersion;
+  private final MicroserviceVersion microserviceVersion;
 
   public CreateMicroserviceVersionEvent(MicroserviceVersion microserviceVersion) {
     this.microserviceVersion = microserviceVersion;

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/DestroyMicroserviceEvent.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/DestroyMicroserviceEvent.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.registry.api.event;
 import org.apache.servicecomb.registry.consumer.MicroserviceVersions;
 
 public class DestroyMicroserviceEvent {
-  private MicroserviceVersions microserviceVersions;
+  private final MicroserviceVersions microserviceVersions;
 
   public DestroyMicroserviceEvent(MicroserviceVersions microserviceVersions) {
     this.microserviceVersions = microserviceVersions;

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/DestroyMicroserviceVersionEvent.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/DestroyMicroserviceVersionEvent.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.registry.api.event;
 import org.apache.servicecomb.registry.consumer.MicroserviceVersion;
 
 public class DestroyMicroserviceVersionEvent {
-  private MicroserviceVersion microserviceVersion;
+  private final MicroserviceVersion microserviceVersion;
 
   public DestroyMicroserviceVersionEvent(MicroserviceVersion microserviceVersion) {
     this.microserviceVersion = microserviceVersion;

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/MicroserviceInstanceRegisteredEvent.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/event/MicroserviceInstanceRegisteredEvent.java
@@ -21,12 +21,12 @@ package org.apache.servicecomb.registry.api.event;
  * when registration is ready, should post this event.
  */
 public class MicroserviceInstanceRegisteredEvent {
-  private String registrationName;
+  private final String registrationName;
 
-  private String instanceId;
+  private final String instanceId;
 
   // If this event is sent by RegistrationManager, which means all Registration are successful.
-  private boolean registrationManager;
+  private final boolean registrationManager;
 
   public MicroserviceInstanceRegisteredEvent(String registrationName, String instanceId,
       boolean registrationManager) {

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/registry/Microservice.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/api/registry/Microservice.java
@@ -66,7 +66,7 @@ public class Microservice {
   private List<String> schemas = new ArrayList<>();
 
   @JsonIgnore
-  private Map<String, String> schemaMap = new HashMap<>();
+  private final Map<String, String> schemaMap = new HashMap<>();
 
   private List<BasePath> paths = new ArrayList<>();
 

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/cache/InstanceCache.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/cache/InstanceCache.java
@@ -41,24 +41,24 @@ public class InstanceCache {
   // 如果相等，可能会导致其他没感知删除的模块，在更新流程上，遇到问题
   private static final AtomicInteger VERSION = new AtomicInteger();
 
-  private int cacheVersion;
+  private final int cacheVersion;
 
-  private String appId;
+  private final String appId;
 
-  private String microserviceName;
+  private final String microserviceName;
 
   // 1.0或1.0+或latest等等，只是规则，不一定表示一个确定的版本
-  private String microserviceVersionRule;
+  private final String microserviceVersionRule;
 
   // key为instanceId
-  private Map<String, MicroserviceInstance> instanceMap;
+  private final Map<String, MicroserviceInstance> instanceMap;
 
-  private VersionedCache versionedCache;
+  private final VersionedCache versionedCache;
 
   // 缓存CacheEndpoint
   private volatile Map<String, List<CacheEndpoint>> transportMap;
 
-  private Object lockObj = new Object();
+  private final Object lockObj = new Object();
 
   /**
    * 用于初始化场景

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/cache/InstanceCacheManagerNew.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/cache/InstanceCacheManagerNew.java
@@ -21,7 +21,7 @@ import org.apache.servicecomb.foundation.common.cache.VersionedCache;
 import org.apache.servicecomb.registry.consumer.AppManager;
 
 public class InstanceCacheManagerNew implements InstanceCacheManager {
-  private AppManager appManager;
+  private final AppManager appManager;
 
   public InstanceCacheManagerNew(AppManager appManager) {
     this.appManager = appManager;

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/cache/MicroserviceInstanceCache.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/cache/MicroserviceInstanceCache.java
@@ -39,7 +39,7 @@ public class MicroserviceInstanceCache {
 
   private static final Logger logger = LoggerFactory.getLogger(MicroserviceInstanceCache.class);
 
-  private static Cache<String, MicroserviceInstance> instances = CacheBuilder.newBuilder()
+  private static final Cache<String, MicroserviceInstance> instances = CacheBuilder.newBuilder()
       .maximumSize(1000)
       .expireAfterAccess(30, TimeUnit.MINUTES)
       .build();

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/AppManager.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/AppManager.java
@@ -33,7 +33,7 @@ public class AppManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(AppManager.class);
 
   // key: appId
-  private Map<String, MicroserviceManager> apps = new ConcurrentHashMapEx<>();
+  private final Map<String, MicroserviceManager> apps = new ConcurrentHashMapEx<>();
 
   public AppManager() {
     getEventBus().register(this);

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/MicroserviceManager.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/MicroserviceManager.java
@@ -31,14 +31,14 @@ import io.vertx.core.Vertx;
 public class MicroserviceManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(MicroserviceManager.class);
 
-  private AppManager appManager;
+  private final AppManager appManager;
 
-  private String appId;
+  private final String appId;
 
   // key: microserviceName
-  private Map<String, MicroserviceVersions> versionsByName = new ConcurrentHashMapEx<>();
+  private final Map<String, MicroserviceVersions> versionsByName = new ConcurrentHashMapEx<>();
 
-  private Object lock = new Object();
+  private final Object lock = new Object();
 
   public MicroserviceManager(AppManager appManager, String appId) {
     this.appManager = appManager;

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/MicroserviceVersion.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/MicroserviceVersion.java
@@ -43,7 +43,7 @@ public class MicroserviceVersion {
 
   protected Collection<MicroserviceInstance> instances;
 
-  private VendorExtensions vendorExtensions = new VendorExtensions();
+  private final VendorExtensions vendorExtensions = new VendorExtensions();
 
   public MicroserviceVersion(MicroserviceVersions microserviceVersions, String microserviceId,
       String microserviceName,

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/MicroserviceVersions.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/consumer/MicroserviceVersions.java
@@ -80,7 +80,7 @@ public class MicroserviceVersions {
 
   private boolean waitingDelete = false;
 
-  private VendorExtensions vendorExtensions = new VendorExtensions();
+  private final VendorExtensions vendorExtensions = new VendorExtensions();
 
   public MicroserviceVersions(AppManager appManager, String appId, String microserviceName) {
     this.appManager = appManager;

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/discovery/DiscoveryContext.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/discovery/DiscoveryContext.java
@@ -24,13 +24,13 @@ import java.util.Stack;
 public class DiscoveryContext {
   private Object inputParameters;
 
-  private Map<String, Object> contextParameters = new HashMap<>();
+  private final Map<String, Object> contextParameters = new HashMap<>();
 
   // some filter support rerun logic, eg:ZoneAware
   // instances grouping to self zone, other zone, and so on
   // first try self zone, after other filter(Isolation Filter), no instances are available
   // then try other zone
-  private Stack<DiscoveryTreeNode> rerunStack = new Stack<>();
+  private final Stack<DiscoveryTreeNode> rerunStack = new Stack<>();
 
   private DiscoveryTreeNode currentNode;
 

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/discovery/DiscoveryTree.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/discovery/DiscoveryTree.java
@@ -80,7 +80,7 @@ public class DiscoveryTree {
 
   private final Object lock = new Object();
 
-  private List<DiscoveryFilter> filters = new ArrayList<>();
+  private final List<DiscoveryFilter> filters = new ArrayList<>();
 
   public void loadFromSPI(Class<? extends DiscoveryFilter> cls) {
     filters.addAll(SPIServiceUtils.getSortedService(cls));

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/swagger/SwaggerLoader.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/swagger/SwaggerLoader.java
@@ -50,7 +50,7 @@ public class SwaggerLoader {
   // first key : appId
   // second key: microservice short name
   // third key : schemaId
-  private Map<String, Map<String, Map<String, Swagger>>> apps = new ConcurrentHashMapEx<>();
+  private final Map<String, Map<String, Map<String, Swagger>>> apps = new ConcurrentHashMapEx<>();
 
   public SwaggerLoader() {
   }

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/version/VersionRuleUtils.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/version/VersionRuleUtils.java
@@ -25,9 +25,9 @@ import java.util.Objects;
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
 
 public final class VersionRuleUtils {
-  private static List<VersionRuleParser> parsers = new ArrayList<>();
+  private static final List<VersionRuleParser> parsers = new ArrayList<>();
 
-  private static Map<String, VersionRule> versionRuleCache = new ConcurrentHashMapEx<>();
+  private static final Map<String, VersionRule> versionRuleCache = new ConcurrentHashMapEx<>();
 
   static {
     parsers.add(new VersionRuleLatestParser());

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/version/VersionUtils.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/version/VersionUtils.java
@@ -24,11 +24,15 @@ import org.apache.servicecomb.foundation.common.Version;
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
 
 public final class VersionUtils {
-  private static Map<String, Version> versionCache = new ConcurrentHashMapEx<>();
+  private static final Map<String, Version> versionCache = new ConcurrentHashMapEx<>();
 
   public static Version getOrCreate(String strVersion) {
     Objects.requireNonNull(strVersion);
 
     return versionCache.computeIfAbsent(strVersion, Version::new);
+  }
+
+  public static void clear() {
+    versionCache.clear();
   }
 }

--- a/foundations/foundation-registry/src/test/java/org/apache/servicecomb/registry/version/TestVersionUtils.java
+++ b/foundations/foundation-registry/src/test/java/org/apache/servicecomb/registry/version/TestVersionUtils.java
@@ -17,32 +17,29 @@
 
 package org.apache.servicecomb.registry.version;
 
-import java.util.concurrent.ConcurrentHashMap;
-
 import org.apache.servicecomb.foundation.common.Version;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
-import mockit.Deencapsulation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestVersionUtils {
-  @Before
+  @BeforeEach
   public void setup() {
-    Deencapsulation.setField(VersionUtils.class, "versionCache", new ConcurrentHashMap<>());
+    VersionUtils.clear();
   }
 
-  @After
+  @AfterEach
   public void teardown() {
-    Deencapsulation.setField(VersionUtils.class, "versionCache", new ConcurrentHashMap<>());
+    VersionUtils.clear();
   }
 
   @Test
   public void getOrCreate() {
     Version v = VersionUtils.getOrCreate("1.0.0");
 
-    Assert.assertEquals("1.0.0.0", v.getVersion());
-    Assert.assertSame(v, VersionUtils.getOrCreate("1.0.0"));
+    Assertions.assertEquals("1.0.0.0", v.getVersion());
+    Assertions.assertSame(v, VersionUtils.getOrCreate("1.0.0"));
   }
 }

--- a/foundations/foundation-spi/src/main/java/org/apache/servicecomb/foundation/auth/SignRequest.java
+++ b/foundations/foundation-spi/src/main/java/org/apache/servicecomb/foundation/auth/SignRequest.java
@@ -37,7 +37,7 @@ public class SignRequest {
   /**
    * Map of the headers included in this request
    */
-  private Map<String, String> headers = new HashMap<>();
+  private final Map<String, String> headers = new HashMap<>();
 
   /**
    * The service endpoint to which this request should be sent
@@ -58,7 +58,7 @@ public class SignRequest {
    * The datetime in milliseconds for which the signature needs to be
    * computed.
    */
-  private long signingDateTimeMilli = System.currentTimeMillis();
+  private final long signingDateTimeMilli = System.currentTimeMillis();
 
   /**
    * The scope of the signature.

--- a/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLSocketFactoryExt.java
+++ b/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLSocketFactoryExt.java
@@ -30,11 +30,11 @@ import javax.net.ssl.SSLSocketFactory;
  *
  */
 public class SSLSocketFactoryExt extends SSLSocketFactory {
-  private SSLSocketFactory sslSocketFactory;
+  private final SSLSocketFactory sslSocketFactory;
 
-  private String[] ciphers;
+  private final String[] ciphers;
 
-  private String[] protos;
+  private final String[] protos;
 
   public SSLSocketFactoryExt(SSLSocketFactory factory, String[] ciphers, String[] protos) {
     this.sslSocketFactory = factory;

--- a/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/TrustManagerExt.java
+++ b/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/TrustManagerExt.java
@@ -50,11 +50,11 @@ public class TrustManagerExt extends X509ExtendedTrustManager {
 
   private static final int WHITE_SIZE = 1024;
 
-  private X509ExtendedTrustManager trustManager;
+  private final X509ExtendedTrustManager trustManager;
 
-  private SSLOption option;
+  private final SSLOption option;
 
-  private SSLCustom custom;
+  private final SSLCustom custom;
 
   public TrustManagerExt(X509ExtendedTrustManager manager, SSLOption option,
       SSLCustom custom) {

--- a/foundations/foundation-ssl/src/test/java/org/apache/servicecomb/foundation/ssl/SSLManagerTest.java
+++ b/foundations/foundation-ssl/src/test/java/org/apache/servicecomb/foundation/ssl/SSLManagerTest.java
@@ -50,7 +50,7 @@ public class SSLManagerTest {
   public void testSSLManagerServerAndClient(final @Mocked NetworkInterface nif) throws Exception {
     final InetAddress ia = Inet4Address.getByName("10.57.65.225");
     final Enumeration<NetworkInterface> interfaces = new Enumeration<NetworkInterface>() {
-      int count = 1;
+      final int count = 1;
 
       int cur = 0;
 
@@ -70,7 +70,7 @@ public class SSLManagerTest {
     };
 
     final Enumeration<InetAddress> ias = new Enumeration<InetAddress>() {
-      int count = 1;
+      final int count = 1;
 
       int cur = 0;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/VertxUtils.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/VertxUtils.java
@@ -59,7 +59,7 @@ public final class VertxUtils {
   private static final long BLOCKED_THREAD_CHECK_INTERVAL = Long.MAX_VALUE / 2;
 
   // key为vertx实例名称，以支撑vertx功能分组
-  private static Map<String, Vertx> vertxMap = new ConcurrentHashMapEx<>();
+  private static final Map<String, Vertx> vertxMap = new ConcurrentHashMapEx<>();
 
   private VertxUtils() {
   }

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/ClientPoolManager.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/ClientPoolManager.java
@@ -39,17 +39,17 @@ import io.vertx.core.Vertx;
  * sync/async is not about net operation, just about consumer invoke mode.
  */
 public class ClientPoolManager<CLIENT_POOL> {
-  private Vertx vertx;
+  private final Vertx vertx;
 
-  private String id = UUID.randomUUID().toString();
+  private final String id = UUID.randomUUID().toString();
 
-  private ClientPoolFactory<CLIENT_POOL> factory;
+  private final ClientPoolFactory<CLIENT_POOL> factory;
 
-  private List<CLIENT_POOL> pools = new CopyOnWriteArrayList<>();
+  private final List<CLIENT_POOL> pools = new CopyOnWriteArrayList<>();
 
   // reactive mode, when call from other thread, must select a context for it
   // if we use threadId to hash a context, will always select the same context from one thread
-  private AtomicInteger reactiveNextIndex = new AtomicInteger();
+  private final AtomicInteger reactiveNextIndex = new AtomicInteger();
 
   public ClientPoolManager(Vertx vertx, ClientPoolFactory<CLIENT_POOL> factory) {
     this.vertx = vertx;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/http/HttpClientPoolFactory.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/http/HttpClientPoolFactory.java
@@ -29,7 +29,7 @@ import io.vertx.core.http.HttpClientOptions;
 public class HttpClientPoolFactory implements ClientPoolFactory<HttpClientWithContext> {
   private static final Logger LOGGER = LoggerFactory.getLogger(HttpClientPoolFactory.class);
 
-  private HttpClientOptions httpClientOptions;
+  private final HttpClientOptions httpClientOptions;
 
   public HttpClientPoolFactory(HttpClientOptions httpClientOptions) {
     this.httpClientOptions = httpClientOptions;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/http/HttpClientWithContext.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/http/HttpClientWithContext.java
@@ -25,9 +25,9 @@ public class HttpClientWithContext {
     void run(HttpClient httpClient);
   }
 
-  private HttpClient httpClient;
+  private final HttpClient httpClient;
 
-  private Context context;
+  private final Context context;
 
   public HttpClientWithContext(HttpClient httpClient, Context context) {
     this.httpClient = httpClient;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/AbstractTcpClientPackage.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/AbstractTcpClientPackage.java
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.servicecomb.foundation.vertx.tcp.TcpOutputStream;
 
 public abstract class AbstractTcpClientPackage {
-  private static AtomicLong reqId = new AtomicLong();
+  private static final AtomicLong reqId = new AtomicLong();
 
   public static long getAndIncRequestId() {
     return reqId.getAndIncrement();

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/NetClientWrapper.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/NetClientWrapper.java
@@ -26,13 +26,13 @@ import io.vertx.core.net.NetSocket;
 // can not support normal and ssl by the same instance
 // so we do this wrap
 public class NetClientWrapper {
-  private TcpClientConfig normalClientConfig;
+  private final TcpClientConfig normalClientConfig;
 
-  private NetClient normalNetClient;
+  private final NetClient normalNetClient;
 
-  private TcpClientConfig sslClientConfig;
+  private final TcpClientConfig sslClientConfig;
 
-  private NetClient sslNetClient;
+  private final NetClient sslNetClient;
 
   public NetClientWrapper(Vertx vertx, TcpClientConfig normalClientConfig, TcpClientConfig sslClientConfig) {
     this.normalClientConfig = normalClientConfig;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpClientConnection.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpClientConnection.java
@@ -53,24 +53,24 @@ public class TcpClientConnection extends TcpConnection {
     WORKING
   }
 
-  private NetClientWrapper netClientWrapper;
+  private final NetClientWrapper netClientWrapper;
 
-  private TcpClientConfig clientConfig;
+  private final TcpClientConfig clientConfig;
 
-  private URIEndpointObject endpoint;
+  private final URIEndpointObject endpoint;
 
-  private InetSocketAddress socketAddress;
+  private final InetSocketAddress socketAddress;
 
   private boolean localSupportLogin = false;
 
-  private boolean remoteSupportLogin;
+  private final boolean remoteSupportLogin;
 
   private volatile Status status = Status.DISCONNECTED;
 
   // save msg before login success.
   // before login, we can not know parameters, like: zip/codec compatible, and so on
   // so can only save package, can not save byteBuf
-  private Queue<AbstractTcpClientPackage> packageQueue = new ConcurrentLinkedQueue<>();
+  private final Queue<AbstractTcpClientPackage> packageQueue = new ConcurrentLinkedQueue<>();
 
   private volatile Map<Long, TcpRequest> requestMap = new ConcurrentHashMap<>();
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpClientPackage.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpClientPackage.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.foundation.vertx.client.tcp;
 import org.apache.servicecomb.foundation.vertx.tcp.TcpOutputStream;
 
 public class TcpClientPackage extends AbstractTcpClientPackage {
-  private TcpOutputStream os;
+  private final TcpOutputStream os;
 
   public TcpClientPackage(TcpOutputStream os) {
     this.os = os;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpRequest.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpRequest.java
@@ -24,15 +24,15 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
 public class TcpRequest {
-  private long begin;
+  private final long begin;
 
-  private long msTimeout;
+  private final long msTimeout;
 
-  private Context callContext;
+  private final Context callContext;
 
-  private long threadId;
+  private final long threadId;
 
-  private TcpResponseCallback responseCallback;
+  private final TcpResponseCallback responseCallback;
 
   public TcpRequest(long msTimeout, TcpResponseCallback responseCallback) {
     callContext = Vertx.currentContext();

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/executor/VertxContextExecutor.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/executor/VertxContextExecutor.java
@@ -31,7 +31,7 @@ public class VertxContextExecutor implements Executor {
     return new VertxContextExecutor(context);
   }
 
-  private Context context;
+  private final Context context;
 
   private VertxContextExecutor(Context context) {
     this.context = context;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/AbstractHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/AbstractHttpServletRequest.java
@@ -43,7 +43,7 @@ import javax.servlet.http.HttpUpgradeHandler;
 import javax.servlet.http.Part;
 
 public abstract class AbstractHttpServletRequest extends BodyBufferSupportImpl implements HttpServletRequestEx {
-  private Map<String, Object> attributeMap = new HashMap<>();
+  private final Map<String, Object> attributeMap = new HashMap<>();
 
   @Override
   public Object getAttribute(String name) {

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/AbstractHttpServletResponse.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/AbstractHttpServletResponse.java
@@ -31,7 +31,7 @@ import javax.servlet.http.Part;
 import javax.ws.rs.core.Response.StatusType;
 
 public abstract class AbstractHttpServletResponse extends BodyBufferSupportImpl implements HttpServletResponseEx {
-  private Map<String, Object> attributes = new HashMap<>();
+  private final Map<String, Object> attributes = new HashMap<>();
 
   @Override
   public String getCharacterEncoding() {

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/FileUploadPart.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/FileUploadPart.java
@@ -28,7 +28,7 @@ import org.apache.servicecomb.foundation.common.part.AbstractPart;
 import io.vertx.ext.web.FileUpload;
 
 public class FileUploadPart extends AbstractPart {
-  private FileUpload fileUpload;
+  private final FileUpload fileUpload;
 
   public FileUploadPart(FileUpload fileUpload) {
     this.fileUpload = fileUpload;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/ReadStreamPart.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/ReadStreamPart.java
@@ -51,9 +51,9 @@ import io.vertx.core.streams.WriteStream;
 public class ReadStreamPart extends AbstractPart {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReadStreamPart.class);
 
-  private Context context;
+  private final Context context;
 
-  private ReadStream<Buffer> readStream;
+  private final ReadStream<Buffer> readStream;
 
   public ReadStreamPart(Context context, HttpClientResponse httpClientResponse) {
     this(context, (ReadStream<Buffer>) httpClientResponse);

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/StandardHttpServletRequestEx.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/StandardHttpServletRequestEx.java
@@ -47,7 +47,7 @@ import io.netty.buffer.Unpooled;
 import io.vertx.core.buffer.Buffer;
 
 public class StandardHttpServletRequestEx extends HttpServletRequestWrapper implements HttpServletRequestEx {
-  private BodyBufferSupport bodyBuffer = new BodyBufferSupportImpl();
+  private final BodyBufferSupport bodyBuffer = new BodyBufferSupportImpl();
 
   private boolean cacheRequest;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/StandardHttpServletResponseEx.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/StandardHttpServletResponseEx.java
@@ -37,9 +37,9 @@ import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 
 public class StandardHttpServletResponseEx extends HttpServletResponseWrapper implements HttpServletResponseEx {
-  private BodyBufferSupport bodyBuffer = new BodyBufferSupportImpl();
+  private final BodyBufferSupport bodyBuffer = new BodyBufferSupportImpl();
 
-  private Map<String, Object> attributes = new HashMap<>();
+  private final Map<String, Object> attributes = new HashMap<>();
 
   private StatusType statusType;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxClientRequestToHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxClientRequestToHttpServletRequest.java
@@ -28,7 +28,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientRequest;
 
 public class VertxClientRequestToHttpServletRequest extends AbstractHttpServletRequest {
-  private HttpClientRequest clientRequest;
+  private final HttpClientRequest clientRequest;
 
   private String characterEncoding;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxClientResponseToHttpServletResponse.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxClientResponseToHttpServletResponse.java
@@ -28,7 +28,7 @@ import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpClientResponse;
 
 public class VertxClientResponseToHttpServletResponse extends AbstractHttpServletResponse {
-  private HttpClientResponse clientResponse;
+  private final HttpClientResponse clientResponse;
 
   private StatusType statusType;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxServerRequestToHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxServerRequestToHttpServletRequest.java
@@ -51,9 +51,9 @@ public class VertxServerRequestToHttpServletRequest extends AbstractHttpServletR
 
   private static final EmptyAsyncContext EMPTY_ASYNC_CONTEXT = new EmptyAsyncContext();
 
-  private RoutingContext context;
+  private final RoutingContext context;
 
-  private HttpServerRequest vertxRequest;
+  private final HttpServerRequest vertxRequest;
 
   private Cookie[] cookies;
 
@@ -61,7 +61,7 @@ public class VertxServerRequestToHttpServletRequest extends AbstractHttpServletR
 
   private String path;
 
-  private SocketAddress socketAddress;
+  private final SocketAddress socketAddress;
 
   // cache from convert vertx parameters to servlet parameters
   private Map<String, String[]> parameterMap;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxServerResponseToHttpServletResponse.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxServerResponseToHttpServletResponse.java
@@ -33,9 +33,9 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServerResponse;
 
 public class VertxServerResponseToHttpServletResponse extends AbstractHttpServletResponse {
-  private Context context;
+  private final Context context;
 
-  private HttpServerResponse serverResponse;
+  private final HttpServerResponse serverResponse;
 
   private StatusType statusType;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultClientEndpointMetric.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultClientEndpointMetric.java
@@ -24,7 +24,7 @@ import com.google.common.annotations.VisibleForTesting;
  * for one listen address, include multiple httpClient or httpServer
  */
 public class DefaultClientEndpointMetric extends DefaultEndpointMetric {
-  private LongAdder queue = new LongAdder();
+  private final LongAdder queue = new LongAdder();
 
   // control if the metric instance will be expired
   // all invoker about incRefCount/isExpired, must lock: DefaultClientEndpointMetricManager

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultClientEndpointMetricManager.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultClientEndpointMetricManager.java
@@ -32,7 +32,7 @@ public class DefaultClientEndpointMetricManager {
 
   // to avoid save too many endpoint that not exist any more
   // must check expired periodically
-  private Map<String, DefaultClientEndpointMetric> clientEndpointMetricMap = new ConcurrentHashMapEx<>();
+  private final Map<String, DefaultClientEndpointMetric> clientEndpointMetricMap = new ConcurrentHashMapEx<>();
 
   // clientEndpointMetricMap is thread safe
   // but get/isExpired/remove is not safe

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultClientTaskMetric.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultClientTaskMetric.java
@@ -18,7 +18,7 @@
 package org.apache.servicecomb.foundation.vertx.metrics.metric;
 
 public class DefaultClientTaskMetric {
-  private DefaultClientEndpointMetric endpointMetric;
+  private final DefaultClientEndpointMetric endpointMetric;
 
   public DefaultClientTaskMetric(DefaultClientEndpointMetric endpointMetric) {
     this.endpointMetric = endpointMetric;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultEndpointMetric.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultEndpointMetric.java
@@ -22,23 +22,23 @@ import java.util.concurrent.atomic.LongAdder;
  * for one listen address, include multiple httpClient or httpServer
  */
 public class DefaultEndpointMetric {
-  private String address;
+  private final String address;
 
   // summary of connect times from boot
   // by this, we can know how many new connections connected recently
-  private LongAdder connectCount = new LongAdder();
+  private final LongAdder connectCount = new LongAdder();
 
   // summary of disconnect times from boot
   // by this, we can know how many connections disconnected recently
-  private LongAdder disconnectCount = new LongAdder();
+  private final LongAdder disconnectCount = new LongAdder();
 
-  private LongAdder bytesRead = new LongAdder();
+  private final LongAdder bytesRead = new LongAdder();
 
-  private LongAdder bytesWritten = new LongAdder();
+  private final LongAdder bytesWritten = new LongAdder();
 
-  private LongAdder requests = new LongAdder();
+  private final LongAdder requests = new LongAdder();
 
-  private LongAdder latency = new LongAdder();
+  private final LongAdder latency = new LongAdder();
 
   public DefaultEndpointMetric(String address) {
     this.address = address;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultServerEndpointMetric.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/metrics/metric/DefaultServerEndpointMetric.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.foundation.vertx.metrics.metric;
 import java.util.concurrent.atomic.LongAdder;
 
 public class DefaultServerEndpointMetric extends DefaultEndpointMetric {
-  private LongAdder rejectByConnectionLimitCount = new LongAdder();
+  private final LongAdder rejectByConnectionLimitCount = new LongAdder();
 
   public DefaultServerEndpointMetric(String address) {
     super(address);

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpParser.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpParser.java
@@ -43,7 +43,7 @@ public class TcpParser implements Handler<Buffer> {
     TCP_PAYLOAD
   }
 
-  private TcpBufferHandler outputHandler;
+  private final TcpBufferHandler outputHandler;
 
   private RecordParser parser;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpServer.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/server/TcpServer.java
@@ -39,7 +39,7 @@ import io.vertx.core.net.impl.NetSocketImpl;
 public class TcpServer {
   private static final Logger LOGGER = LoggerFactory.getLogger(TcpServer.class);
 
-  private URIEndpointObject endpointObject;
+  private final URIEndpointObject endpointObject;
 
   public TcpServer(URIEndpointObject endpointObject) {
     this.endpointObject = endpointObject;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/BufferInputStream.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/BufferInputStream.java
@@ -26,7 +26,7 @@ import javax.servlet.ServletInputStream;
 import io.netty.buffer.ByteBuf;
 
 public class BufferInputStream extends ServletInputStream {
-  private ByteBuf byteBuf;
+  private final ByteBuf byteBuf;
 
   public BufferInputStream(ByteBuf buffer) {
     this.byteBuf = buffer;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/InputStreamToReadStream.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/InputStreamToReadStream.java
@@ -37,9 +37,9 @@ public class InputStreamToReadStream implements ReadStream<Buffer> {
 
   public static final int DEFAULT_READ_BUFFER_SIZE = 1024 * 1024;
 
-  private Context context;
+  private final Context context;
 
-  private InputStream inputStream;
+  private final InputStream inputStream;
 
   private boolean closed;
 
@@ -55,7 +55,7 @@ public class InputStreamToReadStream implements ReadStream<Buffer> {
 
   private Handler<Void> endHandler;
 
-  private boolean autoCloseInputStream;
+  private final boolean autoCloseInputStream;
 
   public InputStreamToReadStream(Context context, InputStream inputStream,
       boolean autoCloseInputStream) {

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/OutputStreamToWriteStream.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/OutputStreamToWriteStream.java
@@ -40,11 +40,11 @@ public class OutputStreamToWriteStream implements WriteStream<Buffer>, AsyncClos
 
   private static final int SMALLEST_MAX_BUFFERS = 2;
 
-  private OutputStream outputStream;
+  private final OutputStream outputStream;
 
-  private Context context;
+  private final Context context;
 
-  private boolean autoCloseOutputStream;
+  private final boolean autoCloseOutputStream;
 
   private Handler<Throwable> exceptionHandler;
 
@@ -58,7 +58,7 @@ public class OutputStreamToWriteStream implements WriteStream<Buffer>, AsyncClos
 
   // buffers.size() need to loop all node, and maybe result is not correct in concurrent condition
   // we just need to flow control by pump, so use another size
-  private Queue<Buffer> buffers = new ConcurrentLinkedQueue<>();
+  private final Queue<Buffer> buffers = new ConcurrentLinkedQueue<>();
 
   private int currentBufferCount;
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/PumpFromPart.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/stream/PumpFromPart.java
@@ -38,9 +38,9 @@ import io.vertx.core.streams.WriteStream;
 public class PumpFromPart {
   private static final Logger LOGGER = LoggerFactory.getLogger(PumpFromPart.class);
 
-  private Context context;
+  private final Context context;
 
-  private Part part;
+  private final Part part;
 
   public PumpFromPart(Context context, Part part) {
     this.context = context;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/tcp/TcpConnection.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/tcp/TcpConnection.java
@@ -49,9 +49,9 @@ public class TcpConnection {
   // so this optimization:
   // 1.avoid vertx's lock
   // 2.reduce netty's task schedule
-  private Queue<ByteBuf> writeQueue = new ConcurrentLinkedQueue<>();
+  private final Queue<ByteBuf> writeQueue = new ConcurrentLinkedQueue<>();
 
-  private AtomicLong writeQueueSize = new AtomicLong();
+  private final AtomicLong writeQueueSize = new AtomicLong();
 
   public String getProtocol() {
     return protocol;

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/tcp/TcpOutputStream.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/tcp/TcpOutputStream.java
@@ -26,7 +26,7 @@ import org.apache.servicecomb.foundation.vertx.stream.BufferOutputStream;
  *
  */
 public class TcpOutputStream extends BufferOutputStream {
-  private long msgId;
+  private final long msgId;
 
   public TcpOutputStream(long msgId) {
     super();

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/client/http/TestHttpClientPoolFactory.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/client/http/TestHttpClientPoolFactory.java
@@ -28,7 +28,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 
 public class TestHttpClientPoolFactory {
-  private HttpClientOptions httpClientOptions = new HttpClientOptions();
+  private final HttpClientOptions httpClientOptions = new HttpClientOptions();
 
   HttpClientPoolFactory factory = new HttpClientPoolFactory(httpClientOptions);
 

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/client/tcp/TestAbstractTcpClientPoolFactory.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/client/tcp/TestAbstractTcpClientPoolFactory.java
@@ -24,9 +24,9 @@ import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 
 public class TestAbstractTcpClientPoolFactory {
-  private TcpClientConfig normalClientConfig = new TcpClientConfig();
+  private final TcpClientConfig normalClientConfig = new TcpClientConfig();
 
-  private TcpClientConfig sslClientConfig = new TcpClientConfig();
+  private final TcpClientConfig sslClientConfig = new TcpClientConfig();
 
   TcpClientPoolFactory factory = new TcpClientPoolFactory(normalClientConfig, sslClientConfig);
 

--- a/governance/src/main/java/org/apache/servicecomb/governance/event/GovernanceConfigurationChangedEvent.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/event/GovernanceConfigurationChangedEvent.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.governance.event;
 import java.util.Set;
 
 public class GovernanceConfigurationChangedEvent {
-  private Set<String> changedConfigurations;
+  private final Set<String> changedConfigurations;
 
   public GovernanceConfigurationChangedEvent(Set<String> changedConfigurations) {
     this.changedConfigurations = changedConfigurations;

--- a/governance/src/main/java/org/apache/servicecomb/governance/event/GovernanceEventManager.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/event/GovernanceEventManager.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.governance.event;
 import com.google.common.eventbus.EventBus;
 
 public class GovernanceEventManager {
-  private static EventBus eventBus = new EventBus();
+  private static final EventBus eventBus = new EventBus();
 
   public static EventBus getEventBus() {
     return eventBus;

--- a/governance/src/main/java/org/apache/servicecomb/governance/handler/AbstractGovernanceHandler.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/handler/AbstractGovernanceHandler.java
@@ -30,7 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import com.google.common.eventbus.Subscribe;
 
 public abstract class AbstractGovernanceHandler<PROCESSOR, POLICY extends AbstractPolicy> {
-  private Map<String, PROCESSOR> map = new ConcurrentHashMap<>();
+  private final Map<String, PROCESSOR> map = new ConcurrentHashMap<>();
 
   private final Object lock = new Object();
 

--- a/governance/src/main/java/org/apache/servicecomb/governance/handler/BulkheadHandler.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/handler/BulkheadHandler.java
@@ -35,7 +35,7 @@ import io.github.resilience4j.bulkhead.BulkheadRegistry;
 public class BulkheadHandler extends AbstractGovernanceHandler<Bulkhead, BulkheadPolicy> {
   private static final Logger LOGGER = LoggerFactory.getLogger(BulkheadHandler.class);
 
-  private BulkheadProperties bulkheadProperties;
+  private final BulkheadProperties bulkheadProperties;
 
   @Autowired
   public BulkheadHandler(BulkheadProperties bulkheadProperties) {

--- a/governance/src/main/java/org/apache/servicecomb/governance/handler/CircuitBreakerHandler.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/handler/CircuitBreakerHandler.java
@@ -34,7 +34,7 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 public class CircuitBreakerHandler extends AbstractGovernanceHandler<CircuitBreaker, CircuitBreakerPolicy> {
   private static final Logger LOGGER = LoggerFactory.getLogger(CircuitBreakerHandler.class);
 
-  private CircuitBreakerProperties circuitBreakerProperties;
+  private final CircuitBreakerProperties circuitBreakerProperties;
 
   @Autowired
   public CircuitBreakerHandler(CircuitBreakerProperties circuitBreakerProperties) {

--- a/governance/src/main/java/org/apache/servicecomb/governance/handler/InstanceIsolationHandler.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/handler/InstanceIsolationHandler.java
@@ -38,7 +38,7 @@ public class InstanceIsolationHandler extends AbstractGovernanceHandler<CircuitB
 
   private static final String DEFAULT_SERVICE_NAME = "default";
 
-  private InstanceIsolationProperties instanceIsolationProperties;
+  private final InstanceIsolationProperties instanceIsolationProperties;
 
   @Autowired
   public InstanceIsolationHandler(InstanceIsolationProperties instanceIsolationProperties) {

--- a/governance/src/main/java/org/apache/servicecomb/governance/handler/RateLimitingHandler.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/handler/RateLimitingHandler.java
@@ -34,7 +34,7 @@ import io.github.resilience4j.ratelimiter.RateLimiterRegistry;
 public class RateLimitingHandler extends AbstractGovernanceHandler<RateLimiter, RateLimitingPolicy> {
   private static final Logger LOGGER = LoggerFactory.getLogger(RateLimitingHandler.class);
 
-  private RateLimitProperties rateLimitProperties;
+  private final RateLimitProperties rateLimitProperties;
 
   @Autowired
   public RateLimitingHandler(RateLimitProperties rateLimitProperties) {

--- a/governance/src/main/java/org/apache/servicecomb/governance/handler/RetryHandler.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/handler/RetryHandler.java
@@ -38,9 +38,9 @@ public class RetryHandler extends AbstractGovernanceHandler<Retry, RetryPolicy> 
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RetryHandler.class);
 
-  private RetryProperties retryProperties;
+  private final RetryProperties retryProperties;
 
-  private RetryExtension retryExtension;
+  private final RetryExtension retryExtension;
 
   @Autowired
   public RetryHandler(RetryProperties retryProperties, RetryExtension retryExtension) {

--- a/governance/src/main/java/org/apache/servicecomb/governance/marker/RequestProcessor.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/marker/RequestProcessor.java
@@ -33,7 +33,7 @@ public class RequestProcessor {
 
   private static final String OPERATOR_SUFFIX = "Operator";
 
-  private Map<String, MatchOperator> operatorMap;
+  private final Map<String, MatchOperator> operatorMap;
 
   @Autowired
   public RequestProcessor(Map<String, MatchOperator> operatorMap) {

--- a/governance/src/main/java/org/apache/servicecomb/governance/marker/operator/CompareOperator.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/marker/operator/CompareOperator.java
@@ -27,7 +27,7 @@ import org.apache.servicecomb.governance.exception.IllegalArgsOperatorException;
 @Component
 public class CompareOperator implements MatchOperator {
 
-  private Set<Character> charSet = new HashSet<>();
+  private final Set<Character> charSet = new HashSet<>();
 
   public CompareOperator() {
     charSet.add('>');

--- a/governance/src/main/java/org/apache/servicecomb/governance/service/MatchersServiceImpl.java
+++ b/governance/src/main/java/org/apache/servicecomb/governance/service/MatchersServiceImpl.java
@@ -28,9 +28,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MatchersServiceImpl implements MatchersService {
-  private RequestProcessor requestProcessor;
+  private final RequestProcessor requestProcessor;
 
-  private MatchProperties matchProperties;
+  private final MatchProperties matchProperties;
 
   @Autowired
   public MatchersServiceImpl(RequestProcessor requestProcessor, MatchProperties matchProperties) {

--- a/governance/src/main/java/org/apache/servicecomb/router/RouterFilter.java
+++ b/governance/src/main/java/org/apache/servicecomb/router/RouterFilter.java
@@ -35,9 +35,9 @@ public class RouterFilter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RouterFilter.class);
 
-  private RouterRuleMatcher routerRuleMatcher;
+  private final RouterRuleMatcher routerRuleMatcher;
 
-  private RouterRuleCache routerRuleCache;
+  private final RouterRuleCache routerRuleCache;
 
   @Autowired
   public RouterFilter(RouterRuleMatcher routerRuleMatcher, RouterRuleCache routerRuleCache) {

--- a/governance/src/test/java/org/apache/servicecomb/governance/MockInvocationContext.java
+++ b/governance/src/test/java/org/apache/servicecomb/governance/MockInvocationContext.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class MockInvocationContext implements InvocationContext {
-  private ThreadLocal<Map<String, Boolean>> context = new ThreadLocal<>();
+  private final ThreadLocal<Map<String, Boolean>> context = new ThreadLocal<>();
 
   @Override
   public Map<String, Boolean> getCalculatedMatches() {

--- a/governance/src/test/java/org/apache/servicecomb/router/RouterDistributorTest.java
+++ b/governance/src/test/java/org/apache/servicecomb/router/RouterDistributorTest.java
@@ -91,7 +91,7 @@ public class RouterDistributorTest {
   public RouterDistributorTest() {
   }
 
-  private Map<String, Object> dynamicValues = new HashMap<>();
+  private final Map<String, Object> dynamicValues = new HashMap<>();
 
   @Before
   public void setUp() {

--- a/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/BizkeeperHandler.java
+++ b/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/BizkeeperHandler.java
@@ -61,7 +61,7 @@ public abstract class BizkeeperHandler implements Handler {
     }
   }
 
-  private BizkeeperHandlerDelegate delegate;
+  private final BizkeeperHandlerDelegate delegate;
 
   public BizkeeperHandler(String groupname) {
     this.groupname = groupname;

--- a/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/BizkeeperHandlerDelegate.java
+++ b/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/BizkeeperHandlerDelegate.java
@@ -28,7 +28,7 @@ import rx.subjects.ReplaySubject;
 
 public class BizkeeperHandlerDelegate {
 
-  private BizkeeperHandler handler;
+  private final BizkeeperHandler handler;
 
   public BizkeeperHandlerDelegate(BizkeeperHandler handler) {
     this.handler = handler;

--- a/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/BizkeeperRequestContext.java
+++ b/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/BizkeeperRequestContext.java
@@ -24,7 +24,7 @@ import com.netflix.hystrix.strategy.concurrency.HystrixRequestContext;
  *
  */
 public final class BizkeeperRequestContext {
-  private HystrixRequestContext context;
+  private final HystrixRequestContext context;
 
   private BizkeeperRequestContext(HystrixRequestContext context) {
     this.context = context;

--- a/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/FromCacheFallbackPolicy.java
+++ b/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/FromCacheFallbackPolicy.java
@@ -27,7 +27,7 @@ import org.springframework.stereotype.Component;
 public class FromCacheFallbackPolicy implements FallbackPolicy {
   private static final String POLICY_NAME = "fromCache";
 
-  private Map<String, Response> cachedResponse = new ConcurrentHashMap<>();
+  private final Map<String, Response> cachedResponse = new ConcurrentHashMap<>();
 
   @Override
   public String name() {

--- a/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/event/CircutBreakerEventNotifier.java
+++ b/handlers/handler-bizkeeper/src/main/java/org/apache/servicecomb/bizkeeper/event/CircutBreakerEventNotifier.java
@@ -33,7 +33,7 @@ public class CircutBreakerEventNotifier extends HystrixEventNotifier {
   /**
    * 使用circuitFlag来记录被熔断的接口
    */
-  private ConcurrentHashMapEx<String, AtomicBoolean> circuitFlag = new ConcurrentHashMapEx<>();
+  private final ConcurrentHashMapEx<String, AtomicBoolean> circuitFlag = new ConcurrentHashMapEx<>();
 
   EventBus eventBus = EventManager.getEventBus();
 

--- a/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultExecutor.java
+++ b/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultExecutor.java
@@ -28,13 +28,13 @@ import org.apache.servicecomb.swagger.invocation.Response;
  * Implements the fault feature execution one after other.
  */
 public class FaultExecutor {
-  private List<Fault> faultInjectList;
+  private final List<Fault> faultInjectList;
 
   private int handlerIndex = 0;
 
-  private Invocation invocation;
+  private final Invocation invocation;
 
-  private FaultParam param;
+  private final FaultParam param;
 
   public FaultExecutor(List<Fault> faultInjectList, Invocation invocation, FaultParam param) {
     this.faultInjectList = faultInjectList;

--- a/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultInjectionConfig.java
+++ b/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultInjectionConfig.java
@@ -36,7 +36,7 @@ public final class FaultInjectionConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(FaultInjectionConfig.class);
 
   // key is configuration parameter.
-  private static Map<String, String> cfgCallback = new ConcurrentHashMapEx<>();
+  private static final Map<String, String> cfgCallback = new ConcurrentHashMapEx<>();
 
   public static int getConfigVal(String config, int defaultValue) {
     DynamicIntProperty dynamicIntProperty = DynamicPropertyFactory.getInstance().getIntProperty(config,

--- a/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultInjectionUtil.java
+++ b/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultInjectionUtil.java
@@ -37,10 +37,10 @@ public class FaultInjectionUtil {
   }
 
   // key is transport+operQualifiedName
-  private static Map<String, AtomicLong> requestCount = new ConcurrentHashMapEx<>();
+  private static final Map<String, AtomicLong> requestCount = new ConcurrentHashMapEx<>();
 
   // key is config paramter
-  private static Map<String, AtomicInteger> configCenterValue = new ConcurrentHashMapEx<>();
+  private static final Map<String, AtomicInteger> configCenterValue = new ConcurrentHashMapEx<>();
 
   /**
    * Returns total requests per provider for operational level.

--- a/handlers/handler-flowcontrol-qps/src/main/java/org/apache/servicecomb/qps/strategy/FixedWindowStrategy.java
+++ b/handlers/handler-flowcontrol-qps/src/main/java/org/apache/servicecomb/qps/strategy/FixedWindowStrategy.java
@@ -29,7 +29,7 @@ public class FixedWindowStrategy extends AbstractQpsStrategy {
   private volatile long msCycleBegin;
 
   // Request count between Interval begin and now in one interval
-  private AtomicLong requestCount = new AtomicLong();
+  private final AtomicLong requestCount = new AtomicLong();
 
   // request count  before an interval
   private volatile long lastRequestCount = 1;

--- a/handlers/handler-flowcontrol-qps/src/main/java/org/apache/servicecomb/qps/strategy/LeakyBucketStrategy.java
+++ b/handlers/handler-flowcontrol-qps/src/main/java/org/apache/servicecomb/qps/strategy/LeakyBucketStrategy.java
@@ -33,7 +33,7 @@ public class LeakyBucketStrategy extends AbstractQpsStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(LeakyBucketStrategy.class);
 
   // Request count between Interval begin and now in one interval
-  private volatile AtomicLong requestCount = new AtomicLong();
+  private final AtomicLong requestCount = new AtomicLong();
 
   private volatile long lastTime;
 

--- a/handlers/handler-governance/src/main/java/org/apache/servicecomb/handler/governance/ProviderGovernanceHandler.java
+++ b/handlers/handler-governance/src/main/java/org/apache/servicecomb/handler/governance/ProviderGovernanceHandler.java
@@ -49,11 +49,11 @@ import io.github.resilience4j.ratelimiter.RequestNotPermitted;
 public class ProviderGovernanceHandler implements Handler {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProviderGovernanceHandler.class);
 
-  private RateLimitingHandler rateLimitingHandler = BeanUtils.getBean(RateLimitingHandler.class);
+  private final RateLimitingHandler rateLimitingHandler = BeanUtils.getBean(RateLimitingHandler.class);
 
-  private CircuitBreakerHandler circuitBreakerHandler = BeanUtils.getBean(CircuitBreakerHandler.class);
+  private final CircuitBreakerHandler circuitBreakerHandler = BeanUtils.getBean(CircuitBreakerHandler.class);
 
-  private BulkheadHandler bulkheadHandler = BeanUtils.getBean(BulkheadHandler.class);
+  private final BulkheadHandler bulkheadHandler = BeanUtils.getBean(BulkheadHandler.class);
 
   @Override
   public void handle(Invocation invocation, AsyncResponse asyncResp) throws Exception {

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/LoadBalancer.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/LoadBalancer.java
@@ -34,13 +34,13 @@ import com.netflix.loadbalancer.LoadBalancerStats;
 public class LoadBalancer {
   private static final Logger LOGGER = LoggerFactory.getLogger(LoadBalancer.class);
 
-  private static AtomicInteger id = new AtomicInteger(0);
+  private static final AtomicInteger id = new AtomicInteger(0);
 
-  private RuleExt rule;
+  private final RuleExt rule;
 
-  private LoadBalancerStats lbStats;
+  private final LoadBalancerStats lbStats;
 
-  private String microServiceName;
+  private final String microServiceName;
 
   private List<ServerListFilterExt> filters;
 

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RoundRobinRuleExt.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RoundRobinRuleExt.java
@@ -26,7 +26,7 @@ import org.apache.servicecomb.core.Invocation;
  * A round robin rule
  */
 public class RoundRobinRuleExt implements RuleExt {
-  private AtomicInteger counter = new AtomicInteger(0);
+  private final AtomicInteger counter = new AtomicInteger(0);
 
   @Override
   public ServiceCombServer choose(List<ServiceCombServer> servers, Invocation invocation) {

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/ServiceCombLoadBalancerStats.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/ServiceCombLoadBalancerStats.java
@@ -53,7 +53,7 @@ public class ServiceCombLoadBalancerStats {
 
   private LoadingCache<ServiceCombServer, ServiceCombServerStats> serverStatsCache;
 
-  private Map<String, ServiceCombServer> serviceCombServers = new ConcurrentHashMap<>();
+  private final Map<String, ServiceCombServer> serviceCombServers = new ConcurrentHashMap<>();
 
   public static ServiceCombLoadBalancerStats INSTANCE;
 
@@ -156,7 +156,7 @@ public class ServiceCombLoadBalancerStats {
 
     timer = new Timer("LoadBalancerStatsTimer", true);
     timer.schedule(new TimerTask() {
-      private MicroserviceInstancePing ping = SPIServiceUtils.getPriorityHighestService(MicroserviceInstancePing.class);
+      private final MicroserviceInstancePing ping = SPIServiceUtils.getPriorityHighestService(MicroserviceInstancePing.class);
 
       @Override
       public void run() {

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/ServiceCombServerStats.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/ServiceCombServerStats.java
@@ -65,7 +65,7 @@ public class ServiceCombServerStats {
 
   private boolean isolated = false;
 
-  private String microserviceName;
+  private final String microserviceName;
 
   public ServiceCombServerStats(String microserviceName) {
     this(microserviceName, TimeUtils.getSystemDefaultZoneClock());

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/SessionStickinessRule.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/SessionStickinessRule.java
@@ -39,7 +39,7 @@ public class SessionStickinessRule implements RuleExt {
   private LoadBalancer loadBalancer;
 
   // use random rule as the trigger rule, to prevent consumer instance select the same producer instance.
-  private RuleExt triggerRule;
+  private final RuleExt triggerRule;
 
   private volatile ServiceCombServer lastServer = null;
 

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/event/IsolationServerEvent.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/event/IsolationServerEvent.java
@@ -25,30 +25,30 @@ import org.apache.servicecomb.registry.api.registry.MicroserviceInstance;
 
 public class IsolationServerEvent extends AlarmEvent {
 
-  private String microserviceName;
+  private final String microserviceName;
 
-  private Endpoint endpoint;
+  private final Endpoint endpoint;
 
-  private MicroserviceInstance instance;
+  private final MicroserviceInstance instance;
 
   //当前实例总请求数
-  private long currentTotalRequest;
+  private final long currentTotalRequest;
 
   //当前实例连续出错次数
-  private long currentCountinuousFailureCount;
+  private final long currentCountinuousFailureCount;
 
   //当前实例出错百分比
-  private double currentErrorPercentage;
+  private final double currentErrorPercentage;
 
-  private int minIsolationTime;
+  private final int minIsolationTime;
 
-  private long enableRequestThreshold;
+  private final long enableRequestThreshold;
 
-  private int continuousFailureThreshold;
+  private final int continuousFailureThreshold;
 
-  private int errorThresholdPercentage;
+  private final int errorThresholdPercentage;
 
-  private long singleTestTime;
+  private final long singleTestTime;
 
   public IsolationServerEvent(Invocation invocation, MicroserviceInstance instance,
       ServiceCombServerStats serverStats,

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestExtensionsManager.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestExtensionsManager.java
@@ -21,21 +21,21 @@ import java.util.List;
 
 import org.apache.servicecomb.config.ConfigUtil;
 import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
 
 import mockit.Deencapsulation;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class TestExtensionsManager {
-  @Before
+  @BeforeEach
   public void setUp() {
     ConfigUtil.createLocalConfig();
     Deencapsulation.setField(ExtensionsManager.class, "extentionFactories", new ArrayList<>());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     Deencapsulation.setField(ExtensionsManager.class, "extentionFactories", new ArrayList<>());
     ArchaiusUtils.resetConfig();
@@ -54,13 +54,13 @@ public class TestExtensionsManager {
     Deencapsulation.setField(holder, "extentionsFactories", extensionsFactories);
     holder.init();
 
-    Assert.assertEquals(RoundRobinRuleExt.class.getName(),
+    Assertions.assertEquals(RoundRobinRuleExt.class.getName(),
         ExtensionsManager.createLoadBalancerRule("mytest1").getClass().getName());
-    Assert.assertEquals(RandomRuleExt.class.getName(),
+    Assertions.assertEquals(RandomRuleExt.class.getName(),
         ExtensionsManager.createLoadBalancerRule("mytest2").getClass().getName());
-    Assert.assertEquals(WeightedResponseTimeRuleExt.class.getName(),
+    Assertions.assertEquals(WeightedResponseTimeRuleExt.class.getName(),
         ExtensionsManager.createLoadBalancerRule("mytest3").getClass().getName());
-    Assert.assertEquals(SessionStickinessRule.class.getName(),
+    Assertions.assertEquals(SessionStickinessRule.class.getName(),
         ExtensionsManager.createLoadBalancerRule("mytest4").getClass().getName());
 
     System.getProperties().remove("servicecomb.loadbalance.mytest1.strategy.name");

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalancer.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalancer.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 public class TestLoadBalancer {
-  private RuleExt rule = Mockito.mock(RuleExt.class);
+  private final RuleExt rule = Mockito.mock(RuleExt.class);
 
   @Test
   public void testLoadBalancerFullOperationWithoutException() {

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestServiceCombServer.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestServiceCombServer.java
@@ -33,7 +33,7 @@ import org.mockito.Mockito;
  */
 public class TestServiceCombServer {
 
-  private Transport transport = Mockito.mock(Transport.class);
+  private final Transport transport = Mockito.mock(Transport.class);
 
   private ServiceCombServer cs;
 

--- a/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/consumer/RSAConsumerTokenManager.java
+++ b/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/consumer/RSAConsumerTokenManager.java
@@ -29,7 +29,7 @@ public class RSAConsumerTokenManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RSAConsumerTokenManager.class);
 
-  private Object lock = new Object();
+  private final Object lock = new Object();
 
   private RSAAuthenticationToken token;
 

--- a/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/provider/ProviderAuthHanlder.java
+++ b/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/provider/ProviderAuthHanlder.java
@@ -25,7 +25,7 @@ import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
 
 public class ProviderAuthHanlder implements Handler {
 
-  private RSAProviderTokenManager authenticationTokenManager = new RSAProviderTokenManager();
+  private final RSAProviderTokenManager authenticationTokenManager = new RSAProviderTokenManager();
 
   @Override
   public void handle(Invocation invocation, AsyncResponse asyncResp) throws Exception {

--- a/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/provider/RSAProviderTokenManager.java
+++ b/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/provider/RSAProviderTokenManager.java
@@ -38,11 +38,11 @@ public class RSAProviderTokenManager {
 
   private final static Logger LOGGER = LoggerFactory.getLogger(RSAProviderTokenManager.class);
 
-  private Cache<RSAAuthenticationToken, Boolean> validatedToken = CacheBuilder.newBuilder()
+  private final Cache<RSAAuthenticationToken, Boolean> validatedToken = CacheBuilder.newBuilder()
       .expireAfterAccess(getExpiredTime(), TimeUnit.MILLISECONDS)
       .build();
 
-  private AccessController accessController = new AccessController();
+  private final AccessController accessController = new AccessController();
 
   public boolean valid(String token) {
     try {

--- a/handlers/handler-router/src/main/java/org/apache/servicecomb/router/custom/MicroserviceCache.java
+++ b/handlers/handler-router/src/main/java/org/apache/servicecomb/router/custom/MicroserviceCache.java
@@ -24,9 +24,9 @@ import org.apache.servicecomb.registry.api.registry.Microservice;
 
 public final class MicroserviceCache {
 
-  private static MicroserviceCache instance = new MicroserviceCache();
+  private static final MicroserviceCache instance = new MicroserviceCache();
 
-  private Map<String, Microservice> services = new HashMap<>();
+  private final Map<String, Microservice> services = new HashMap<>();
 
   private MicroserviceCache() {
   }

--- a/handlers/handler-router/src/main/java/org/apache/servicecomb/router/custom/RouterServerListFilter.java
+++ b/handlers/handler-router/src/main/java/org/apache/servicecomb/router/custom/RouterServerListFilter.java
@@ -47,10 +47,10 @@ public class RouterServerListFilter implements ServerListFilterExt {
   public static final String ROUTER_HEADER = "X-RouterContext";
 
   @SuppressWarnings("unchecked")
-  private RouterDistributor<ServiceCombServer, Microservice> routerDistributor = BeanUtils
+  private final RouterDistributor<ServiceCombServer, Microservice> routerDistributor = BeanUtils
       .getBean(RouterDistributor.class);
 
-  private RouterFilter routerFilter = BeanUtils.getBean(RouterFilter.class);
+  private final RouterFilter routerFilter = BeanUtils.getBean(RouterFilter.class);
 
   @Override
   public boolean enabled() {

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchRule.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchRule.java
@@ -38,7 +38,7 @@ public class DarklaunchRule {
 
   private PolicyType policyType;
 
-  private List<DarklaunchRuleItem> ruleItems = new ArrayList<>();
+  private final List<DarklaunchRuleItem> ruleItems = new ArrayList<>();
 
   public static DarklaunchRule parse(String ruleStr) {
     if (StringUtils.isEmpty(ruleStr)) {

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchRuleItem.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchRuleItem.java
@@ -30,7 +30,7 @@ public class DarklaunchRuleItem {
 
   private Condition policyCondition;
 
-  private List<ServiceCombServer> servers = new ArrayList<ServiceCombServer>();
+  private final List<ServiceCombServer> servers = new ArrayList<ServiceCombServer>();
 
   public DarklaunchRuleItem(String groupName) {
     this.groupName = groupName;

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchServerListFilter.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/DarklaunchServerListFilter.java
@@ -36,7 +36,7 @@ public class DarklaunchServerListFilter implements ServerListFilterExt {
 
   private static final int HUNDRED = 100;
 
-  private Random random = new Random();
+  private final Random random = new Random();
 
   public DarklaunchServerListFilter() {
   }

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/MicroserviceCache.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/MicroserviceCache.java
@@ -24,9 +24,9 @@ import org.apache.servicecomb.registry.api.registry.Microservice;
 import org.apache.servicecomb.serviceregistry.RegistryUtils;
 
 public final class MicroserviceCache {
-  private static MicroserviceCache instance = new MicroserviceCache();
+  private static final MicroserviceCache instance = new MicroserviceCache();
 
-  private Map<String, Microservice> services = new HashMap<>();
+  private final Map<String, Microservice> services = new HashMap<>();
 
   private MicroserviceCache() {
   }

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/AbstractCondition.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/AbstractCondition.java
@@ -18,9 +18,9 @@
 package org.apache.servicecomb.darklaunch.oper;
 
 public abstract class AbstractCondition implements Condition {
-  private String key;
+  private final String key;
 
-  private String expected;
+  private final String expected;
 
   private Object actual;
 

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/AndCondition.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/AndCondition.java
@@ -18,7 +18,7 @@
 package org.apache.servicecomb.darklaunch.oper;
 
 public class AndCondition extends AbstractCondition {
-  private Condition[] conditions;
+  private final Condition[] conditions;
 
   public AndCondition(Condition... conditions) {
     super("and", "and");

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/CaseInsensitiveCondition.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/CaseInsensitiveCondition.java
@@ -18,7 +18,7 @@
 package org.apache.servicecomb.darklaunch.oper;
 
 public class CaseInsensitiveCondition extends AbstractCondition {
-  private Condition condition;
+  private final Condition condition;
 
   public CaseInsensitiveCondition(Condition condition) {
     super(condition.key(), condition.expected());

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/LikeCondition.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/LikeCondition.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.darklaunch.oper;
 import java.util.regex.Pattern;
 
 public class LikeCondition extends AbstractCondition {
-  private Pattern pattern;
+  private final Pattern pattern;
 
   public LikeCondition(String key, String expected) {
     super(key, expected);

--- a/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/OrCondition.java
+++ b/huawei-cloud/darklaunch/src/main/java/org/apache/servicecomb/darklaunch/oper/OrCondition.java
@@ -18,7 +18,7 @@
 package org.apache.servicecomb.darklaunch.oper;
 
 public class OrCondition extends AbstractCondition {
-  private Condition[] conditions;
+  private final Condition[] conditions;
 
   public OrCondition(Condition... conditions) {
     super("or", "or");

--- a/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/HealthMonitorDataProvider.java
+++ b/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/HealthMonitorDataProvider.java
@@ -47,7 +47,7 @@ public class HealthMonitorDataProvider implements MonitorDaraProvider {
 
   private InstanceCacheSummary instanceCacheSummary;
 
-  private Object lock = new Object();
+  private final Object lock = new Object();
 
   @Override
   public String getURL() {

--- a/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/SignUtil.java
+++ b/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/SignUtil.java
@@ -36,7 +36,7 @@ import java.util.Map;
 public class SignUtil {
   private static final Logger LOGGER = LoggerFactory.getLogger(SignUtil.class);
 
-  private static List<AuthHeaderProvider> authHeaderProviders = SPIServiceUtils.
+  private static final List<AuthHeaderProvider> authHeaderProviders = SPIServiceUtils.
       getSortedService(AuthHeaderProvider.class);
 
   public static SignRequest createSignRequest(String method, String endpoint, Map<String, String>

--- a/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/data/CPUMonitorCalc.java
+++ b/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/data/CPUMonitorCalc.java
@@ -25,11 +25,11 @@ import java.lang.management.ThreadMXBean;
 public class CPUMonitorCalc {
   private static final int PERCENTAGE = 100;
 
-  private static CPUMonitorCalc instance = new CPUMonitorCalc();
+  private static final CPUMonitorCalc instance = new CPUMonitorCalc();
 
-  private OperatingSystemMXBean osMxBean;
+  private final OperatingSystemMXBean osMxBean;
 
-  private ThreadMXBean threadMXBean;
+  private final ThreadMXBean threadMXBean;
 
   private long preTime = System.nanoTime();
 

--- a/huawei-cloud/dashboard/src/test/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/AddressManagerTest.java
+++ b/huawei-cloud/dashboard/src/test/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/AddressManagerTest.java
@@ -32,7 +32,7 @@ import mockit.Deencapsulation;
 
 class AddressManagerTest {
 
-  private static List<String> addresses = new ArrayList<>();
+  private static final List<String> addresses = new ArrayList<>();
 
   private static AddressManager addressManager1;
 

--- a/huawei-cloud/servicestage/src/main/java/org/apache/servicecomb/huaweicloud/servicestage/AKSKAuthHeaderProvider.java
+++ b/huawei-cloud/servicestage/src/main/java/org/apache/servicecomb/huaweicloud/servicestage/AKSKAuthHeaderProvider.java
@@ -63,13 +63,13 @@ public class AKSKAuthHeaderProvider implements AuthHeaderProvider {
 
   private static final String X_SERVICE_PROJECT = "X-Service-Project";
 
-  private Map<String, String> headers = new HashMap<>();
+  private final Map<String, String> headers = new HashMap<>();
 
   private final Configuration configuration;
 
   private boolean enabled;
 
-  private boolean loaded = false;
+  private final boolean loaded = false;
 
   public AKSKAuthHeaderProvider() {
     this(ConfigUtil.createLocalConfig());

--- a/huawei-cloud/servicestage/src/main/java/org/apache/servicecomb/huaweicloud/servicestage/CasEnvConfig.java
+++ b/huawei-cloud/servicestage/src/main/java/org/apache/servicecomb/huaweicloud/servicestage/CasEnvConfig.java
@@ -40,7 +40,7 @@ public class CasEnvConfig {
 
   public static final CasEnvConfig INSTANCE = new CasEnvConfig();
 
-  private Map<String, String> properties = new HashMap<>();
+  private final Map<String, String> properties = new HashMap<>();
 
   private CasEnvConfig() {
     init();

--- a/metrics/metrics-core/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorPublishModelFactory.java
+++ b/metrics/metrics-core/src/main/java/com/netflix/spectator/api/patterns/ThreadPoolMonitorPublishModelFactory.java
@@ -31,9 +31,9 @@ public class ThreadPoolMonitorPublishModelFactory {
     void set(ThreadPoolPublishModel model, Measurement measurement);
   }
 
-  private MeasurementTree tree;
+  private final MeasurementTree tree;
 
-  private Map<String, ThreadPoolPublishModel> threadPools;
+  private final Map<String, ThreadPoolPublishModel> threadPools;
 
   public ThreadPoolMonitorPublishModelFactory(MeasurementTree tree,
       Map<String, ThreadPoolPublishModel> threadPools) {

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MetricsBootListener.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/MetricsBootListener.java
@@ -28,7 +28,7 @@ import org.apache.servicecomb.metrics.core.publish.SlowInvocationLogger;
 import com.netflix.config.DynamicPropertyFactory;
 
 public class MetricsBootListener implements BootListener {
-  private MetricsBootstrap metricsBootstrap = new MetricsBootstrap();
+  private final MetricsBootstrap metricsBootstrap = new MetricsBootstrap();
 
   private SlowInvocationLogger slowInvocationLogger;
 

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/ConsumerMeters.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/ConsumerMeters.java
@@ -22,7 +22,7 @@ import org.apache.servicecomb.metrics.core.meter.invocation.ConsumerInvocationMe
 import com.netflix.spectator.api.Registry;
 
 public class ConsumerMeters {
-  private AbstractInvocationMeters invocationMeters;
+  private final AbstractInvocationMeters invocationMeters;
 
   public ConsumerMeters(Registry registry) {
     invocationMeters = new ConsumerInvocationMeters(registry);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/EdgeMeters.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/EdgeMeters.java
@@ -23,7 +23,7 @@ import org.apache.servicecomb.metrics.core.meter.invocation.EdgeInvocationMeters
 import com.netflix.spectator.api.Registry;
 
 public class EdgeMeters {
-  private AbstractInvocationMeters invocationMeters;
+  private final AbstractInvocationMeters invocationMeters;
 
 
   public EdgeMeters(Registry registry) {

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/ProducerMeters.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/ProducerMeters.java
@@ -22,7 +22,7 @@ import org.apache.servicecomb.metrics.core.meter.invocation.ProducerInvocationMe
 import com.netflix.spectator.api.Registry;
 
 public class ProducerMeters {
-  private AbstractInvocationMeters invocationMeters;
+  private final AbstractInvocationMeters invocationMeters;
 
   public ProducerMeters(Registry registry) {
     invocationMeters = new ProducerInvocationMeters(registry);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/AbstractInvocationMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/AbstractInvocationMeter.java
@@ -34,19 +34,19 @@ public abstract class AbstractInvocationMeter extends AbstractPeriodMeter {
   private final Registry registry;
 
   //total time
-  private SimpleTimer totalTimer;
+  private final SimpleTimer totalTimer;
 
   // prepare time
-  private SimpleTimer prepareTimer;
+  private final SimpleTimer prepareTimer;
 
   // handler request
-  private SimpleTimer handlersRequestTimer;
+  private final SimpleTimer handlersRequestTimer;
 
   // handler response
-  private SimpleTimer handlersResponseTimer;
+  private final SimpleTimer handlersResponseTimer;
 
   // latency distribution
-  private LatencyDistributionMeter latencyDistributionMeter;
+  private final LatencyDistributionMeter latencyDistributionMeter;
 
   private long lastUpdated;
 

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/AbstractInvocationMeters.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/AbstractInvocationMeters.java
@@ -31,7 +31,7 @@ import com.netflix.spectator.api.SpectatorUtils;
 public abstract class AbstractInvocationMeters {
   protected Registry registry;
 
-  private Map<String, AbstractInvocationMeter> metersMap = new ConcurrentHashMapEx<>();
+  private final Map<String, AbstractInvocationMeter> metersMap = new ConcurrentHashMapEx<>();
 
   // not care for concurrency, just for make build key faster 
   private int maxKeyLen = 64;

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/ConsumerInvocationMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/ConsumerInvocationMeter.java
@@ -27,19 +27,19 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 
 public class ConsumerInvocationMeter extends AbstractInvocationMeter {
-  private SimpleTimer clientFiltersRequestTimer;
+  private final SimpleTimer clientFiltersRequestTimer;
 
-  private SimpleTimer consumerSendRequestTimer;
+  private final SimpleTimer consumerSendRequestTimer;
 
-  private SimpleTimer consumerGetConnectionTimer;
+  private final SimpleTimer consumerGetConnectionTimer;
 
-  private SimpleTimer consumerWriteToBufTimer;
+  private final SimpleTimer consumerWriteToBufTimer;
 
-  private SimpleTimer consumerWaitResponseTimer;
+  private final SimpleTimer consumerWaitResponseTimer;
 
-  private SimpleTimer consumerWakeConsumerTimer;
+  private final SimpleTimer consumerWakeConsumerTimer;
 
-  private SimpleTimer clientFiltersResponseTimer;
+  private final SimpleTimer clientFiltersResponseTimer;
 
   public ConsumerInvocationMeter(Registry registry, Id id) {
     super(registry, id);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/EdgeInvocationMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/EdgeInvocationMeter.java
@@ -28,13 +28,13 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 
 public class EdgeInvocationMeter extends ConsumerInvocationMeter {
-  private SimpleTimer executorQueueTimer;
+  private final SimpleTimer executorQueueTimer;
 
-  private SimpleTimer serverFiltersRequestTimer;
+  private final SimpleTimer serverFiltersRequestTimer;
 
-  private SimpleTimer serverFiltersResponseTimer;
+  private final SimpleTimer serverFiltersResponseTimer;
 
-  private SimpleTimer sendResponseTimer;
+  private final SimpleTimer sendResponseTimer;
 
   public EdgeInvocationMeter(Registry registry, Id id) {
     super(registry, id);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/ProducerInvocationMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/invocation/ProducerInvocationMeter.java
@@ -27,15 +27,15 @@ import com.netflix.spectator.api.Measurement;
 import com.netflix.spectator.api.Registry;
 
 public class ProducerInvocationMeter extends AbstractInvocationMeter {
-  private SimpleTimer executorQueueTimer;
+  private final SimpleTimer executorQueueTimer;
 
-  private SimpleTimer executionTimer;
+  private final SimpleTimer executionTimer;
 
-  private SimpleTimer serverFiltersRequestTimer;
+  private final SimpleTimer serverFiltersRequestTimer;
 
-  private SimpleTimer serverFiltersResponseTimer;
+  private final SimpleTimer serverFiltersResponseTimer;
 
-  private SimpleTimer sendResponseTimer;
+  private final SimpleTimer sendResponseTimer;
 
   public ProducerInvocationMeter(Registry registry, Id id) {
     super(registry, id);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/CpuMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/CpuMeter.java
@@ -30,10 +30,10 @@ public class CpuMeter {
   private static final Logger LOGGER = LoggerFactory.getLogger(CpuMeter.class);
 
   // read from /proc/stat
-  private OsCpuUsage allCpuUsage;
+  private final OsCpuUsage allCpuUsage;
 
   // read from /proc/self/stat /proc/uptime
-  private ProcessCpuUsage processCpuUsage;
+  private final ProcessCpuUsage processCpuUsage;
 
   public CpuMeter(Id id) {
     allCpuUsage = new OsCpuUsage(id.withTag(OsMeter.OS_TYPE, OsMeter.OS_TYPE_ALL_CPU));

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/NetMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/NetMeter.java
@@ -53,7 +53,7 @@ public class NetMeter {
 
   private final Id id;
 
-  private Map<String, InterfaceUsage> interfaceUsageMap = new ConcurrentHashMap<>();
+  private final Map<String, InterfaceUsage> interfaceUsageMap = new ConcurrentHashMap<>();
 
   public NetMeter(Id id) {
     this.id = id;

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/OsMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/OsMeter.java
@@ -44,9 +44,9 @@ public class OsMeter extends AbstractPeriodMeter {
 
   public static final String OS_TYPE_NET = "net";
 
-  private CpuMeter cpuMeter;
+  private final CpuMeter cpuMeter;
 
-  private NetMeter netMeter;
+  private final NetMeter netMeter;
 
   public OsMeter(Registry registry) {
     this.id = registry.createId(OS_NAME);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/cpu/OsCpuUsage.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/cpu/OsCpuUsage.java
@@ -33,9 +33,9 @@ import com.netflix.spectator.api.Id;
  */
 public class OsCpuUsage extends AbstractCpuUsage {
 
-  private Period total = new Period();
+  private final Period total = new Period();
 
-  private Period idle = new Period();
+  private final Period idle = new Period();
 
   public OsCpuUsage(Id id) {
     super(id);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/cpu/ProcessCpuUsage.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/cpu/ProcessCpuUsage.java
@@ -39,11 +39,11 @@ import com.netflix.spectator.api.Id;
 public class ProcessCpuUsage extends AbstractCpuUsage {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCpuUsage.class);
 
-  private Period busy = new Period();
+  private final Period busy = new Period();
 
-  private Period total = new Period();
+  private final Period total = new Period();
 
-  private int userHZ = CpuUtils.calcHertz();
+  private final int userHZ = CpuUtils.calcHertz();
 
   public ProcessCpuUsage(Id id) {
     super(id);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/net/InterfaceUsage.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/net/InterfaceUsage.java
@@ -31,7 +31,7 @@ import com.netflix.spectator.api.Measurement;
 public class InterfaceUsage {
   private final String name;
 
-  private List<NetStat> netStats = new ArrayList<>();
+  private final List<NetStat> netStats = new ArrayList<>();
 
   public InterfaceUsage(Id id, String name) {
     this.name = name;

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/net/NetStat.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/os/net/NetStat.java
@@ -21,7 +21,7 @@ import com.netflix.spectator.api.Id;
 public class NetStat {
   private final int index;
 
-  private Id id;
+  private final Id id;
 
   // send/recv bytes/packets
   private long lastValue;

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/EndpointMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/EndpointMeter.java
@@ -47,19 +47,19 @@ public class EndpointMeter {
 
   protected Id id;
 
-  private Id idConnect;
+  private final Id idConnect;
 
-  private Id idDisconnect;
+  private final Id idDisconnect;
 
-  private Id idConnections;
+  private final Id idConnections;
 
-  private Id idBytesRead;
+  private final Id idBytesRead;
 
-  private Id idBytesWritten;
+  private final Id idBytesWritten;
 
-  private Id idRequests;
+  private final Id idRequests;
 
-  private Id idLatency;
+  private final Id idLatency;
 
   protected DefaultEndpointMetric metric;
 

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/HttpClientEndpointMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/HttpClientEndpointMeter.java
@@ -27,7 +27,7 @@ import com.netflix.spectator.api.Measurement;
 public class HttpClientEndpointMeter extends EndpointMeter {
   public static final String QUEUE_COUNT = "queueCount";
 
-  private Id idQueueCount;
+  private final Id idQueueCount;
 
   public HttpClientEndpointMeter(Id id, DefaultEndpointMetric metric) {
     super(id, metric);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/ServerEndpointMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/ServerEndpointMeter.java
@@ -27,7 +27,7 @@ import com.netflix.spectator.api.Measurement;
 public class ServerEndpointMeter extends EndpointMeter {
   public static final String REJECT_BY_CONNECTION_LIMIT = "rejectByConnectionLimit";
 
-  private Id idRejectByConnectionLimit;
+  private final Id idRejectByConnectionLimit;
 
   private long lastRejectByConnectionLimit;
 

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/VertxEndpointsMeter.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/meter/vertx/VertxEndpointsMeter.java
@@ -28,9 +28,9 @@ import com.netflix.spectator.api.Id;
 import com.netflix.spectator.api.Measurement;
 
 public class VertxEndpointsMeter extends AbstractPeriodMeter {
-  private Map<String, DefaultEndpointMetric> endpointMetricMap;
+  private final Map<String, DefaultEndpointMetric> endpointMetricMap;
 
-  private Map<String, EndpointMeter> endpointMeterMap = new ConcurrentHashMapEx<>();
+  private final Map<String, EndpointMeter> endpointMeterMap = new ConcurrentHashMapEx<>();
 
   @SuppressWarnings("unchecked")
   public <T extends DefaultEndpointMetric> VertxEndpointsMeter(Id id, Map<String, T> endpointMetricMap) {

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/publish/AbstractMeasurementNodeLogPublisher.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/publish/AbstractMeasurementNodeLogPublisher.java
@@ -24,7 +24,7 @@ public abstract class AbstractMeasurementNodeLogPublisher {
 
   protected MeasurementNode measurementNode;
 
-  private boolean exists;
+  private final boolean exists;
 
   public AbstractMeasurementNodeLogPublisher(MeasurementTree tree, StringBuilder sb, String... childNames) {
     this.sb = sb;

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/publish/PublishModelFactory.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/publish/PublishModelFactory.java
@@ -35,7 +35,7 @@ import com.netflix.spectator.api.Meter;
 import com.netflix.spectator.api.patterns.ThreadPoolMonitorPublishModelFactory;
 
 public class PublishModelFactory {
-  private MeasurementTree tree;
+  private final MeasurementTree tree;
 
   public PublishModelFactory(List<Meter> meters) {
     tree = createMeasurementTree(meters);

--- a/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/publish/model/invocation/OperationPerfGroup.java
+++ b/metrics/metrics-core/src/main/java/org/apache/servicecomb/metrics/core/publish/model/invocation/OperationPerfGroup.java
@@ -20,11 +20,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class OperationPerfGroup {
-  private String transport;
+  private final String transport;
 
-  private String status;
+  private final String status;
 
-  private List<OperationPerf> operationPerfs = new ArrayList<>();
+  private final List<OperationPerf> operationPerfs = new ArrayList<>();
 
   private OperationPerf summary;
 

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestHealthCheckerPublisher.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestHealthCheckerPublisher.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class TestHealthCheckerPublisher {
-  private HealthChecker good = new HealthChecker() {
+  private final HealthChecker good = new HealthChecker() {
     @Override
     public String getName() {
       return "test";
@@ -39,7 +39,7 @@ public class TestHealthCheckerPublisher {
     }
   };
 
-  private HealthChecker bad = new HealthChecker() {
+  private final HealthChecker bad = new HealthChecker() {
     @Override
     public String getName() {
       return "test2";

--- a/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/PojoProducerProvider.java
+++ b/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/PojoProducerProvider.java
@@ -32,7 +32,7 @@ import org.apache.servicecomb.provider.pojo.schema.PojoProducerMeta;
 import org.apache.servicecomb.provider.pojo.schema.PojoProducers;
 
 public class PojoProducerProvider extends AbstractProducerProvider {
-  private Map<String, InstanceFactory> instanceFactoryMgr = new HashMap<>();
+  private final Map<String, InstanceFactory> instanceFactoryMgr = new HashMap<>();
 
   private void registerInstanceFactory(InstanceFactory instanceFactory) {
     instanceFactoryMgr.put(instanceFactory.getImplName(), instanceFactory);

--- a/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/definition/PojoConsumerOperationMeta.java
+++ b/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/definition/PojoConsumerOperationMeta.java
@@ -33,17 +33,17 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import com.google.common.reflect.TypeToken;
 
 public class PojoConsumerOperationMeta {
-  private PojoConsumerMeta pojoConsumerMeta;
+  private final PojoConsumerMeta pojoConsumerMeta;
 
-  private OperationMeta operationMeta;
+  private final OperationMeta operationMeta;
 
-  private SwaggerConsumerOperation swaggerConsumerOperation;
+  private final SwaggerConsumerOperation swaggerConsumerOperation;
 
   private JavaType responseType;
 
   private InvocationRuntimeType invocationRuntimeType;
 
-  private boolean sync;
+  private final boolean sync;
 
   public PojoConsumerOperationMeta(PojoConsumerMeta pojoConsumerMeta, OperationMeta operationMeta,
       SwaggerConsumerOperation swaggerConsumerOperation) {

--- a/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/schema/PojoProducers.java
+++ b/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/schema/PojoProducers.java
@@ -29,7 +29,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class PojoProducers implements BeanPostProcessor {
-  private List<ProducerMeta> producerMetas = new ArrayList<>();
+  private final List<ProducerMeta> producerMetas = new ArrayList<>();
 
   public synchronized void registerPojoProducer(PojoProducerMeta pojoProducer) {
     producerMetas.add(pojoProducer);

--- a/providers/provider-pojo/src/test/java/org/apache/servicecomb/provider/common/MockUtil.java
+++ b/providers/provider-pojo/src/test/java/org/apache/servicecomb/provider/common/MockUtil.java
@@ -26,7 +26,7 @@ import mockit.MockUp;
 
 public class MockUtil {
 
-  private static MockUtil instance = new MockUtil();
+  private static final MockUtil instance = new MockUtil();
 
   private MockUtil() {
 

--- a/providers/provider-rest-common/src/main/java/org/apache/servicecomb/provider/rest/common/InvocationToHttpServletRequest.java
+++ b/providers/provider-rest-common/src/main/java/org/apache/servicecomb/provider/rest/common/InvocationToHttpServletRequest.java
@@ -34,9 +34,9 @@ import io.vertx.core.net.SocketAddress;
  * when transport is not over http, mock an HttpServletRequest from Invocation
  */
 public class InvocationToHttpServletRequest extends AbstractHttpServletRequest {
-  private RestOperationMeta swaggerOperation;
+  private final RestOperationMeta swaggerOperation;
 
-  private Invocation invocation;
+  private final Invocation invocation;
 
   public InvocationToHttpServletRequest(Invocation invocation) {
     this.swaggerOperation = invocation.getOperationMeta().getExtData(RestConst.SWAGGER_REST_OPERATION);

--- a/providers/provider-rest-common/src/main/java/org/apache/servicecomb/provider/rest/common/RestProducers.java
+++ b/providers/provider-rest-common/src/main/java/org/apache/servicecomb/provider/rest/common/RestProducers.java
@@ -32,13 +32,13 @@ import com.netflix.config.DynamicPropertyFactory;
 
 @Component
 public class RestProducers implements BeanPostProcessor {
-  private List<ProducerMeta> producerMetaList = new ArrayList<>();
+  private final List<ProducerMeta> producerMetaList = new ArrayList<>();
 
   @SuppressWarnings("unchecked")
-  private Class<? extends Annotation> restControllerCls = (Class<? extends Annotation>) ReflectUtils
+  private final Class<? extends Annotation> restControllerCls = (Class<? extends Annotation>) ReflectUtils
       .getClassByName("org.springframework.web.bind.annotation.RestController");
 
-  private boolean scanRestController = restControllerCls != null &&
+  private final boolean scanRestController = restControllerCls != null &&
       DynamicPropertyFactory.getInstance().getBooleanProperty(RestConst.PROVIDER_SCAN_REST_CONTROLLER, true).get();
 
   public List<ProducerMeta> getProducerMetaList() {

--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CommonToHttpServletRequest.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CommonToHttpServletRequest.java
@@ -41,9 +41,9 @@ import com.google.common.annotations.VisibleForTesting;
 
 // restTemplate convert parameters to invocation args.
 public class CommonToHttpServletRequest extends AbstractHttpServletRequest {
-  private Map<String, List<String>> queryParams;
+  private final Map<String, List<String>> queryParams;
 
-  private Map<String, List<String>> httpHeaders;
+  private final Map<String, List<String>> httpHeaders;
 
   //contains all the file key in the parts
   private List<String> fileKeys = new ArrayList<>();

--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseClientHttpResponse.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseClientHttpResponse.java
@@ -55,7 +55,7 @@ public class CseClientHttpResponse implements ClientHttpResponse {
     }
   };
 
-  private Response response;
+  private final Response response;
 
   private HttpHeaders httpHeaders;
 

--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseRequestCallback.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseRequestCallback.java
@@ -24,11 +24,11 @@ import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.web.client.RequestCallback;
 
 public class CseRequestCallback implements RequestCallback {
-  private Object requestBody;
+  private final Object requestBody;
 
-  private RequestCallback orgCallback;
+  private final RequestCallback orgCallback;
 
-  private Type responseType;
+  private final Type responseType;
 
   public CseRequestCallback(Object requestBody, RequestCallback orgCallback, Type responseType) {
     this.requestBody = requestBody;

--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/RequestMeta.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/RequestMeta.java
@@ -27,13 +27,13 @@ import org.apache.servicecomb.core.provider.consumer.ReferenceConfig;
  * 封装每一次调用的元数据
  */
 public class RequestMeta {
-  private ReferenceConfig referenceConfig;
+  private final ReferenceConfig referenceConfig;
 
-  private OperationMeta operationMeta;
+  private final OperationMeta operationMeta;
 
-  private RestOperationMeta swaggerRestOperation;
+  private final RestOperationMeta swaggerRestOperation;
 
-  private Map<String, String> pathParams;
+  private final Map<String, String> pathParams;
 
   public RequestMeta(ReferenceConfig referenceConfig, RestOperationMeta swaggerRestOperation,
       Map<String, String> pathParams) {

--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/UrlWithProviderPrefixClientHttpRequestFactory.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/UrlWithProviderPrefixClientHttpRequestFactory.java
@@ -30,7 +30,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
  */
 public class UrlWithProviderPrefixClientHttpRequestFactory implements ClientHttpRequestFactory {
   static class UrlWithProviderPrefixClientHttpRequest extends CseClientHttpRequest {
-    private String prefix;
+    private final String prefix;
 
     public UrlWithProviderPrefixClientHttpRequest(URI uri, HttpMethod httpMethod, String prefix) {
       super(uri, httpMethod);
@@ -43,7 +43,7 @@ public class UrlWithProviderPrefixClientHttpRequestFactory implements ClientHttp
     }
   }
 
-  private String prefix;
+  private final String prefix;
 
   public UrlWithProviderPrefixClientHttpRequestFactory(String prefix) {
     this.prefix = prefix;

--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/async/CseAsyncRequestCallback.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/async/CseAsyncRequestCallback.java
@@ -23,7 +23,7 @@ import org.springframework.http.HttpEntity;
 @SuppressWarnings("deprecation")
 // TODO : upgrade to spring 5 will having warning's , we'll fix it later
 public class CseAsyncRequestCallback<T> implements org.springframework.web.client.AsyncRequestCallback {
-  private HttpEntity<T> requestBody;
+  private final HttpEntity<T> requestBody;
 
   CseAsyncRequestCallback(HttpEntity<T> requestBody) {
     this.requestBody = requestBody;

--- a/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/common/MockUtil.java
+++ b/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/common/MockUtil.java
@@ -28,7 +28,7 @@ import mockit.Mock;
 import mockit.MockUp;
 
 public class MockUtil {
-  private static MockUtil instance = new MockUtil();
+  private static final MockUtil instance = new MockUtil();
 
   private MockUtil() {
 

--- a/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/LocalDiscovery.java
+++ b/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/LocalDiscovery.java
@@ -30,7 +30,7 @@ import com.netflix.config.DynamicPropertyFactory;
 public class LocalDiscovery implements Discovery {
   public static final String NAME = "local discovery";
 
-  private LocalRegistryStore localDiscoveryStore = LocalRegistryStore.INSTANCE;
+  private final LocalRegistryStore localDiscoveryStore = LocalRegistryStore.INSTANCE;
 
   @Override
   public void init() {

--- a/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/LocalRegistration.java
+++ b/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/LocalRegistration.java
@@ -32,7 +32,7 @@ import com.netflix.config.DynamicPropertyFactory;
 public class LocalRegistration implements Registration {
   public static final String NAME = "local registration";
 
-  private LocalRegistryStore localRegistrationStore = LocalRegistryStore.INSTANCE;
+  private final LocalRegistryStore localRegistrationStore = LocalRegistryStore.INSTANCE;
 
   @Override
   public void init() {

--- a/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/LocalRegistryStore.java
+++ b/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/LocalRegistryStore.java
@@ -54,11 +54,11 @@ public class LocalRegistryStore {
   private MicroserviceInstance selfMicroserviceInstance;
 
   // key is microservice id
-  private Map<String, Microservice> microserviceMap = new ConcurrentHashMap<>();
+  private final Map<String, Microservice> microserviceMap = new ConcurrentHashMap<>();
 
   // first key is microservice id
   // second key is instance id
-  private Map<String, Map<String, MicroserviceInstance>> microserviceInstanceMap = new ConcurrentHashMap<>();
+  private final Map<String, Map<String, MicroserviceInstance>> microserviceInstanceMap = new ConcurrentHashMap<>();
 
   public LocalRegistryStore() {
 

--- a/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/RegistryBean.java
+++ b/service-registry/registry-local/src/main/java/org/apache/servicecomb/localregistry/RegistryBean.java
@@ -69,7 +69,7 @@ public class RegistryBean {
 
   private List<String> schemaIds = new ArrayList<>();
 
-  private Map<String, Class<?>> schemaInterfaces = new HashMap<>();
+  private final Map<String, Class<?>> schemaInterfaces = new HashMap<>();
 
   private Instances instances;
 

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/RegistryUtils.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/RegistryUtils.java
@@ -302,9 +302,9 @@ public final class RegistryUtils {
   }
 
   public static class AfterServiceInstanceRegistryHandler {
-    private static AtomicInteger instanceRegisterCounter = new AtomicInteger(EXTRA_SERVICE_REGISTRIES.size() + 1);
+    private static final AtomicInteger instanceRegisterCounter = new AtomicInteger(EXTRA_SERVICE_REGISTRIES.size() + 1);
 
-    private ServiceRegistry serviceRegistry;
+    private final ServiceRegistry serviceRegistry;
 
     AfterServiceInstanceRegistryHandler(ServiceRegistry serviceRegistry) {
       this.serviceRegistry = serviceRegistry;

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/auth/TokenCacheManager.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/auth/TokenCacheManager.java
@@ -55,7 +55,7 @@ public final class TokenCacheManager {
   private static final TokenCacheManager INSTANCE = new TokenCacheManager();
 
 
-  private Map<String, TokenCache> tokenCacheMap;
+  private final Map<String, TokenCache> tokenCacheMap;
 
   private Map<String, ServiceCenterClient> serviceCenterClients;
 
@@ -102,7 +102,7 @@ public final class TokenCacheManager {
 
     private LoadingCache<String, String> cache;
 
-    private Cipher cipher;
+    private final Cipher cipher;
 
     private int lastStatusCode;
 

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/IpPortManager.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/IpPortManager.java
@@ -36,19 +36,19 @@ import org.slf4j.LoggerFactory;
 public class IpPortManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(IpPortManager.class);
 
-  private ServiceRegistryConfig serviceRegistryConfig;
+  private final ServiceRegistryConfig serviceRegistryConfig;
 
   InstanceCacheManager instanceCacheManager;
 
-  private ArrayList<IpPort> defaultIpPort;
+  private final ArrayList<IpPort> defaultIpPort;
 
   private boolean autoDiscoveryInited = false;
 
-  private AddressManager addressManger;
+  private final AddressManager addressManger;
 
   ClassificationAddress classificationAddress;
 
-  private Object lock = new Object();
+  private final Object lock = new Object();
 
   public void setAutoDiscoveryInited(boolean autoDiscoveryInited) {
     this.autoDiscoveryInited = autoDiscoveryInited;

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/HttpClientPool.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/HttpClientPool.java
@@ -18,7 +18,7 @@
 package org.apache.servicecomb.serviceregistry.client.http;
 
 class HttpClientPool extends AbstractClientPool {
-  private String clientName;
+  private final String clientName;
 
   HttpClientPool(String clientName) {
     this.clientName = clientName;

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RegistryHttpClientOptionsSPI.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RegistryHttpClientOptionsSPI.java
@@ -30,7 +30,7 @@ import io.vertx.core.http.HttpVersion;
 public class RegistryHttpClientOptionsSPI implements HttpClientOptionsSPI {
   public static final String CLIENT_NAME = "registry";
 
-  private ServiceRegistryConfig serviceRegistryConfig = ServiceRegistryConfig.INSTANCE;
+  private final ServiceRegistryConfig serviceRegistryConfig = ServiceRegistryConfig.INSTANCE;
 
   @Override
   public String clientName() {

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RegistryWatchHttpClientOptionsSPI.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/RegistryWatchHttpClientOptionsSPI.java
@@ -24,7 +24,7 @@ import com.netflix.config.DynamicPropertyFactory;
 public class RegistryWatchHttpClientOptionsSPI extends RegistryHttpClientOptionsSPI {
   public static final String CLIENT_NAME = "registry-watch";
 
-  private ServiceRegistryConfig serviceRegistryConfig = ServiceRegistryConfig.INSTANCE;
+  private final ServiceRegistryConfig serviceRegistryConfig = ServiceRegistryConfig.INSTANCE;
 
   @Override
   public String clientName() {

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/ServiceRegistryClientImpl.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/ServiceRegistryClientImpl.java
@@ -89,15 +89,15 @@ public final class ServiceRegistryClientImpl implements ServiceRegistryClient {
 
   private static final String ERR_SCHEMA_NOT_EXISTS = "400016";
 
-  private IpPortManager ipPortManager;
+  private final IpPortManager ipPortManager;
 
   // key是本进程的微服务id和服务管理中心的id
   // extract this, ServiceRegistryClient is better to be no status.
-  private Map<String, Boolean> watchServices = new ConcurrentHashMap<>();
+  private final Map<String, Boolean> watchServices = new ConcurrentHashMap<>();
 
-  private RestClientUtil restClientUtil;
+  private final RestClientUtil restClientUtil;
 
-  private WebsocketClientUtil websocketClientUtil;
+  private final WebsocketClientUtil websocketClientUtil;
 
   public ServiceRegistryClientImpl(ServiceRegistryConfig serviceRegistryConfig) {
     this.ipPortManager = new IpPortManager(serviceRegistryConfig);
@@ -105,7 +105,7 @@ public final class ServiceRegistryClientImpl implements ServiceRegistryClient {
     this.websocketClientUtil = new WebsocketClientUtil(serviceRegistryConfig);
   }
 
-  private LoadingCache<String, Map<String, String>> schemaCache = CacheBuilder.newBuilder()
+  private final LoadingCache<String, Map<String, String>> schemaCache = CacheBuilder.newBuilder()
       .expireAfterAccess(60, TimeUnit.SECONDS).build(new CacheLoader<String, Map<String, String>>() {
         public Map<String, String> load(String key) {
           Holder<List<GetSchemaResponse>> result = getSchemas(key, true, true);

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientPool.java
@@ -18,7 +18,7 @@
 package org.apache.servicecomb.serviceregistry.client.http;
 
 public class WebsocketClientPool extends AbstractClientPool {
-  private String clientName;
+  private final String clientName;
 
   WebsocketClientPool(String clientName) {
     this.clientName = clientName;

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientUtil.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/client/http/WebsocketClientUtil.java
@@ -41,9 +41,9 @@ import io.vertx.core.http.WebSocketConnectOptions;
 public final class WebsocketClientUtil {
   private static final Logger LOGGER = LoggerFactory.getLogger(WebsocketClientUtil.class);
 
-  private WebsocketClientPool websocketClientPool;
+  private final WebsocketClientPool websocketClientPool;
 
-  private List<AuthHeaderProvider> authHeaderProviders;
+  private final List<AuthHeaderProvider> authHeaderProviders;
 
   WebsocketClientUtil(ServiceRegistryConfig serviceRegistryConfig) {
     websocketClientPool = new WebsocketClientPool(serviceRegistryConfig.getWatchClientName());

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigCustomizer.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/config/ServiceRegistryConfigCustomizer.java
@@ -31,7 +31,7 @@ import com.netflix.config.DynamicPropertyFactory;
  * easier way to have new customized copies of ServiceRegistryConfig
  */
 public class ServiceRegistryConfigCustomizer {
-  private ServiceRegistryConfig original;
+  private final ServiceRegistryConfig original;
 
   private ServiceRegistryConfigCustomizer(ServiceRegistryConfig original) {
     this.original = original;

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/InstanceCacheChecker.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/diagnosis/instance/InstanceCacheChecker.java
@@ -43,11 +43,11 @@ public class InstanceCacheChecker {
 
   Clock clock = TimeUtils.getSystemDefaultZoneClock();
 
-  private AppManager appManager;
+  private final AppManager appManager;
 
-  private Set<Status> statuses = new HashSet<>();
+  private final Set<Status> statuses = new HashSet<>();
 
-  private InstanceCacheSummary instanceCacheSummary = new InstanceCacheSummary();
+  private final InstanceCacheSummary instanceCacheSummary = new InstanceCacheSummary();
 
   public InstanceCacheChecker(AppManager appManager) {
     this.appManager = appManager;

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/event/ExceptionEvent.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/event/ExceptionEvent.java
@@ -17,7 +17,7 @@
 package org.apache.servicecomb.serviceregistry.event;
 
 public class ExceptionEvent {
-  private Throwable throwable;
+  private final Throwable throwable;
 
   public ExceptionEvent(Throwable throwable) {
     this.throwable = throwable;

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/refresh/ClassificationAddress.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/refresh/ClassificationAddress.java
@@ -61,13 +61,13 @@ public class ClassificationAddress {
 
   private String defaultTransport = "rest";
 
-  private boolean isAutoRefresh;
+  private final boolean isAutoRefresh;
 
   private DataCenterInfo dataCenterInfo;
 
   InstanceCacheManager instanceCacheManager;
 
-  private ArrayList<IpPort> defaultIpPort;
+  private final ArrayList<IpPort> defaultIpPort;
 
   private int maxRetryTimes;
 

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/AbstractServiceRegistry.java
@@ -53,7 +53,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 public abstract class AbstractServiceRegistry implements ServiceRegistry {
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractServiceRegistry.class);
 
-  private MicroserviceFactory microserviceFactory = new MicroserviceFactory();
+  private final MicroserviceFactory microserviceFactory = new MicroserviceFactory();
 
   protected EventBus eventBus;
 

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/RemoteServiceRegistry.java
@@ -41,10 +41,10 @@ public class RemoteServiceRegistry extends AbstractServiceRegistry {
 
   private ScheduledThreadPoolExecutor taskPool;
 
-  private List<ServiceRegistryTaskInitializer> taskInitializers = SPIServiceUtils
+  private final List<ServiceRegistryTaskInitializer> taskInitializers = SPIServiceUtils
       .getOrLoadSortedService(ServiceRegistryTaskInitializer.class);
 
-  private AtomicBoolean heartBeatStatus = new AtomicBoolean(true);
+  private final AtomicBoolean heartBeatStatus = new AtomicBoolean(true);
 
   public RemoteServiceRegistry(EventBus eventBus, ServiceRegistryConfig serviceRegistryConfig,
       Configuration configuration) {

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateMicroserviceCache.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/AggregateMicroserviceCache.java
@@ -32,7 +32,7 @@ import org.apache.servicecomb.serviceregistry.ServiceRegistry;
 import org.apache.servicecomb.registry.api.registry.MicroserviceInstance;
 
 public class AggregateMicroserviceCache implements MicroserviceCache {
-  private MicroserviceCacheKey key;
+  private final MicroserviceCacheKey key;
 
   Map<String, MicroserviceCache> caches;
 

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheKey.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/registry/cache/MicroserviceCacheKey.java
@@ -91,7 +91,7 @@ public class MicroserviceCacheKey {
   }
 
   public static class MicroserviceCacheKeyBuilder {
-    private MicroserviceCacheKey microserviceCacheKey;
+    private final MicroserviceCacheKey microserviceCacheKey;
 
     public MicroserviceCacheKey build() {
       microserviceCacheKey.validate();

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/CompositeTask.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/CompositeTask.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CompositeTask implements Runnable {
-  private List<Runnable> taskList = new ArrayList<>();
+  private final List<Runnable> taskList = new ArrayList<>();
 
   public void addTask(Runnable task) {
     taskList.add(task);

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/MicroserviceInstanceHeartbeatTask.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/MicroserviceInstanceHeartbeatTask.java
@@ -31,7 +31,7 @@ import com.google.common.eventbus.Subscribe;
 public class MicroserviceInstanceHeartbeatTask extends AbstractTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(MicroserviceInstanceHeartbeatTask.class);
 
-  private MicroserviceInstance microserviceInstance;
+  private final MicroserviceInstance microserviceInstance;
 
   private HeartbeatResult heartbeatResult;
 

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/MicroserviceInstanceRegisterTask.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/MicroserviceInstanceRegisterTask.java
@@ -32,9 +32,9 @@ import com.google.common.eventbus.Subscribe;
 public class MicroserviceInstanceRegisterTask extends AbstractRegisterTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(MicroserviceInstanceRegisterTask.class);
 
-  private ServiceRegistryConfig serviceRegistryConfig;
+  private final ServiceRegistryConfig serviceRegistryConfig;
 
-  private MicroserviceInstance microserviceInstance;
+  private final MicroserviceInstance microserviceInstance;
 
   public MicroserviceInstanceRegisterTask(EventBus eventBus, ServiceRegistryConfig serviceRegistryConfig,
       ServiceRegistryClient srClient,

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/MicroserviceWatchTask.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/MicroserviceWatchTask.java
@@ -32,7 +32,7 @@ import com.google.common.eventbus.Subscribe;
 public class MicroserviceWatchTask extends AbstractTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(MicroserviceWatchTask.class);
 
-  private ServiceRegistryConfig serviceRegistryConfig;
+  private final ServiceRegistryConfig serviceRegistryConfig;
 
   public MicroserviceWatchTask(EventBus eventBus, ServiceRegistryConfig serviceRegistryConfig,
       ServiceRegistryClient srClient, Microservice microservice) {

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/ServiceCenterTask.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/serviceregistry/task/ServiceCenterTask.java
@@ -27,15 +27,15 @@ import com.google.common.eventbus.Subscribe;
 public class ServiceCenterTask implements Runnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceCenterTask.class);
 
-  private EventBus eventBus;
+  private final EventBus eventBus;
 
-  private int interval;
+  private final int interval;
 
-  private MicroserviceServiceCenterTask microserviceServiceCenterTask;
+  private final MicroserviceServiceCenterTask microserviceServiceCenterTask;
 
   private boolean registerInstanceSuccess = false;
 
-  private ServiceCenterTaskMonitor serviceCenterTaskMonitor = new ServiceCenterTaskMonitor();
+  private final ServiceCenterTaskMonitor serviceCenterTaskMonitor = new ServiceCenterTaskMonitor();
 
   public ServiceCenterTask(EventBus eventBus, int interval,
       MicroserviceServiceCenterTask microserviceServiceCenterTask) {

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/MockMicroserviceVersions.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/MockMicroserviceVersions.java
@@ -41,9 +41,9 @@ import mockit.MockUp;
 
 public class MockMicroserviceVersions extends MicroserviceVersions {
   // key is serviceId
-  private Map<String, Microservice> mockedMicroservices = new HashMap<>();
+  private final Map<String, Microservice> mockedMicroservices = new HashMap<>();
 
-  private List<MicroserviceInstance> mockedInstances = new ArrayList<>();
+  private final List<MicroserviceInstance> mockedInstances = new ArrayList<>();
 
   public MockMicroserviceVersions() {
     super(new AppManager(), "appId", "msName");

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/adapter/TestEnvAdapterManager.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/adapter/TestEnvAdapterManager.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 
 public class TestEnvAdapterManager {
 
-  private EnvAdapterManager manager = EnvAdapterManager.INSTANCE;
+  private final EnvAdapterManager manager = EnvAdapterManager.INSTANCE;
 
   @Test
   public void testLoadAdapter() {

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/LocalServiceRegistryClientImpl.java
@@ -61,13 +61,13 @@ public class LocalServiceRegistryClientImpl implements ServiceRegistryClient {
   public static final String LOCAL_REGISTRY_FILE_KEY = "local.registry.file";
 
   // key is microservice id
-  private Map<String, Microservice> microserviceIdMap = new ConcurrentHashMap<>();
+  private final Map<String, Microservice> microserviceIdMap = new ConcurrentHashMap<>();
 
   // first key is microservice id
   // second key is instance id
-  private Map<String, Map<String, MicroserviceInstance>> microserviceInstanceMap = new ConcurrentHashMap<>();
+  private final Map<String, Map<String, MicroserviceInstance>> microserviceInstanceMap = new ConcurrentHashMap<>();
 
-  private AtomicInteger revision = new AtomicInteger(0);
+  private final AtomicInteger revision = new AtomicInteger(0);
 
   public LocalServiceRegistryClientImpl() {
     this(System.getProperty(LOCAL_REGISTRY_FILE_KEY));

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestClientHttp.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestClientHttp.java
@@ -42,7 +42,7 @@ import mockit.MockUp;
 import mockit.Mocked;
 
 public class TestClientHttp {
-  private Microservice microservice = new Microservice();
+  private final Microservice microservice = new Microservice();
 
   @SuppressWarnings("unchecked")
   @Test

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
@@ -75,7 +75,7 @@ import mockit.Mocked;
 public class TestServiceRegistryClientImpl {
   private ServiceRegistryClientImpl oClient = null;
 
-  private Microservice microservice = new Microservice();
+  private final Microservice microservice = new Microservice();
 
   @Before
   public void setUp() throws Exception {

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/config/TestPropertiesLoader.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/config/TestPropertiesLoader.java
@@ -31,7 +31,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestPropertiesLoader {
-  private static MicroserviceFactory microserviceFactory = new MicroserviceFactory();
+  private static final MicroserviceFactory microserviceFactory = new MicroserviceFactory();
 
   @Test
   public void testEmptyExtendedClass() {

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/refresh/AddressManagerTest.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/refresh/AddressManagerTest.java
@@ -35,7 +35,7 @@ import mockit.Deencapsulation;
 
 class AddressManagerTest {
 
-  private static List<String> addresses = new ArrayList<>();
+  private static final List<String> addresses = new ArrayList<>();
 
   private static AddressManager addressManager1;
 

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableMicroserviceCacheTest.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableMicroserviceCacheTest.java
@@ -39,7 +39,7 @@ import mockit.MockUp;
 
 public class RefreshableMicroserviceCacheTest {
 
-  private Holder<Function<Object[], MicroserviceInstances>> findServiceInstancesOprHolder = new Holder<>();
+  private final Holder<Function<Object[], MicroserviceInstances>> findServiceInstancesOprHolder = new Holder<>();
 
   private ServiceRegistryClient srClient;
 

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableServiceRegistryCacheTest.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/registry/cache/RefreshableServiceRegistryCacheTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 
 public class RefreshableServiceRegistryCacheTest {
 
-  private Holder<Function<String, MicroserviceInstances>> pullInstanceFromServiceCenterLogic = new Holder<>(
+  private final Holder<Function<String, MicroserviceInstances>> pullInstanceFromServiceCenterLogic = new Holder<>(
       rev -> {
         MicroserviceInstances microserviceInstances = new MicroserviceInstances();
         microserviceInstances.setMicroserviceNotExist(false);

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/swagger/TestSwaggerLoader.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/swagger/TestSwaggerLoader.java
@@ -208,7 +208,7 @@ public class TestSwaggerLoader extends TestRegistryBase {
     IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> {
       URL url = new MockUp<URL>() {
 
-        private String path = "location/invalid.yaml";
+        private final String path = "location/invalid.yaml";
 
         @Mock
         String getPath() {

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/task/TestServiceCenterTask.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/task/TestServiceCenterTask.java
@@ -30,7 +30,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 
 public class TestServiceCenterTask {
-  private EventBus eventBus = new EventBus();
+  private final EventBus eventBus = new EventBus();
 
   @Mocked
   private MicroserviceServiceCenterTask microserviceServiceCenterTask;

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/ConverterMgr.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/ConverterMgr.java
@@ -71,7 +71,7 @@ public final class ConverterMgr {
   // value is related java class
   private static final Map<String, JavaType> TYPE_FORMAT_MAP = new HashMap<>();
 
-  private static Map<Class<?>, Converter> converterMap = new HashMap<>();
+  private static final Map<Class<?>, Converter> converterMap = new HashMap<>();
 
   static {
     initPropertyMap();

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/extend/ModelResolverExt.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/extend/ModelResolverExt.java
@@ -58,11 +58,11 @@ import io.swagger.models.properties.StringProperty;
 import io.swagger.util.PrimitiveType;
 
 public class ModelResolverExt extends ModelResolver {
-  private Map<Class<?>, PropertyCreator> propertyCreatorMap = new HashMap<>();
+  private final Map<Class<?>, PropertyCreator> propertyCreatorMap = new HashMap<>();
 
   private static ObjectMapper objectMapper;
 
-  private Set<Type> concreteInterfaces = new HashSet<>();
+  private final Set<Type> concreteInterfaces = new HashSet<>();
 
   private static final String DISABLE_DATA_TYPE_CHECK = "servicecomb.swagger.disableDataTypeCheck";
 

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/ParameterGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/ParameterGenerator.java
@@ -30,14 +30,14 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 import io.swagger.models.parameters.Parameter;
 
 public class ParameterGenerator {
-  private String parameterName;
+  private final String parameterName;
 
-  private List<Annotation> annotations;
+  private final List<Annotation> annotations;
 
   /**
    * when wrap parameters to body, genericType is null
    */
-  private JavaType genericType;
+  private final JavaType genericType;
 
   private HttpParameterType httpParameterType;
 

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/SwaggerGeneratorFeature.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/SwaggerGeneratorFeature.java
@@ -17,7 +17,7 @@
 package org.apache.servicecomb.swagger.generator;
 
 public class SwaggerGeneratorFeature {
-  private static ThreadLocal<SwaggerGeneratorFeature> featureThreadLocal = new ThreadLocal<>();
+  private static final ThreadLocal<SwaggerGeneratorFeature> featureThreadLocal = new ThreadLocal<>();
 
   public static ThreadLocal<SwaggerGeneratorFeature> getFeatureThreadLocal() {
     return featureThreadLocal;

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/SwaggerGeneratorUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/SwaggerGeneratorUtils.java
@@ -50,23 +50,23 @@ public final class SwaggerGeneratorUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(SwaggerGeneratorUtils.class);
 
   // all static fields load from SPI and stateless
-  private static Set<JavaType> contextTypes = SPIServiceUtils.getOrLoadSortedService(SwaggerContextRegister.class)
+  private static final Set<JavaType> contextTypes = SPIServiceUtils.getOrLoadSortedService(SwaggerContextRegister.class)
       .stream()
       .map(swaggerContextRegister -> TypeFactory.defaultInstance()
           .constructType(swaggerContextRegister.getContextType()))
       .collect(Collectors.toSet());
 
-  private static Map<Type, ClassAnnotationProcessor<?>> classAnnotationProcessors = new HashMap<>();
+  private static final Map<Type, ClassAnnotationProcessor<?>> classAnnotationProcessors = new HashMap<>();
 
-  private static Map<Type, MethodAnnotationProcessor<?>> methodAnnotationProcessors = new HashMap<>();
+  private static final Map<Type, MethodAnnotationProcessor<?>> methodAnnotationProcessors = new HashMap<>();
 
-  private static Map<JavaType, ParameterProcessor<?, ?>> parameterProcessors = new HashMap<>();
+  private static final Map<JavaType, ParameterProcessor<?, ?>> parameterProcessors = new HashMap<>();
 
-  private static Map<Type, ResponseTypeProcessor> responseTypeProcessors = new HashMap<>();
+  private static final Map<Type, ResponseTypeProcessor> responseTypeProcessors = new HashMap<>();
 
-  private static DefaultResponseTypeProcessor defaultResponseTypeProcessor = new DefaultResponseTypeProcessor();
+  private static final DefaultResponseTypeProcessor defaultResponseTypeProcessor = new DefaultResponseTypeProcessor();
 
-  private static List<OperationPostProcessor> operationPostProcessors = SPIServiceUtils
+  private static final List<OperationPostProcessor> operationPostProcessors = SPIServiceUtils
       .getOrLoadSortedService(OperationPostProcessor.class);
 
   static {

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/AbstractOperationGenerator.java
@@ -96,7 +96,7 @@ public abstract class AbstractOperationGenerator implements OperationGenerator {
   // 如果Response中不存在对应的header，则会将这些header补充进去
   protected Map<String, Property> methodResponseHeaders = new LinkedHashMap<>();
 
-  private static List<String> NOT_NULL_ANNOTATIONS = Arrays.asList("NotBlank", "NotEmpty");
+  private static final List<String> NOT_NULL_ANNOTATIONS = Arrays.asList("NotBlank", "NotEmpty");
 
   public AbstractOperationGenerator(AbstractSwaggerGenerator swaggerGenerator, Method method) {
     this.swaggerGenerator = swaggerGenerator;

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/model/SwaggerOperation.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/model/SwaggerOperation.java
@@ -24,15 +24,15 @@ import io.swagger.models.Operation;
 import io.swagger.models.Swagger;
 
 public class SwaggerOperation {
-  private Swagger swagger;
+  private final Swagger swagger;
 
-  private String path;
+  private final String path;
 
-  private HttpMethod httpMethod;
+  private final HttpMethod httpMethod;
 
-  private Operation operation;
+  private final Operation operation;
 
-  private Map<String, Integer> parameterIndexes = new HashMap<>();
+  private final Map<String, Integer> parameterIndexes = new HashMap<>();
 
   public SwaggerOperation(Swagger swagger, String path, HttpMethod httpMethod, Operation operation) {
     this.swagger = swagger;

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/model/SwaggerOperations.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/model/SwaggerOperations.java
@@ -34,10 +34,10 @@ public class SwaggerOperations {
     return new SwaggerOperations(swagger);
   }
 
-  private Swagger swagger;
+  private final Swagger swagger;
 
   // key is operationId
-  private Map<String, SwaggerOperation> operations = new HashMap<>();
+  private final Map<String, SwaggerOperation> operations = new HashMap<>();
 
   public SwaggerOperations(Swagger swagger) {
     this.swagger = swagger;

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/unittest/UnitTestSwaggerUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/generator/core/unittest/UnitTestSwaggerUtils.java
@@ -33,7 +33,7 @@ import io.swagger.models.Swagger;
 import io.swagger.util.Yaml;
 
 public final class UnitTestSwaggerUtils {
-  private static ObjectWriter writer = Yaml.pretty();
+  private static final ObjectWriter writer = Yaml.pretty();
 
   private UnitTestSwaggerUtils() {
   }

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/utils/paramUtilsModel/AbstractBaseService.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/utils/paramUtilsModel/AbstractBaseService.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.swagger.generator.core.utils.paramUtilsModel;
 import java.util.List;
 
 public class AbstractBaseService<T extends AbstractBean> implements IBaseService<T> {
-  private IBaseService<T> target;
+  private final IBaseService<T> target;
 
   protected AbstractBaseService(IBaseService<T> t) {
     target = t;

--- a/swagger/swagger-generator/generator-springmvc/src/test/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessorTest.java
+++ b/swagger/swagger-generator/generator-springmvc/src/test/java/org/apache/servicecomb/swagger/generator/springmvc/processor/annotation/RequestPartAnnotationProcessorTest.java
@@ -37,7 +37,7 @@ import io.swagger.models.properties.StringProperty;
 public class RequestPartAnnotationProcessorTest {
   private static Method producerMethod;
 
-  private static RequestPartAnnotationProcessor requestPartAnnotationProcessor = new RequestPartAnnotationProcessor();
+  private static final RequestPartAnnotationProcessor requestPartAnnotationProcessor = new RequestPartAnnotationProcessor();
 
   @BeforeClass
   public static void beforeClass() {

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerConsumer.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerConsumer.java
@@ -27,7 +27,7 @@ public class SwaggerConsumer {
   private Class<?> consumerIntf;
 
   // key is consumer method name
-  private Map<Method, SwaggerConsumerOperation> operations = new HashMap<>();
+  private final Map<Method, SwaggerConsumerOperation> operations = new HashMap<>();
 
   public Class<?> getConsumerIntf() {
     return consumerIntf;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerProducer.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerProducer.java
@@ -30,7 +30,7 @@ public class SwaggerProducer {
   private Swagger swagger;
 
   // key is operationId
-  private Map<String, SwaggerProducerOperation> opMap = new HashMap<>();
+  private final Map<String, SwaggerProducerOperation> opMap = new HashMap<>();
 
   public Class<?> getProducerCls() {
     return producerCls;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerProducerOperation.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/engine/SwaggerProducerOperation.java
@@ -50,7 +50,7 @@ public class SwaggerProducerOperation {
 
   private ProducerResponseMapper responseMapper;
 
-  private List<ProducerInvokeExtension> producerInvokeExtenstionList =
+  private final List<ProducerInvokeExtension> producerInvokeExtenstionList =
       SPIServiceUtils.getSortedService(ProducerInvokeExtension.class);
 
   public String getOperationId() {

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/consumer/ArgumentsMapperCommon.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/consumer/ArgumentsMapperCommon.java
@@ -28,7 +28,7 @@ import org.apache.servicecomb.swagger.invocation.arguments.ArgumentsMapper;
  * map consumer arguments to swagger arguments
  */
 public class ArgumentsMapperCommon implements ArgumentsMapper {
-  private List<ArgumentMapper> mappers;
+  private final List<ArgumentMapper> mappers;
 
   public ArgumentsMapperCommon(List<ArgumentMapper> mappers) {
     this.mappers = mappers;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerArgumentsMapper.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerArgumentsMapper.java
@@ -29,7 +29,7 @@ import org.apache.servicecomb.swagger.invocation.arguments.ArgumentsMapper;
  * map swagger arguments to producer arguments
  */
 public class ProducerArgumentsMapper implements ArgumentsMapper {
-  private List<ArgumentMapper> producerArgMapperList;
+  private final List<ArgumentMapper> producerArgMapperList;
 
   public ProducerArgumentsMapper(List<ArgumentMapper> producerArgMapperList) {
     this.producerArgMapperList = producerArgMapperList;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerArgumentsMapperCreator.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerArgumentsMapperCreator.java
@@ -41,7 +41,7 @@ public class ProducerArgumentsMapperCreator extends AbstractArgumentsMapperCreat
   // swagger parameter types relate to producer
   // because features of @BeanParam/query, and rpc mode parameter wrapper
   // types is not always equals to producerMethod parameter types directly
-  private Map<String, Type> swaggerParameterTypes;
+  private final Map<String, Type> swaggerParameterTypes;
 
   public ProducerArgumentsMapperCreator(SerializationConfig serializationConfig,
       Map<Class<?>, ContextArgumentMapperFactory> contextFactorys, Class<?> producerClass,

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerBeanParamMapper.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerBeanParamMapper.java
@@ -40,7 +40,7 @@ public class ProducerBeanParamMapper extends ProducerArgumentMapper {
 
   private final Class<?> producerParamType;
 
-  private List<FieldMeta> fields = new ArrayList<>();
+  private final List<FieldMeta> fields = new ArrayList<>();
 
   public ProducerBeanParamMapper(String invocationArgumentName, Class<?> producerParamType) {
     this.invocationArgumentName = invocationArgumentName;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/codec/ArgWrapperJavaType.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/codec/ArgWrapperJavaType.java
@@ -47,7 +47,7 @@ public class ArgWrapperJavaType extends SimpleType {
     }
   }
 
-  private Map<String, ArgInfo> argInfos = new HashMap<>();
+  private final Map<String, ArgInfo> argInfos = new HashMap<>();
 
   public ArgWrapperJavaType() {
     super(Object.class);

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/ContextUtils.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/ContextUtils.java
@@ -26,7 +26,7 @@ public final class ContextUtils {
   private ContextUtils() {
   }
 
-  private static ThreadLocal<InvocationContext> contextMgr = new ThreadLocal<>();
+  private static final ThreadLocal<InvocationContext> contextMgr = new ThreadLocal<>();
 
   public static InvocationContext getInvocationContext() {
     return contextMgr.get();

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/InvocationContext.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/InvocationContext.java
@@ -28,7 +28,7 @@ import javax.ws.rs.core.Response.StatusType;
  *  InvocationContext is used to pass data between microservices or in microservice different layer.
  */
 public class InvocationContext {
-  private static HttpStatusManager statusMgr = new HttpStatusManager();
+  private static final HttpStatusManager statusMgr = new HttpStatusManager();
 
   protected StatusType httpStatus;
 

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/InvocationContextCompletableFuture.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/context/InvocationContextCompletableFuture.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.swagger.invocation.context;
 import java.util.concurrent.CompletableFuture;
 
 public class InvocationContextCompletableFuture<T> extends CompletableFuture<T> {
-  private InvocationContext context;
+  private final InvocationContext context;
 
   public InvocationContextCompletableFuture(InvocationContext context) {
     this.context = context;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/exception/ExceptionFactory.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/exception/ExceptionFactory.java
@@ -46,7 +46,7 @@ public final class ExceptionFactory {
 
   public static final String CONSUMER_INNER_REASON_PHRASE = "Unexpected consumer error, please check logs for details";
 
-  private static ExceptionToProducerResponseConverters exceptionToProducerResponseConverters = new ExceptionToProducerResponseConverters();
+  private static final ExceptionToProducerResponseConverters exceptionToProducerResponseConverters = new ExceptionToProducerResponseConverters();
 
   public static final StatusType CONSUMER_INNER_STATUS =
       new HttpStatus(CONSUMER_INNER_STATUS_CODE, CONSUMER_INNER_REASON_PHRASE);

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/exception/ExceptionToProducerResponseConverters.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/exception/ExceptionToProducerResponseConverters.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class ExceptionToProducerResponseConverters {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionToProducerResponseConverters.class);
 
-  private Map<Class<?>, ExceptionToProducerResponseConverter<Throwable>> exceptionToProducerResponseConverters =
+  private final Map<Class<?>, ExceptionToProducerResponseConverter<Throwable>> exceptionToProducerResponseConverters =
       new HashMap<>();
 
   private ExceptionToProducerResponseConverter<Throwable> defaultConverter;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/exception/InvocationException.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/exception/InvocationException.java
@@ -33,9 +33,9 @@ public class InvocationException extends RuntimeException {
    * http header中的statusCode
    * 不直接使用Status类型，是为了支持业务自定义code
    */
-  private StatusType status;
+  private final StatusType status;
 
-  private Object errorData;
+  private final Object errorData;
 
   public InvocationException(StatusType status, Object errorData) {
     this.status = status;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponseMapperFactorys.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponseMapperFactorys.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.apache.servicecomb.foundation.common.utils.SPIServiceUtils;
 
 public class ResponseMapperFactorys<MAPPER> {
-  private List<ResponseMapperFactory<MAPPER>> factorys;
+  private final List<ResponseMapperFactory<MAPPER>> factorys;
 
   @SuppressWarnings("unchecked")
   public ResponseMapperFactorys(Class<? extends ResponseMapperFactory<MAPPER>> factoryCls) {

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponsesMeta.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/ResponsesMeta.java
@@ -70,7 +70,7 @@ public class ResponsesMeta {
   private static final ResponseMetaMapper GLOBAL_DEFAULT_MAPPER = SPIServiceUtils
       .getPriorityHighestService(ResponseMetaMapper.class);
 
-  private Map<Integer, JavaType> responseMap = new HashMap<>();
+  private final Map<Integer, JavaType> responseMap = new HashMap<>();
 
   private JavaType defaultResponse;
 

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/consumer/OptionalConsumerResponseMapper.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/consumer/OptionalConsumerResponseMapper.java
@@ -21,7 +21,7 @@ import java.util.Optional;
 import org.apache.servicecomb.swagger.invocation.Response;
 
 public class OptionalConsumerResponseMapper implements ConsumerResponseMapper {
-  private ConsumerResponseMapper realMapper;
+  private final ConsumerResponseMapper realMapper;
 
   public OptionalConsumerResponseMapper(ConsumerResponseMapper realMapper) {
     this.realMapper = realMapper;

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/producer/OptionalProducerResponseMapper.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/response/producer/OptionalProducerResponseMapper.java
@@ -23,7 +23,7 @@ import javax.ws.rs.core.Response.StatusType;
 import org.apache.servicecomb.swagger.invocation.Response;
 
 public class OptionalProducerResponseMapper implements ProducerResponseMapper {
-  private ProducerResponseMapper realMapper;
+  private final ProducerResponseMapper realMapper;
 
   public OptionalProducerResponseMapper(ProducerResponseMapper realMapper) {
     this.realMapper = realMapper;

--- a/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/engine/TestSwaggerProducerOperation.java
+++ b/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/engine/TestSwaggerProducerOperation.java
@@ -22,7 +22,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class TestSwaggerProducerOperation {
-  private static SwaggerEnvironment env = new SwaggerEnvironment();
+  private static final SwaggerEnvironment env = new SwaggerEnvironment();
 
   private static SwaggerProducer producer;
 

--- a/swagger/swagger-invocation/invocation-springmvc/src/main/java/org/apache/servicecomb/swagger/invocation/converter/PartToMultipartFile.java
+++ b/swagger/swagger-invocation/invocation-springmvc/src/main/java/org/apache/servicecomb/swagger/invocation/converter/PartToMultipartFile.java
@@ -27,7 +27,7 @@ import org.apache.commons.io.IOUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 public class PartToMultipartFile implements MultipartFile {
-  private Part part;
+  private final Part part;
 
   public PartToMultipartFile(Part part) {
     this.part = part;

--- a/swagger/swagger-invocation/invocation-springmvc/src/main/java/org/apache/servicecomb/swagger/invocation/springmvc/response/SpringmvcConsumerResponseMapper.java
+++ b/swagger/swagger-invocation/invocation-springmvc/src/main/java/org/apache/servicecomb/swagger/invocation/springmvc/response/SpringmvcConsumerResponseMapper.java
@@ -27,7 +27,7 @@ import org.springframework.http.ResponseEntity;
 import io.vertx.core.MultiMap;
 
 public class SpringmvcConsumerResponseMapper implements ConsumerResponseMapper {
-  private ConsumerResponseMapper realMapper;
+  private final ConsumerResponseMapper realMapper;
 
   public SpringmvcConsumerResponseMapper(ConsumerResponseMapper realMapper) {
     this.realMapper = realMapper;

--- a/swagger/swagger-invocation/invocation-springmvc/src/main/java/org/apache/servicecomb/swagger/invocation/springmvc/response/SpringmvcProducerResponseMapper.java
+++ b/swagger/swagger-invocation/invocation-springmvc/src/main/java/org/apache/servicecomb/swagger/invocation/springmvc/response/SpringmvcProducerResponseMapper.java
@@ -28,7 +28,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 
 public class SpringmvcProducerResponseMapper implements ProducerResponseMapper {
-  private ProducerResponseMapper realMapper;
+  private final ProducerResponseMapper realMapper;
 
   public SpringmvcProducerResponseMapper(ProducerResponseMapper realMapper) {
     this.realMapper = realMapper;

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayClientPackage.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayClientPackage.java
@@ -26,9 +26,9 @@ import org.slf4j.LoggerFactory;
 public class HighwayClientPackage extends AbstractTcpClientPackage {
   private static final Logger LOGGER = LoggerFactory.getLogger(HighwayClientPackage.class);
 
-  private Invocation invocation;
+  private final Invocation invocation;
 
-  private OperationProtobuf operationProtobuf;
+  private final OperationProtobuf operationProtobuf;
 
   public HighwayClientPackage(Invocation invocation, OperationProtobuf operationProtobuf, long msRequestTimeout) {
     this.invocation = invocation;

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServer.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServer.java
@@ -25,7 +25,7 @@ import org.apache.servicecomb.foundation.vertx.server.TcpServerConnection;
 import com.netflix.config.DynamicPropertyFactory;
 
 public class HighwayServer extends TcpServer {
-  private Endpoint endpoint;
+  private final Endpoint endpoint;
 
   public HighwayServer(Endpoint endpoint) {
     super((URIEndpointObject) endpoint.getAddress());

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServerInvoke.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayServerInvoke.java
@@ -58,13 +58,13 @@ public class HighwayServerInvoke {
 
   private Buffer bodyBuffer;
 
-  private Endpoint endpoint;
+  private final Endpoint endpoint;
 
   private Invocation invocation;
 
   private OperationProtobuf operationProtobuf;
 
-  private long start;
+  private final long start;
 
   public HighwayServerInvoke(Endpoint endpoint) {
     this.start = System.nanoTime();

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayTransport.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayTransport.java
@@ -30,7 +30,7 @@ import org.apache.servicecomb.swagger.invocation.AsyncResponse;
 import io.vertx.core.DeploymentOptions;
 
 public class HighwayTransport extends AbstractTransport {
-  private HighwayClient highwayClient = new HighwayClient();
+  private final HighwayClient highwayClient = new HighwayClient();
 
   @Override
   public String getName() {

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/LoginRequest.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/LoginRequest.java
@@ -23,13 +23,13 @@ import org.apache.servicecomb.foundation.protobuf.RootSerializer;
 import io.vertx.core.buffer.Buffer;
 
 public class LoginRequest {
-  private static ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
+  private static final ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
 
-  private static RootDeserializer<LoginRequest> rootDeserializer = protoMapperFactory
+  private static final RootDeserializer<LoginRequest> rootDeserializer = protoMapperFactory
       .createFromName("LoginRequest.proto")
       .createRootDeserializer("LoginRequest", LoginRequest.class);
 
-  private static RootSerializer rootSerializer = protoMapperFactory.createFromName("LoginRequest.proto")
+  private static final RootSerializer rootSerializer = protoMapperFactory.createFromName("LoginRequest.proto")
       .createRootSerializer("LoginRequest", LoginRequest.class);
 
   public static RootSerializer getRootSerializer() {

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/LoginResponse.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/LoginResponse.java
@@ -23,13 +23,13 @@ import org.apache.servicecomb.foundation.protobuf.RootSerializer;
 import io.vertx.core.buffer.Buffer;
 
 public class LoginResponse {
-  private static ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
+  private static final ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
 
-  private static RootDeserializer<LoginResponse> rootDeserializer = protoMapperFactory
+  private static final RootDeserializer<LoginResponse> rootDeserializer = protoMapperFactory
       .createFromName("LoginResponse.proto")
       .createRootDeserializer("LoginResponse", LoginResponse.class);
 
-  private static RootSerializer rootSerializer = protoMapperFactory.createFromName("LoginResponse.proto")
+  private static final RootSerializer rootSerializer = protoMapperFactory.createFromName("LoginResponse.proto")
       .createRootSerializer("LoginResponse", LoginResponse.class);
 
   public static RootSerializer getRootSerializer() {

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/RequestHeader.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/RequestHeader.java
@@ -26,13 +26,13 @@ import org.apache.servicecomb.foundation.protobuf.RootSerializer;
 import io.vertx.core.buffer.Buffer;
 
 public class RequestHeader {
-  private static ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
+  private static final ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
 
-  private static RootDeserializer<RequestHeader> rootDeserializer = protoMapperFactory
+  private static final RootDeserializer<RequestHeader> rootDeserializer = protoMapperFactory
       .createFromName("RequestHeader.proto")
       .createRootDeserializer("RequestHeader", RequestHeader.class);
 
-  private static RootSerializer rootSerializer = protoMapperFactory.createFromName("RequestHeader.proto")
+  private static final RootSerializer rootSerializer = protoMapperFactory.createFromName("RequestHeader.proto")
       .createRootSerializer("RequestHeader", RequestHeader.class);
 
   public static RootSerializer getRootSerializer() {

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/ResponseHeader.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/message/ResponseHeader.java
@@ -29,13 +29,13 @@ import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 
 public class ResponseHeader {
-  private static ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
+  private static final ProtoMapperFactory protoMapperFactory = new ProtoMapperFactory();
 
-  private static RootDeserializer<ResponseHeader> rootDeserializer = protoMapperFactory
+  private static final RootDeserializer<ResponseHeader> rootDeserializer = protoMapperFactory
       .createFromName("ResponseHeader.proto")
       .createRootDeserializer("ResponseHeader", ResponseHeader.class);
 
-  private static RootSerializer rootSerializer = protoMapperFactory.createFromName("ResponseHeader.proto")
+  private static final RootSerializer rootSerializer = protoMapperFactory.createFromName("ResponseHeader.proto")
       .createRootSerializer("ResponseHeader", ResponseHeader.class);
 
   public static RootSerializer getRootSerializer() {

--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/common/MockUtil.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/common/MockUtil.java
@@ -30,7 +30,7 @@ import mockit.MockUp;
 
 public class MockUtil {
 
-  private static MockUtil instance = new MockUtil();
+  private static final MockUtil instance = new MockUtil();
 
   private MockUtil() {
 

--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayTransport.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayTransport.java
@@ -40,7 +40,7 @@ import mockit.MockUp;
 public class TestHighwayTransport {
   private static final Logger LOGGER = LoggerFactory.getLogger(TestHighwayTransport.class);
 
-  private HighwayTransport transport = new HighwayTransport();
+  private final HighwayTransport transport = new HighwayTransport();
 
   @BeforeClass
   public static void setup() {

--- a/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/RestTransportClientManager.java
+++ b/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/RestTransportClientManager.java
@@ -27,7 +27,7 @@ public final class RestTransportClientManager {
   // same instance in AbstractTransport. need refactor in future.
   private final Vertx transportVertx = VertxUtils.getOrCreateVertxByName("transport", null);
 
-  private RestTransportClient restClient;
+  private final RestTransportClient restClient;
 
   private RestTransportClientManager() {
     try {

--- a/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestDefaultHttpClientFilter.java
+++ b/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestDefaultHttpClientFilter.java
@@ -52,7 +52,7 @@ import mockit.MockUp;
 import mockit.Mocked;
 
 public class TestDefaultHttpClientFilter {
-  private DefaultHttpClientFilter filter = new DefaultHttpClientFilter();
+  private final DefaultHttpClientFilter filter = new DefaultHttpClientFilter();
 
   @Test
   public void testOrder() {

--- a/transports/transport-rest/transport-rest-servlet/src/main/java/org/apache/servicecomb/transport/rest/servlet/RestServlet.java
+++ b/transports/transport-rest/transport-rest-servlet/src/main/java/org/apache/servicecomb/transport/rest/servlet/RestServlet.java
@@ -33,7 +33,7 @@ public class RestServlet extends HttpServlet {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RestServlet.class);
 
-  private ServletRestDispatcher servletRestServer = new ServletRestDispatcher();
+  private final ServletRestDispatcher servletRestServer = new ServletRestDispatcher();
 
   @Override
   public void init() throws ServletException {

--- a/transports/transport-rest/transport-rest-servlet/src/main/java/org/apache/servicecomb/transport/rest/servlet/ServletRestDispatcher.java
+++ b/transports/transport-rest/transport-rest-servlet/src/main/java/org/apache/servicecomb/transport/rest/servlet/ServletRestDispatcher.java
@@ -37,13 +37,13 @@ import org.apache.servicecomb.foundation.vertx.http.StandardHttpServletRequestEx
 import org.apache.servicecomb.foundation.vertx.http.StandardHttpServletResponseEx;
 
 public class ServletRestDispatcher {
-  private RestAsyncListener restAsyncListener = new RestAsyncListener();
+  private final RestAsyncListener restAsyncListener = new RestAsyncListener();
 
   private Transport transport;
 
   private MicroserviceMeta microserviceMeta;
 
-  private List<HttpServerFilter> httpServerFilters = SPIServiceUtils.getSortedService(HttpServerFilter.class);
+  private final List<HttpServerFilter> httpServerFilters = SPIServiceUtils.getSortedService(HttpServerFilter.class);
 
   public void service(HttpServletRequest request, HttpServletResponse response) {
     if (transport == null) {

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/MockForRestServerVerticle.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/MockForRestServerVerticle.java
@@ -27,7 +27,7 @@ import mockit.MockUp;
 
 public class MockForRestServerVerticle {
 
-  private static MockForRestServerVerticle instance = new MockForRestServerVerticle();
+  private static final MockForRestServerVerticle instance = new MockForRestServerVerticle();
 
   private MockForRestServerVerticle() {
     // private constructor for Singleton

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestVertxRestTransport.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestVertxRestTransport.java
@@ -39,7 +39,7 @@ import mockit.MockUp;
 
 public class TestVertxRestTransport {
 
-  private VertxRestTransport instance = new VertxRestTransport();
+  private final VertxRestTransport instance = new VertxRestTransport();
 
   @Test
   public void testGetInstance() {


### PR DESCRIPTION
Marking fields as `final` is always good for reader and compiler
1. the reader knows these fields value will never change.
2. The compiler can do more optimize based on final keyword.