### PR TITLE
[SCB-2469] update vertx to 4.2.7

### DIFF
--- a/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/element/impl/CookieAccessItem.java
+++ b/common/common-access-log/src/main/java/org/apache/servicecomb/common/accessLog/core/element/impl/CookieAccessItem.java
@@ -19,6 +19,7 @@ package org.apache.servicecomb.common.accessLog.core.element.impl;
 
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 
 import org.apache.servicecomb.common.accessLog.core.element.AccessLogItem;
 import org.apache.servicecomb.common.rest.RestConst;
@@ -41,12 +42,12 @@ public class CookieAccessItem implements AccessLogItem<RoutingContext> {
 
   @Override
   public void appendServerFormattedItem(ServerAccessLogEvent accessLogEvent, StringBuilder builder) {
-    Map<String, Cookie> cookieMap = accessLogEvent.getRoutingContext().cookieMap();
-    if (null == cookieMap) {
+    Set<Cookie> cookies = accessLogEvent.getRoutingContext().request().cookies();
+    if (null == cookies) {
       builder.append(RESULT_NOT_FOUND);
       return;
     }
-    for (Cookie cookie : cookieMap.values()) {
+    for (Cookie cookie : cookies) {
       if (varName.equals(cookie.getName())) {
         builder.append(cookie.getValue());
         return;

--- a/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/CookieItemTest.java
+++ b/common/common-access-log/src/test/java/org/apache/servicecomb/common/accessLog/core/element/impl/CookieItemTest.java
@@ -20,8 +20,10 @@ package org.apache.servicecomb.common.accessLog.core.element.impl;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 
+import io.vertx.core.http.HttpServerRequest;
 import org.apache.servicecomb.common.rest.RestConst;
 import org.apache.servicecomb.common.rest.codec.param.RestClientRequestImpl;
 import org.apache.servicecomb.core.Invocation;
@@ -52,6 +54,8 @@ public class CookieItemTest {
 
   private RoutingContext mockContext;
 
+  private HttpServerRequest httpServerRequest;
+
   private Invocation invocation;
 
   private RestClientRequestImpl restClientRequest;
@@ -59,6 +63,7 @@ public class CookieItemTest {
   @Before
   public void initStrBuilder() {
     mockContext = Mockito.mock(RoutingContext.class);
+    httpServerRequest = Mockito.mock(HttpServerRequest.class);
     finishEvent = Mockito.mock(InvocationFinishEvent.class);
     invocation = Mockito.mock(Invocation.class);
     restClientRequest = Mockito.mock(RestClientRequestImpl.class);
@@ -69,12 +74,12 @@ public class CookieItemTest {
 
   @Test
   public void serverFormattedElement() {
-    HashMap<String, Cookie> cookieSet = new HashMap<>();
+    HashSet<Cookie> cookieSet = new HashSet<>();
     CookieImpl cookie = new CookieImpl(COOKIE_NAME, COOKIE_VALUE);
 
-    cookieSet.put(cookie.getName(), cookie);
-    when(mockContext.cookieCount()).thenReturn(1);
-    when(mockContext.cookieMap()).thenReturn(cookieSet);
+    cookieSet.add(cookie);
+    Mockito.when(mockContext.request()).thenReturn(httpServerRequest);
+    Mockito.when(httpServerRequest.cookies()).thenReturn(cookieSet);
     accessLogEvent.setRoutingContext(mockContext);
 
     ELEMENT.appendServerFormattedItem(accessLogEvent, strBuilder);
@@ -99,9 +104,9 @@ public class CookieItemTest {
 
   @Test
   public void serverFormattedElementOnCookieCountIsZero() {
-    HashMap<String, Cookie> cookieSet = new HashMap<>();
-    Mockito.when(mockContext.cookieCount()).thenReturn(0);
-    Mockito.when(mockContext.cookieMap()).thenReturn(cookieSet);
+    HashSet<Cookie> cookieSet = new HashSet<>();
+    Mockito.when(mockContext.request()).thenReturn(httpServerRequest);
+    Mockito.when(httpServerRequest.cookies()).thenReturn(cookieSet);
     accessLogEvent.setRoutingContext(mockContext);
 
     ELEMENT.appendServerFormattedItem(accessLogEvent, strBuilder);
@@ -125,8 +130,8 @@ public class CookieItemTest {
 
   @Test
   public void serverFormattedElementOnCookieSetIsNull() {
-    Mockito.when(mockContext.cookieCount()).thenReturn(1);
-    Mockito.when(mockContext.cookieMap()).thenReturn(null);
+    Mockito.when(mockContext.request()).thenReturn(httpServerRequest);
+    Mockito.when(httpServerRequest.cookies()).thenReturn(null);
     accessLogEvent.setRoutingContext(mockContext);
 
     ELEMENT.appendServerFormattedItem(accessLogEvent, strBuilder);
@@ -149,11 +154,11 @@ public class CookieItemTest {
 
   @Test
   public void serverFormattedElementOnNotFound() {
-    HashMap<String, Cookie> cookieSet = new HashMap<>();
+    HashSet<Cookie> cookieSet = new HashSet<>();
     CookieImpl cookie = new CookieImpl("anotherCookieName", COOKIE_VALUE);
-    cookieSet.put(cookie.getName(), cookie);
-    Mockito.when(mockContext.cookieCount()).thenReturn(1);
-    Mockito.when(mockContext.cookieMap()).thenReturn(cookieSet);
+    cookieSet.add(cookie);
+    Mockito.when(mockContext.request()).thenReturn(httpServerRequest);
+    Mockito.when(httpServerRequest.cookies()).thenReturn(cookieSet);
     accessLogEvent.setRoutingContext(mockContext);
 
     ELEMENT.appendServerFormattedItem(accessLogEvent, strBuilder);

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -82,7 +82,7 @@
     <mock-server.version>3.10.4</mock-server.version>
     <narayana.version>5.3.2.Final</narayana.version>
     <netflix-commons.version>0.3.0</netflix-commons.version>
-    <netty.version>4.1.72.Final</netty.version>
+    <netty.version>4.1.74.Final</netty.version>
     <okhttp3.version>3.14.2</okhttp3.version>
     <powermock.version>1.6.2</powermock.version>
     <maven-model.version>3.8.5</maven-model.version>
@@ -107,10 +107,10 @@
     <stax2-api.version>4.2</stax2-api.version>
     <swagger.version>1.6.2</swagger.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>
-    <tcnetty.version>2.0.46.Final</tcnetty.version>
+    <tcnetty.version>2.0.48.Final</tcnetty.version>
     <tec-zkclient.version>0.10</tec-zkclient.version>
     <tomakehurst.version>2.6.0</tomakehurst.version>
-    <vertx.version>4.1.7</vertx.version>
+    <vertx.version>4.2.7</vertx.version>
     <xstream.version>1.4.11.1</xstream.version>
     <zipkin.version>2.19.1</zipkin.version>
     <zipkin-reporter.version>2.7.13</zipkin-reporter.version>

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/VertxUtils.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/VertxUtils.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import io.vertx.core.file.impl.FileResolverImpl;
 import org.apache.commons.io.IOUtils;
 import org.apache.servicecomb.foundation.common.Holder;
 import org.apache.servicecomb.foundation.common.concurrent.ConcurrentHashMapEx;
@@ -43,7 +44,6 @@ import io.vertx.core.Verticle;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.file.impl.FileResolver;
 import io.vertx.core.impl.VertxBuilder;
 import io.vertx.core.impl.VertxThread;
 import io.vertx.core.spi.VertxThreadFactory;
@@ -138,7 +138,7 @@ public final class VertxUtils {
    */
   private static void configureVertxFileCaching(VertxOptions vertxOptions) {
     boolean disableFileCPResolving = DynamicPropertyFactory.getInstance()
-        .getBooleanProperty(FileResolver.DISABLE_CP_RESOLVING_PROP_NAME, true).get();
+        .getBooleanProperty(FileResolverImpl.DISABLE_CP_RESOLVING_PROP_NAME, true).get();
     vertxOptions.getFileSystemOptions().setClassPathResolvingEnabled(!disableFileCPResolving);
   }
 

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxServerRequestToHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/VertxServerRequestToHttpServletRequest.java
@@ -95,11 +95,11 @@ public class VertxServerRequestToHttpServletRequest extends AbstractHttpServletR
   @Override
   public Cookie[] getCookies() {
     if (cookies == null) {
-      Map<String, io.vertx.core.http.Cookie> vertxCookies = context.cookieMap();
-      Cookie tmpCookies[] = new Cookie[vertxCookies.size()];
+      Set<io.vertx.core.http.Cookie> cookieSet = context.request().cookies();
+      Cookie[] tmpCookies = new Cookie[cookieSet.size()];
       int idx = 0;
-      for (io.vertx.core.http.Cookie oneVertxCookie : vertxCookies.values()) {
-        Cookie cookie = new Cookie(oneVertxCookie.getName(), oneVertxCookie.getValue());
+      for (io.vertx.core.http.Cookie vertxCookie : cookieSet) {
+        Cookie cookie = new Cookie(vertxCookie.getName(), vertxCookie.getValue());
         tmpCookies[idx] = cookie;
         idx++;
       }

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/TestVertxUtils.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/TestVertxUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.CountDownLatch;
 
+import io.vertx.core.file.impl.FileResolverImpl;
 import org.apache.commons.io.FileUtils;
 import org.apache.servicecomb.foundation.common.Holder;
 import org.apache.servicecomb.foundation.test.scaffolding.config.ArchaiusUtils;
@@ -35,7 +36,6 @@ import io.netty.buffer.Unpooled;
 import io.vertx.core.Vertx;
 import io.vertx.core.VertxOptions;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.file.impl.FileResolver;
 
 public class TestVertxUtils {
   @Test
@@ -60,7 +60,7 @@ public class TestVertxUtils {
     ArchaiusUtils.resetConfig();
 
     // create .vertx folder
-    ArchaiusUtils.setProperty(FileResolver.DISABLE_CP_RESOLVING_PROP_NAME, false);
+    ArchaiusUtils.setProperty(FileResolverImpl.DISABLE_CP_RESOLVING_PROP_NAME, false);
     deleteCacheFile();
     VertxUtils.getOrCreateVertxByName("testCreateVertxWithFileCPResolvingFalse", null);
     Assert.assertTrue(isCacheFileExists());
@@ -69,7 +69,7 @@ public class TestVertxUtils {
     // don't create .vertx folder
     deleteCacheFile();
     Assert.assertFalse(isCacheFileExists());
-    ArchaiusUtils.setProperty(FileResolver.DISABLE_CP_RESOLVING_PROP_NAME, true);
+    ArchaiusUtils.setProperty(FileResolverImpl.DISABLE_CP_RESOLVING_PROP_NAME, true);
     VertxUtils.getOrCreateVertxByName("testCreateVertxWithFileCPResolvingTrue", null);
     Assert.assertFalse(isCacheFileExists());
     VertxUtils.blockCloseVertxByName("testCreateVertxWithFileCPResolvingTrue");
@@ -78,7 +78,7 @@ public class TestVertxUtils {
   }
 
   private void deleteCacheFile() {
-    String cacheDirBase = System.getProperty(FileResolver.CACHE_DIR_BASE_PROP_NAME,
+    String cacheDirBase = System.getProperty(FileResolverImpl.CACHE_DIR_BASE_PROP_NAME,
         System.getProperty("java.io.tmpdir", "."));
     File folder = new File(cacheDirBase);
     File[] files = folder.listFiles();
@@ -90,7 +90,7 @@ public class TestVertxUtils {
   }
 
   private boolean isCacheFileExists() {
-    String cacheDirBase = System.getProperty(FileResolver.CACHE_DIR_BASE_PROP_NAME,
+    String cacheDirBase = System.getProperty(FileResolverImpl.CACHE_DIR_BASE_PROP_NAME,
         System.getProperty("java.io.tmpdir", "."));
     File folder = new File(cacheDirBase);
     File[] files = folder.listFiles();

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestVertxServerRequestToHttpServletRequest.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestVertxServerRequestToHttpServletRequest.java
@@ -20,8 +20,10 @@ package org.apache.servicecomb.foundation.vertx.http;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.AsyncContext;
 import javax.servlet.ServletInputStream;
@@ -118,23 +120,29 @@ public class TestVertxServerRequestToHttpServletRequest {
 
   @Test
   public void testGetCookies() {
-    Map<String, io.vertx.core.http.Cookie>  vertxCookies = new LinkedHashMap<>();
-    vertxCookies.put("c1", io.vertx.core.http.Cookie.cookie("c1", "c1v"));
-    vertxCookies.put("c2", io.vertx.core.http.Cookie.cookie("c2", "c2v"));
+    Set<io.vertx.core.http.Cookie> vertxCookies = new HashSet<>();
+    vertxCookies.add(io.vertx.core.http.Cookie.cookie("c1", "c1v"));
+    vertxCookies.add(io.vertx.core.http.Cookie.cookie("c2", "c2v"));
     new Expectations() {
       {
-        context.cookieMap();
+        context.request().cookies();
         result = vertxCookies;
       }
     };
 
     Cookie[] cookies = request.getCookies();
-    Assert.assertEquals("c1", cookies[0].getName());
-    Assert.assertEquals("c1v", cookies[0].getValue());
-    Assert.assertEquals("c2", cookies[1].getName());
-    Assert.assertEquals("c2v", cookies[1].getValue());
-
-    Assert.assertSame(cookies, request.getCookies());
+    // we can't ensure the sequence when set to list
+    if (cookies[0].getName().equals("c1")) {
+      Assert.assertEquals("c1", cookies[0].getName());
+      Assert.assertEquals("c1v", cookies[0].getValue());
+      Assert.assertEquals("c2", cookies[1].getName());
+      Assert.assertEquals("c2v", cookies[1].getValue());
+    } else {
+      Assert.assertEquals("c2", cookies[0].getName());
+      Assert.assertEquals("c2v", cookies[0].getValue());
+      Assert.assertEquals("c1", cookies[1].getName());
+      Assert.assertEquals("c1v", cookies[1].getValue());
+    }
   }
 
   @Test

--- a/integration-tests/spring-pojo-connection-limit-test/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoSpringConnectionLimitIntegrationTest.java
+++ b/integration-tests/spring-pojo-connection-limit-test/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoSpringConnectionLimitIntegrationTest.java
@@ -38,7 +38,7 @@ public class PojoSpringConnectionLimitIntegrationTest {
       PojoService.hello.SayHello("whatever");
       fail("connection limit failed");
     } catch (Exception e) {
-      Assert.assertEquals("io.vertx.core.VertxException: Connection was closed", e.getCause().toString());
+      Assert.assertEquals("io.vertx.core.http.HttpClosedException: Connection was closed", e.getCause().toString());
     }
   }
 }

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestVertxMetersInitializer.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestVertxMetersInitializer.java
@@ -176,9 +176,6 @@ public class TestVertxMetersInitializer {
           + "      connectCount disconnectCount queue         connections requests latency send(Bps) receive(Bps) remote\n";
       expect +=
           "      1            0               0             1           1        %-7s 4         21           http://127.0.0.1:%-"
-              + portSize + "s\n"
-              +
-              "      1            0               0             1           0        0       0         0            tcp://127.0.0.1:%-"
               + portSize + "s\n";
     }
     expect += ""
@@ -188,7 +185,7 @@ public class TestVertxMetersInitializer {
 
     if (printDetail) {
       expect = String
-          .format(expect, clientLatency, port, port, serverLatency);
+          .format(expect, clientLatency, port, serverLatency);
     } else {
       expect = String.format(expect, serverLatency);
     }

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestTransportConfig.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestTransportConfig.java
@@ -215,7 +215,7 @@ public class TestTransportConfig {
     ArchaiusUtils.setProperty("servicecomb.rest.server.http2.maxFrameSize", 65535);
     Assert.assertEquals(65535, TransportConfig.getMaxFrameSize());
 
-    Assert.assertEquals(Integer.MAX_VALUE, TransportConfig.getMaxHeaderListSize());
+    Assert.assertEquals(8192, TransportConfig.getMaxHeaderListSize());
     ArchaiusUtils.setProperty("servicecomb.rest.server.http2.maxHeaderListSize", 65535);
     Assert.assertEquals(65535, TransportConfig.getMaxHeaderListSize());
   }

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestVertxRestDispatcher.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestVertxRestDispatcher.java
@@ -20,6 +20,7 @@ package org.apache.servicecomb.transport.rest.vertx;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response.Status;
@@ -646,7 +647,17 @@ class MockHttpServerResponse implements HttpServerResponse {
   }
 
   @Override
-  public @Nullable Cookie removeCookie(String s, boolean b) {
+  public @Nullable Cookie removeCookie(String name, boolean invalidate) {
+    return null;
+  }
+
+  @Override
+  public Set<Cookie> removeCookies(String name, boolean invalidate) {
+    return null;
+  }
+
+  @Override
+  public @Nullable Cookie removeCookie(String name, String domain, String path, boolean invalidate) {
     return null;
   }
 }


### PR DESCRIPTION
## main changes
- cookie changes from map to set, because the rfc allow more than two cookies with same name
- `getMaxHeaderListSize` changes from Integer.MAX to 8192