### PR TITLE
[SCB-2531] Bump servo version from 0.12.25 to 0.13.2

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -88,7 +88,7 @@
     <rxjava.version>1.3.8</rxjava.version>
     <rxnetty.version>0.5.1</rxnetty.version>
     <seanyinx.version>1.0.0</seanyinx.version>
-    <servo.version>0.12.25</servo.version>
+    <servo.version>0.13.2</servo.version>
     <servlet-api.version>4.0.4</servlet-api.version>
     <slf4j.version>1.7.36</slf4j.version>
     <snakeyaml.version>1.30</snakeyaml.version>

--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestDefaultRegistryInitializer.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/TestDefaultRegistryInitializer.java
@@ -44,7 +44,7 @@ public class TestDefaultRegistryInitializer {
     Assertions.assertEquals(-10, registryInitializer.getOrder());
     Assertions.assertTrue(globalRegistry.getDefaultRegistry() instanceof com.netflix.spectator.servo.ServoRegistry);
     Assertions.assertEquals(1, registries.size());
-    Assertions.assertEquals(1, DefaultMonitorRegistry.getInstance().getRegisteredMonitors().size());
+    Assertions.assertEquals(0, DefaultMonitorRegistry.getInstance().getRegisteredMonitors().size());
 
     registryInitializer.destroy();
 


### PR DESCRIPTION
<img width="1009" alt="image" src="https://user-images.githubusercontent.com/24262327/169829683-05ee1d20-fce0-48e3-a4bb-5e351d9a4cdf.png">

By the servo v0.13.2, the default way of  monitor registry return a abstract class, and its size is 0. 

<img width="1004" alt="image" src="https://user-images.githubusercontent.com/24262327/169832062-99dea270-12b0-44ee-b3b5-15ca7e196776.png">

By the servo v0.12.25,the default way of  monitor registry return a class, and its size is 1. old version's test is suitable for new version.