### PR TITLE
[SCB-2489] Add dependeny bot ignore jakarta.servlet-api 6.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,7 @@ updates:
       - dependency-name: "jakarta.servlet-api"
         versions:
           - "5.x"
+          - "6.x"
       - dependency-name: "jakarta.ws.rs-api"
         versions:
           - "3.x"


### PR DESCRIPTION
## motivation
many frameworks still use jakarta.servlet-api 4.x, we should not update so quick to avoid conflict
## changes
add jakarta.activation 6.x ignore