### PR TITLE
[SCB-2489] optimize dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,10 +22,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-  - package-ecosystem: "maven"
-    directory: "/dependencies/default"
-    schedule:
-      interval: "daily"
+    open-pull-requests-limit: 20
     ignore:
       - dependency-name: "jakarta.activation"
         versions:

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -677,12 +677,6 @@
 
       <dependency>
         <groupId>org.mockito</groupId>
-        <artifactId>mockito-all</artifactId>
-        <version>${mockito.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
         <scope>test</scope>


### PR DESCRIPTION
## changes
- Since https://github.com/dependabot/dependabot-core/issues/222 is merged, we don't need to specify all the version location in the project
- `mockito-all` is on longer release since mockito 2.x, now we are using mockit 3.x