### PR TITLE
[SCB-2533] [1.3.x] encode invocation context before add to http header

### DIFF
--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/JsonUtils.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/utils/JsonUtils.java
@@ -28,6 +28,7 @@ import org.apache.servicecomb.foundation.common.utils.json.JavaxServletPartSeria
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,6 +37,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public final class JsonUtils {
   public static final ObjectMapper OBJ_MAPPER;
+  private static final ObjectMapper UNICODE_OBJ_MAPPER;
 
   static {
     OBJ_MAPPER = new ObjectMapper();
@@ -48,6 +50,9 @@ public final class JsonUtils {
     partDeserializeModule.addSerializer(Part.class, new JavaxServletPartSerializer());
     partDeserializeModule.addDeserializer(Part.class, new JavaxServletPartDeserializer());
     OBJ_MAPPER.registerModule(partDeserializeModule);
+
+    UNICODE_OBJ_MAPPER = OBJ_MAPPER.copy();
+    UNICODE_OBJ_MAPPER.enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature());
   }
 
   private JsonUtils() {
@@ -71,6 +76,10 @@ public final class JsonUtils {
 
   public static String writeValueAsString(Object value) throws JsonProcessingException {
     return OBJ_MAPPER.writeValueAsString(value);
+  }
+
+  public static String writeUnicodeValueAsString(Object value) throws JsonProcessingException {
+    return UNICODE_OBJ_MAPPER.writeValueAsString(value);
   }
 
   public static <T> T convertValue(Object fromValue, Class<T> toValueType) {

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/JsonUtilsTest.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/JsonUtilsTest.java
@@ -1,0 +1,29 @@
+package org.apache.servicecomb.foundation.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import junit.framework.TestCase;
+import org.apache.commons.lang.StringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class JsonUtilsTest extends TestCase {
+
+    @Test
+    public void testWriteUnicodeValueAsString() throws JsonProcessingException {
+        String unicodeStr = "测试";
+        Map<String, String> inMap = new HashMap<>();
+        inMap.put("key", unicodeStr);
+
+        Assert.assertFalse(StringUtils.isAsciiPrintable(JsonUtils.writeValueAsString(inMap)));
+        String jsonStr = JsonUtils.writeUnicodeValueAsString(inMap);
+        Assert.assertTrue(StringUtils.isAsciiPrintable(jsonStr));
+
+        Map<String, String> outMap = JsonUtils.OBJ_MAPPER.readValue(jsonStr, new TypeReference<Map<String, String>>() {
+        });
+        Assert.assertEquals(unicodeStr, outMap.get("key"));
+    }
+}

--- a/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/JsonUtilsTest.java
+++ b/foundations/foundation-common/src/test/java/org/apache/servicecomb/foundation/common/utils/JsonUtilsTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.servicecomb.foundation.common.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/java-chassis-dependencies/default/pom.xml
+++ b/java-chassis-dependencies/default/pom.xml
@@ -43,6 +43,7 @@
     <commons-io.version>2.6</commons-io.version>
     <commons-lang.version>2.6</commons-lang.version>
     <commons-lang3.version>3.9</commons-lang3.version>
+    <commons-text.version>1.9</commons-text.version>
     <commons-logging.version>1.2</commons-logging.version>
     <cxf.version>3.3.1</cxf.version>
     <dyuproject-protostuff.version>1.0.7.fixed.3500</dyuproject-protostuff.version>
@@ -722,6 +723,12 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-text</artifactId>
+        <version>${commons-text.version}</version>
       </dependency>
 
       <dependency>

--- a/transports/transport-rest/transport-rest-client/pom.xml
+++ b/transports/transport-rest/transport-rest-client/pom.xml
@@ -58,6 +58,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>foundation-test-scaffolding</artifactId>
       <scope>test</scope>

--- a/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/http/RestClientInvocation.java
+++ b/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/http/RestClientInvocation.java
@@ -274,7 +274,7 @@ public class RestClientInvocation {
 
   protected void setCseContext() {
     try {
-      String cseContext = JsonUtils.writeValueAsString(invocation.getContext());
+      String cseContext = JsonUtils.writeUnicodeValueAsString(invocation.getContext());
       clientRequest.putHeader(org.apache.servicecomb.core.Const.CSE_CONTEXT, cseContext);
     } catch (Throwable e) {
       LOGGER.debug(invocation.getMarker(), "Failed to encode and set cseContext.", e);

--- a/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestRestClientInvocation.java
+++ b/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestRestClientInvocation.java
@@ -277,7 +277,7 @@ public class TestRestClientInvocation {
 
     new Expectations(JsonUtils.class) {
       {
-        JsonUtils.writeValueAsString(any);
+        JsonUtils.writeUnicodeValueAsString(any);
         result = new RuntimeExceptionWithoutStackTrace();
       }
     };

--- a/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestRestClientInvocation.java
+++ b/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestRestClientInvocation.java
@@ -31,8 +31,11 @@ import java.util.Map;
 
 import javax.servlet.http.Part;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.log4j.Level;
 import org.apache.servicecomb.common.rest.RestConst;
+import org.apache.servicecomb.common.rest.VertxRestInvocation;
 import org.apache.servicecomb.common.rest.definition.RestOperationMeta;
 import org.apache.servicecomb.common.rest.definition.path.URLPathBuilder;
 import org.apache.servicecomb.common.rest.filter.HttpClientFilter;
@@ -49,6 +52,7 @@ import org.apache.servicecomb.foundation.common.utils.ReflectUtils;
 import org.apache.servicecomb.foundation.test.scaffolding.exception.RuntimeExceptionWithoutStackTrace;
 import org.apache.servicecomb.foundation.test.scaffolding.log.LogCollector;
 import org.apache.servicecomb.foundation.vertx.client.http.HttpClientWithContext;
+import org.apache.servicecomb.foundation.vertx.http.HttpServletRequestEx;
 import org.apache.servicecomb.foundation.vertx.http.ReadStreamPart;
 import org.apache.servicecomb.foundation.vertx.metrics.metric.DefaultEndpointMetric;
 import org.apache.servicecomb.foundation.vertx.metrics.metric.DefaultHttpSocketMetric;
@@ -287,6 +291,75 @@ public class TestRestClientInvocation {
     Assert.assertEquals("Failed to encode and set cseContext.", logCollector.getEvents().get(0).getMessage());
     logCollector.teardown();
   }
+
+  @Test
+  public void testSetCseContext_enable_unicode() {
+    Map<String, String> contextMap = new HashMap<String, String>();
+    contextMap.put("key", "测试");
+    contextMap.put("encodedKey", StringEscapeUtils.escapeJson("测试"));
+    when(invocation.getContext()).thenReturn(contextMap);
+    restClientInvocation.setCseContext();
+
+    String context =  headers.get(org.apache.servicecomb.core.Const.CSE_CONTEXT);
+    HttpServletRequestEx requestEx = new MockUp<HttpServletRequestEx>(){
+      @Mock
+      public String getHeader(String name){
+        if (StringUtils.equals(name, org.apache.servicecomb.core.Const.CSE_CONTEXT)){
+          return context;
+        } else {
+          return null;
+        }
+      }
+    }.getMockInstance();
+
+    VertxRestInvocation vertxRestInvocation = new VertxRestInvocation();
+    Deencapsulation.setField(vertxRestInvocation, "requestEx", requestEx);
+    Deencapsulation.setField(vertxRestInvocation, "invocation", invocation);
+
+    Deencapsulation.invoke(vertxRestInvocation, "setContext");
+
+    Assert.assertEquals("测试", invocation.getContext().get("key"));
+    Assert.assertEquals(StringEscapeUtils.escapeJson("测试"), invocation.getContext().get("encodedKey"));
+  }
+
+
+  @Test
+  public void testSetCseContext_disable_unicode() throws JsonProcessingException {
+    Map<String, String> contextMap = new HashMap<String, String>();
+    contextMap.put("key", "测试");
+    contextMap.put("encodedKey", StringEscapeUtils.escapeJson("测试"));
+    when(invocation.getContext()).thenReturn(contextMap);
+
+    new MockUp<JsonUtils>() {
+      @Mock
+      public String writeUnicodeValueAsString(Object value) throws JsonProcessingException {
+        return JsonUtils.writeValueAsString(value);
+      }
+    };
+    
+    restClientInvocation.setCseContext();
+    String context =  headers.get(org.apache.servicecomb.core.Const.CSE_CONTEXT);
+    HttpServletRequestEx requestEx = new MockUp<HttpServletRequestEx>(){
+      @Mock
+      public String getHeader(String name){
+        if (StringUtils.equals(name, org.apache.servicecomb.core.Const.CSE_CONTEXT)){
+          return context;
+        } else {
+          return null;
+        }
+      }
+    }.getMockInstance();
+
+    VertxRestInvocation vertxRestInvocation = new VertxRestInvocation();
+    Deencapsulation.setField(vertxRestInvocation, "requestEx", requestEx);
+    Deencapsulation.setField(vertxRestInvocation, "invocation", invocation);
+
+    Deencapsulation.invoke(vertxRestInvocation, "setContext");
+
+    Assert.assertEquals("测试", invocation.getContext().get("key"));
+    Assert.assertEquals(StringEscapeUtils.escapeJson("测试"), invocation.getContext().get("encodedKey"));
+  }
+
 
   @SuppressWarnings("unchecked")
   @Test


### PR DESCRIPTION
fix issus #3008

add writeUnicodeValueAsString to JsonUtils to support unicode encoding
encode invocation context before add to http header