### PR TITLE
[SCB-2542]bump guice version from 4.2.0 to 5.1.0

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -51,7 +51,7 @@
     <governator-api.version>1.17.12</governator-api.version>
     <guava.version>31.1-jre</guava.version>
     <failureaccess.version>1.0.1</failureaccess.version>
-    <guice.version>4.2.0</guice.version>
+    <guice.version>5.1.0</guice.version>
     <hamcrest.version>1.3</hamcrest.version>
     <hdr-histogram.version>2.1.12</hdr-histogram.version>
     <hibernate-validator.version>6.2.3.Final</hibernate-validator.version>
@@ -180,6 +180,11 @@
             <artifactId>aopalliance</artifactId>
           </exclusion>
         </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject.extensions</groupId>
+        <artifactId>guice-assistedinject</artifactId>
+        <version>${guice.version}</version>
       </dependency>
 
       <dependency>
@@ -426,6 +431,10 @@
           <exclusion>
             <groupId>org.abego.treelayout</groupId>
             <artifactId>org.abego.treelayout.core</artifactId>
+          </exclusion>
+          <exclusion>
+              <groupId>com.google.inject.extensions</groupId>
+              <artifactId>guice-multibindings</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
bump guice version from 4.2.0 to 5.1.0

### changes description

1. `io.protostuff-parser` [2.2.27](https://mvnrepository.com/artifact/io.protostuff/protostuff-parser/2.2.27) is not compatible with `guice 5.1.0` because of depending on an older version of `guice-multibindings` and `guice-assistedinject`.
2. It's was decided to upgrade `guice-multibindings` and `guice-assistedinject` instead of directly upgrading `io.protostuff-parser` since newer version of  `io.protostuff-parser` requires java 11.

4. `guice-multibindings` is excluded explicitly because it was removed(and not needed) since [guice 4.2](https://github.com/google/guice/wiki/Multibindings).
5. manually set `guice-assistedinject` version in order to make it consistent with guice(5.1.0) 
