### PR TITLE
[SCB-2561] Use mockito-inline to replace powermock

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -71,12 +71,11 @@
     <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.17.2</log4j2.version>
     <logback.version>1.2.11</logback.version>
-    <mockito.version>3.3.3</mockito.version>
+    <mockito.version>3.12.4</mockito.version>
     <mock-server.version>5.13.2</mock-server.version>
     <netflix-commons.version>0.3.0</netflix-commons.version>
     <netty.version>4.1.77.Final</netty.version>
     <okhttp3.version>4.10.0</okhttp3.version>
-    <powermock.version>2.0.9</powermock.version>
     <maven-model.version>3.8.6</maven-model.version>
     <micrometer.version>1.9.0</micrometer.version>
     <nacos-client.version>2.1.0</nacos-client.version>
@@ -706,25 +705,6 @@
         <groupId>org.mock-server</groupId>
         <artifactId>mockserver-netty</artifactId>
         <version>${mock-server.version}</version>
-        <scope>test</scope>
-      </dependency>
-
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-api-mockito2</artifactId>
-        <version>${powermock.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-junit4</artifactId>
-        <version>${powermock.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.powermock</groupId>
-        <artifactId>powermock-module-test-mockito-junit4-delegate</artifactId>
-        <version>${powermock.version}</version>
         <scope>test</scope>
       </dependency>
 

--- a/foundations/foundation-common/pom.xml
+++ b/foundations/foundation-common/pom.xml
@@ -131,6 +131,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-inline</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jmockit</groupId>
       <artifactId>jmockit</artifactId>
       <scope>test</scope>

--- a/handlers/handler-fault-injection/src/test/java/org/apache/servicecomb/faultinjection/TestFaultInjectHandler.java
+++ b/handlers/handler-fault-injection/src/test/java/org/apache/servicecomb/faultinjection/TestFaultInjectHandler.java
@@ -81,7 +81,7 @@ public class TestFaultInjectHandler {
     asyncResp = Mockito.mock(AsyncResponse.class);
     operationMeta = Mockito.mock(OperationMeta.class);
     transport = Mockito.mock(Transport.class);
-    MockitoAnnotations.initMocks(this);
+    MockitoAnnotations.openMocks(this);
   }
 
   @After

--- a/parents/default/pom.xml
+++ b/parents/default/pom.xml
@@ -56,16 +56,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-api-mockito2</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.powermock</groupId>
-      <artifactId>powermock-module-junit4</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.github.seanyinx</groupId>
       <artifactId>unit-scaffolding</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
powermock can not use with junit5, use `mockito-inline` to replace powermock