### PR TITLE
[SCB-2566] Remove unused tcnative dependency version define

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -98,7 +98,6 @@
     <spring-boot.version>2.6.7</spring-boot.version>
     <swagger.version>1.6.6</swagger.version>
     <swagger2markup.version>1.3.3</swagger2markup.version>
-    <tcnetty.version>2.0.53.Final</tcnetty.version>
     <vertx.version>4.2.7</vertx.version>
     <zipkin.version>2.23.16</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
@@ -365,11 +364,6 @@
         <scope>import</scope>
         <version>${netty.version}</version>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${tcnetty.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
It's already defined in netty-bom, and should be keep consistent with netty.