### PR TITLE
[SCB-2557] Remove unused plugin maven-jxr-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,16 +162,6 @@
     <module>huawei-cloud</module>
   </modules>
 
-  <reporting>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jxr-plugin</artifactId>
-        <version>${maven-jxr-plugin.version}</version>
-      </plugin>
-    </plugins>
-  </reporting>
-
   <build>
     <extensions>
       <extension>


### PR DESCRIPTION
the variable `${maven-jxr-plugin.version}` is not defined, no need to delete