### PR TITLE
[SCB-2489] Add dependeny bot ignore jakarta.servlet-api

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,9 @@ updates:
       - dependency-name: "jakarta.activation"
         versions:
           - "2.x"
+      - dependency-name: "jakarta.servlet-api"
+        versions:
+          - "5.x"
       - dependency-name: "jakarta.ws.rs-api"
         versions:
           - "3.x"

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -92,7 +92,7 @@
     <rxnetty.version>0.5.1</rxnetty.version>
     <seanyinx.version>1.0.0</seanyinx.version>
     <servo.version>0.12.25</servo.version>
-    <servlet-api.version>4.0.3</servlet-api.version>
+    <servlet-api.version>4.0.4</servlet-api.version>
     <slf4j.version>1.7.36</slf4j.version>
     <snakeyaml.version>1.30</snakeyaml.version>
     <spectator.version>0.83.0</spectator.version>


### PR DESCRIPTION
## motivation
many frameworks still use jakarta.servlet-api 4.x, we should not update so quick to avoid conflict
## changes
- add jakarta.activation 5.x ignore
- bump  jakarta.activation to 4.0.4