### PR TITLE
[SCB-2538] Bump okhttp version from 3.14.2 to 4.9.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,8 +41,5 @@ updates:
           - "3.x"
       - dependency-name: "protostuff-parser"
         # protostuff-parser new versions needs java11 now
-      - dependency-name: "okhttp"
-        versions:
-          - "4.x"
       - dependency-name: "swagger2markup"
         # swagger2markup new version needs java11 now

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -74,7 +74,7 @@
     <mock-server.version>5.13.2</mock-server.version>
     <netflix-commons.version>0.3.0</netflix-commons.version>
     <netty.version>4.1.77.Final</netty.version>
-    <okhttp3.version>3.14.2</okhttp3.version>
+    <okhttp3.version>4.9.3</okhttp3.version>
     <powermock.version>2.0.9</powermock.version>
     <maven-model.version>3.8.5</maven-model.version>
     <micrometer.version>1.9.0</micrometer.version>
@@ -298,6 +298,12 @@
       <dependency>
         <groupId>com.squareup.okhttp3</groupId>
         <artifactId>okhttp</artifactId>
+        <version>${okhttp3.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>mockwebserver</artifactId>
         <version>${okhttp3.version}</version>
       </dependency>
 


### PR DESCRIPTION
Sine okhttp3 3.x is not maintained, update to 4.x