### PR TITLE
[SCB-2489] Add dependeny bot ignore swagger2markup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,5 @@ updates:
       - dependency-name: "okhttp"
         versions:
           - "4.x"
+      - dependency-name: "swagger2markup"
+        # swagger2markup new version needs java11 now


### PR DESCRIPTION
swagger2markup new version needs java11 now