### PR TITLE
[SCB-2489] Add dependeny bot ignore rs-api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
       - dependency-name: "jakarta.activation"
         versions:
           - "2.x"
+      - dependency-name: "jakarta.ws.rs-api"
+        versions:
+          - "3.x"
       - dependency-name: "jersey-common"
         versions:
           - "3.x"


### PR DESCRIPTION
## motivation
many frameworks still use jakarta.ws.rs-api 2.x, we should not update so quick to avoid conflict
## changes
- add jakarta.ws.rs-api 3.x ignore