### PR TITLE
[SCB-2481] Make test paas on jdk11

### DIFF
--- a/.github/workflows/unit-test-jdk11.yml
+++ b/.github/workflows/unit-test-jdk11.yml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Unit Test Jdk11
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up jdk
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Compilation and Installation
+        run: mvn -B -Dcheckstyle.skip -Dspotbugs.skip=true clean test

--- a/foundations/foundation-spi/src/test/java/org/apache/servicecomb/foundation/common/utils/TestSPIServiceUtils.java
+++ b/foundations/foundation-spi/src/test/java/org/apache/servicecomb/foundation/common/utils/TestSPIServiceUtils.java
@@ -26,7 +26,7 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
 import org.mockito.Mockito;
 import org.springframework.core.Ordered;
@@ -66,7 +66,7 @@ public class TestSPIServiceUtils {
   }
 
   @Test
-  @EnabledForJreRange(min = JRE.JAVA_8, max = JRE.JAVA_11)
+  @EnabledOnJre(JRE.JAVA_8)
   public void testSort() {
     Ordered o1 = Mockito.mock(Ordered.class);
     Ordered o2 = Mockito.mock(Ordered.class);
@@ -136,7 +136,7 @@ public class TestSPIServiceUtils {
   }
 
   @Test
-  @EnabledForJreRange(min = JRE.JAVA_8, max = JRE.JAVA_11)
+  @EnabledOnJre(JRE.JAVA_8)
   public void getPriorityHighestServices() {
     Map<String, PriorityIntf> instances = new LinkedHashMap<>();
     instances.putIfAbsent("1", new PriorityImpl("n1", 0));

--- a/pom.xml
+++ b/pom.xml
@@ -666,6 +666,20 @@
       </reporting>
     </profile>
     <profile>
+      <id>jdk11</id>
+      <activation>
+        <jdk>[11,)</jdk>
+      </activation>
+      <properties>
+        <werror.properties/>
+        <test.additional.args>
+          -Djdk.attach.allowAttachSelf
+          --add-opens java.base/java.lang=ALL-UNNAMED
+          --add-reads java.base=java.desktop
+        </test.additional.args>
+      </properties>
+    </profile>
+    <profile>
       <id>jdk17</id>
       <activation>
         <jdk>[17,)</jdk>

--- a/swagger/swagger-generator/generator-jaxrs/pom.xml
+++ b/swagger/swagger-generator/generator-jaxrs/pom.xml
@@ -45,5 +45,10 @@
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>foundation-test-scaffolding</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/swagger/swagger-generator/generator-springmvc/pom.xml
+++ b/swagger/swagger-generator/generator-springmvc/pom.xml
@@ -53,5 +53,10 @@
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>foundation-test-scaffolding</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
### changes
- make test paas on jdk11
- add jdk11 check

### why don't run integrate-tests on jdk11
I think now we don't need run integrates-tests on all java version, it costs time and little effect