### PR TITLE
[SCB-2489] Add dependeny bot ignore jakarta.activation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,9 @@ updates:
     schedule:
       interval: "daily"
     ignore:
+      - dependency-name: "jakarta.activation"
+        versions:
+          - "2.x"
       - dependency-name: "jersey-common"
         versions:
           - "3.x"

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -31,7 +31,7 @@
 
   <properties>
     <!-- Dependency versions -->
-    <activation.version>1.2.1</activation.version>
+    <activation.version>1.2.2</activation.version>
     <archaius.version>0.7.7</archaius.version>
     <asciidoctorj.version>1.6.2</asciidoctorj.version>
     <aspectj.version>1.9.9.1</aspectj.version>


### PR DESCRIPTION
## motivation
many frameworks still use jakarta.activation 2.x, we should not update so quick to avoid conflict
## changes
- add jakarta.activation 2.x ignore
- bump  jakarta.activation to 1.2.2