### PR TITLE
[SCB-2489] Add dependeny bot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,10 @@ updates:
     directory: "/dependencies/default"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "jersey-common"
+        versions:
+          - "3.x"
+      - dependency-name: "okhttp"
+        versions:
+          - "4.x"


### PR DESCRIPTION
## motivation
many frameworks still use jersey 2.x and okhttp 3.x, we should not update so quick to avoid conflict
## changes
- add jersey-common 3.x ignore
- add okhttp 4.x ignore