### PR TITLE
[#2809]A judgment condition is added when gray rules match instances. This condition applies to scenarios where instances cannot be matched in cross-app invoking.

### DIFF
--- a/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/model/MicroserviceInstance.java
+++ b/clients/service-center-client/src/main/java/org/apache/servicecomb/service/center/client/model/MicroserviceInstance.java
@@ -153,6 +153,11 @@ public class MicroserviceInstance {
   }
 
   @JsonIgnore
+  public String getAlias() {
+    return this.microservice.getAlias();
+  }
+
+  @JsonIgnore
   public String getApplicationName() {
     return this.microservice.getAppId();
   }

--- a/governance/src/main/java/org/apache/servicecomb/router/distribute/AbstractRouterDistributor.java
+++ b/governance/src/main/java/org/apache/servicecomb/router/distribute/AbstractRouterDistributor.java
@@ -43,6 +43,8 @@ public abstract class AbstractRouterDistributor<T, E> implements
   private Function<E, String> getVersion;
 
   private Function<E, String> getServerName;
+  
+  private Function<E, String> getAlias;
 
   private Function<E, Map<String, String>> getProperties;
 
@@ -83,10 +85,12 @@ public abstract class AbstractRouterDistributor<T, E> implements
   public void init(Function<T, E> getIns,
       Function<E, String> getVersion,
       Function<E, String> getServerName,
+      Function<E, String> getAlias,
       Function<E, Map<String, String>> getProperties) {
     this.getIns = getIns;
     this.getVersion = getVersion;
     this.getServerName = getServerName;
+    this.getAlias = getAlias;
     this.getProperties = getProperties;
   }
 
@@ -110,7 +114,7 @@ public abstract class AbstractRouterDistributor<T, E> implements
     for (T server : list) {
       //get server
       E ms = getIns.apply(server);
-      if (getServerName.apply(ms).equals(serviceName)) {
+      if (getServerName.apply(ms).equals(serviceName) || getAlias.apply(ms).equals(serviceName)) {
         //most matching
         TagItem tagItem = new TagItem(getVersion.apply(ms), getProperties.apply(ms));
         TagItem targetTag = null;
@@ -146,7 +150,7 @@ public abstract class AbstractRouterDistributor<T, E> implements
     String latestVersion = null;
     for (T server : list) {
       E ms = getIns.apply(server);
-      if (getServerName.apply(ms).equals(serviceName)) {
+      if (getServerName.apply(ms).equals(serviceName) || getAlias.apply(ms).equals(serviceName)) {
         if (latestVersion == null || VersionCompareUtil
             .compareVersion(latestVersion, getVersion.apply(ms)) == -1) {
           latestVersion = getVersion.apply(ms);

--- a/governance/src/main/java/org/apache/servicecomb/router/distribute/RouterDistributor.java
+++ b/governance/src/main/java/org/apache/servicecomb/router/distribute/RouterDistributor.java
@@ -29,6 +29,7 @@ public interface RouterDistributor<T, E> {
 
   void init(Function<T, E> getIns, Function<E, String> getVersion,
       Function<E, String> getServerName,
+      Function<E, String> getAlias,
       Function<E, Map<String, String>> getProperties);
 
   List<T> distribute(String targetServiceName, List<T> list, PolicyRuleItem invokeRule);

--- a/governance/src/test/java/org/apache/servicecomb/router/ExampleDistributor.java
+++ b/governance/src/test/java/org/apache/servicecomb/router/ExampleDistributor.java
@@ -23,6 +23,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class ExampleDistributor extends AbstractRouterDistributor<ServiceIns, ServiceIns> {
   public ExampleDistributor() {
-    init(a -> a, ServiceIns::getVersion, ServiceIns::getServerName, ServiceIns::getTags);
+    init(a -> a, ServiceIns::getVersion, ServiceIns::getServerName, null, ServiceIns::getTags);
   }
 }

--- a/governance/src/test/java/org/apache/servicecomb/router/ExampleDistributor.java
+++ b/governance/src/test/java/org/apache/servicecomb/router/ExampleDistributor.java
@@ -23,6 +23,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class ExampleDistributor extends AbstractRouterDistributor<ServiceIns, ServiceIns> {
   public ExampleDistributor() {
-    init(a -> a, ServiceIns::getVersion, ServiceIns::getServerName, null, ServiceIns::getTags);
+    init(a -> a, ServiceIns::getVersion, ServiceIns::getServerName, ServiceIns::getAlias, ServiceIns::getTags);
   }
 }

--- a/governance/src/test/java/org/apache/servicecomb/router/RouterDistributorTest.java
+++ b/governance/src/test/java/org/apache/servicecomb/router/RouterDistributorTest.java
@@ -151,9 +151,9 @@ public class RouterDistributorTest {
 
   private List<ServiceIns> getMockList() {
     List<ServiceIns> serverList = new ArrayList<>();
-    ServiceIns ins1 = new ServiceIns("01", TARGET_SERVICE_NAME);
+    ServiceIns ins1 = new ServiceIns("01", TARGET_SERVICE_NAME, "");
     ins1.setVersion("2.0");
-    ServiceIns ins2 = new ServiceIns("02", TARGET_SERVICE_NAME);
+    ServiceIns ins2 = new ServiceIns("02", TARGET_SERVICE_NAME, "");
     ins2.addTags("app", "a");
     serverList.add(ins1);
     serverList.add(ins2);

--- a/governance/src/test/java/org/apache/servicecomb/router/ServiceIns.java
+++ b/governance/src/test/java/org/apache/servicecomb/router/ServiceIns.java
@@ -25,13 +25,16 @@ public class ServiceIns {
 
   String serverName;
 
+  String Alias;
+
   Map<String, String> tags = new HashMap<>();
 
   private final String id;
 
-  public ServiceIns(String id, String serverName) {
+  public ServiceIns(String id, String serverName, String alias) {
     this.id = id;
     this.serverName = serverName;
+    this.Alias = alias;
   }
 
   public String getId() {
@@ -56,5 +59,9 @@ public class ServiceIns {
 
   public void addTags(String key, String v) {
     tags.put(key, v);
+  }
+
+  public String getAlias() {
+    return Alias;
   }
 }

--- a/handlers/handler-router/src/main/java/org/apache/servicecomb/router/custom/ServiceCombCanaryDistributer.java
+++ b/handlers/handler-router/src/main/java/org/apache/servicecomb/router/custom/ServiceCombCanaryDistributer.java
@@ -30,6 +30,7 @@ public class ServiceCombCanaryDistributer extends
             .getService(server.getInstance().getServiceId()),
         Microservice::getVersion,
         Microservice::getServiceName,
+        Microservice::getAlias,
         Microservice::getProperties);
   }
 }


### PR DESCRIPTION
A judgment condition is added when gray rules match instances. This condition applies to scenarios where instances cannot be matched in cross-app invoking.
From:#2809