### PR TITLE
[SCB-2585]migrate integration-test module to junit5

### DIFF
--- a/integration-tests/dynamic-config-tests/src/test/java/org/apache/dynamicconfig/test/DynamicConfigurationIT.java
+++ b/integration-tests/dynamic-config-tests/src/test/java/org/apache/dynamicconfig/test/DynamicConfigurationIT.java
@@ -19,9 +19,9 @@ package org.apache.dynamicconfig.test;
 
 import org.apache.servicecomb.foundation.common.utils.BeanUtils;
 import org.apache.servicecomb.foundation.common.utils.Log4jUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import com.netflix.config.DynamicPropertyFactory;
 
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Assertions;
 public class DynamicConfigurationIT {
   private static Vertx vertx = null;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     vertx = Vertx.vertx();
     vertx.deployVerticle(new SimApolloServer());
@@ -40,7 +40,7 @@ public class DynamicConfigurationIT {
     BeanUtils.init();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     vertx.close();
   }

--- a/integration-tests/it-consumer/pom.xml
+++ b/integration-tests/it-consumer/pom.xml
@@ -47,6 +47,10 @@
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/ResultPrinter.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/ResultPrinter.java
@@ -53,8 +53,8 @@ public class ResultPrinter {
       sb.append(String.format("%s, %s\n"
               + "%s\n",
           failure.getParents(),
-          failure.getTestHeader(),
-          failure.getTrace()));
+          failure.getDisplayName(),
+          failure.getStacktrace()));
     }
     sb.append(String.format("\nrun count:%d, failed count: %d, totalTime: %s.\n",
         ITJUnitUtils.getRunCount(),

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/junit/SCBFailure.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/junit/SCBFailure.java
@@ -16,22 +16,42 @@
  */
 package org.apache.servicecomb.it.junit;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.List;
 
-import org.junit.runner.Description;
-import org.junit.runner.notification.Failure;
-
-public class SCBFailure extends Failure {
-  private static final long serialVersionUID = 6467681668616080232L;
+public class SCBFailure {
 
   private final List<String> parents;
 
-  public SCBFailure(Description description, Throwable thrownException) {
-    super(description, thrownException);
+  private final String displayName;
+
+  private final Throwable exception;
+
+  public SCBFailure(String displayName, Throwable thrownException) {
+    this.displayName = displayName;
+    exception = thrownException;
+
     parents = ITJUnitUtils.cloneParents();
   }
 
   public List<String> getParents() {
     return parents;
+  }
+
+  public String getDisplayName() {
+    return displayName;
+  }
+
+  public String getStacktrace() {
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter writer = new PrintWriter(stringWriter);
+    exception.printStackTrace(writer);
+    return stringWriter.toString();
+  }
+
+  @Override
+  public String toString() {
+    return "" + displayName + ":" + exception.getMessage();
   }
 }

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/schema/TestApiOperation.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/schema/TestApiOperation.java
@@ -24,7 +24,7 @@ import org.apache.servicecomb.core.definition.MicroserviceMeta;
 import org.apache.servicecomb.core.definition.SchemaMeta;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.swagger.models.Operation;
 import io.swagger.models.Swagger;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/schema/generic/TestMyService.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/schema/generic/TestMyService.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.servicecomb.it.Consumers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestMyService {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestAcceptType.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestAcceptType.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestAnnotatedAttribute.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestAnnotatedAttribute.java
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestApiOperationOverride.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestApiOperationOverride.java
@@ -21,7 +21,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.servicecomb.it.Consumers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.ResponseEntity;
 

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestApiParam.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestApiParam.java
@@ -21,7 +21,7 @@ import org.apache.servicecomb.core.definition.MicroserviceMeta;
 import org.apache.servicecomb.core.definition.OperationMeta;
 import org.apache.servicecomb.core.definition.SchemaMeta;
 import org.apache.servicecomb.swagger.SwaggerUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.swagger.models.ModelImpl;
 import io.swagger.models.parameters.BodyParameter;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestAsyncInvoke.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestAsyncInvoke.java
@@ -29,7 +29,7 @@ import org.apache.servicecomb.it.schema.DefaultJsonValueResponse;
 import org.apache.servicecomb.provider.springmvc.reference.async.CseAsyncRestTemplate;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.concurrent.ListenableFuture;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestChangeTransport.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestChangeTransport.java
@@ -17,7 +17,7 @@
 package org.apache.servicecomb.it.testcase;
 
 import org.apache.servicecomb.it.Consumers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestChangeTransport {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDataTypePrimitive.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDataTypePrimitive.java
@@ -25,7 +25,7 @@ import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.it.extend.engine.ITSCBRestTemplate;
 import org.apache.servicecomb.it.junit.ITJUnitUtils;
 import org.apache.servicecomb.it.schema.DynamicColor;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDefaultJsonValueJaxrsSchema.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDefaultJsonValueJaxrsSchema.java
@@ -22,7 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDefaultMethod.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDefaultMethod.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.it.testcase;
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.swagger.SwaggerUtils;
 import org.apache.servicecomb.swagger.generator.SwaggerGenerator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import io.swagger.models.Swagger;
 import org.junit.jupiter.api.Assertions;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDefaultValue.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDefaultValue.java
@@ -18,7 +18,7 @@ package org.apache.servicecomb.it.testcase;
 
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDownload.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDownload.java
@@ -31,7 +31,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.servicecomb.foundation.vertx.http.ReadStreamPart;
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.it.testcase.support.DownloadSchemaIntf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDownloadSlowStreamEdge.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestDownloadSlowStreamEdge.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.it.testcase;
 import java.io.IOException;
 
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import okhttp3.OkHttpClient;
 import okhttp3.Request;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestExceptionConvertEdge.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestExceptionConvertEdge.java
@@ -18,8 +18,9 @@
 package org.apache.servicecomb.it.testcase;
 
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
-import org.junit.Test;
+
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestGenericEdge.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestGenericEdge.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
 import org.apache.servicecomb.it.schema.Generic;
 import org.apache.servicecomb.it.schema.User;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestGenericEdge {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestIgnoreMethod.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestIgnoreMethod.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.it.testcase;
 import org.apache.servicecomb.core.SCBEngine;
 import org.apache.servicecomb.core.definition.MicroserviceMeta;
 import org.apache.servicecomb.core.definition.SchemaMeta;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestIgnoreMethod {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestIgnoreStaticMethod.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestIgnoreStaticMethod.java
@@ -21,7 +21,7 @@ import org.apache.servicecomb.core.SCBEngine;
 import org.apache.servicecomb.core.definition.MicroserviceMeta;
 import org.apache.servicecomb.core.definition.OperationMeta;
 import org.apache.servicecomb.core.definition.SchemaMeta;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestIgnoreStaticMethod {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestJsonView.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestJsonView.java
@@ -18,7 +18,7 @@ package org.apache.servicecomb.it.testcase;
 
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.it.schema.PersonViewModel;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestJsonView {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestOptional.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestOptional.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.servicecomb.it.Consumers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.ResponseEntity;
 

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestParamCodec.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestParamCodec.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.it.testcase;
 import org.apache.servicecomb.foundation.test.scaffolding.model.Media;
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.it.junit.ITJUnitUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestParamCodec {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestParamCodecEdge.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestParamCodecEdge.java
@@ -28,7 +28,7 @@ import javax.ws.rs.core.MediaType;
 import org.apache.servicecomb.foundation.test.scaffolding.model.Media;
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
 import org.apache.servicecomb.it.junit.ITJUnitUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestReactive.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestReactive.java
@@ -20,7 +20,7 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.it.schema.ReactiveHelloIntf;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestReactive {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRequestBodySpringMvcSchema.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRequestBodySpringMvcSchema.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRestController.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRestController.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.it.testcase;
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
 import org.apache.servicecomb.it.extend.engine.ITSCBRestTemplate;
 import org.apache.servicecomb.it.junit.ITJUnitUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestRestController {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRestServerConfigEdge.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRestServerConfigEdge.java
@@ -23,7 +23,7 @@ import java.net.URL;
 import java.util.Scanner;
 
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRestVertxTransportConfig.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestRestVertxTransportConfig.java
@@ -22,7 +22,7 @@ import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.google.common.base.Strings;
 import org.junit.jupiter.api.Assertions;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestSpringConfiguration.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestSpringConfiguration.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 
 import org.apache.servicecomb.foundation.common.utils.BeanUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.core.env.Environment;
 
 public class TestSpringConfiguration {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestTrace.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestTrace.java
@@ -23,9 +23,9 @@ import org.apache.servicecomb.core.Const;
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.swagger.invocation.context.ContextUtils;
 import org.apache.servicecomb.swagger.invocation.context.InvocationContext;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestTrace {
@@ -35,14 +35,14 @@ public class TestTrace {
 
   static Consumers<TraceSchemaIntf> consumers = new Consumers<>("trace", TraceSchemaIntf.class);
 
-  @BeforeClass
+  @BeforeAll
   public static void classSetup() {
     InvocationContext context = new InvocationContext();
     context.addContext(Const.TRACE_ID_NAME, "testId");
     ContextUtils.setInvocationContext(context);
   }
 
-  @AfterClass
+  @AfterAll
   public static void classTeardown() {
     ContextUtils.removeInvocationContext();
   }

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestTraceEdge.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestTraceEdge.java
@@ -18,7 +18,7 @@ package org.apache.servicecomb.it.testcase;
 
 import org.apache.servicecomb.core.Const;
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestTransportContext.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestTransportContext.java
@@ -19,7 +19,7 @@ package org.apache.servicecomb.it.testcase;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.servicecomb.it.Consumers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTransportContext {
   interface TransportContextIntf {

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestUpload.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/TestUpload.java
@@ -37,8 +37,8 @@ import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
 import org.assertj.core.api.Condition;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.FileSystemResource;
@@ -83,7 +83,7 @@ public class TestUpload {
   private static Consumers<UploadIntf> consumersJaxrs = new Consumers<>("uploadJaxrsSchema",
       UploadIntf.class);
 
-  @Before
+  @BeforeEach
   public void init() {
     try {
       File file1 = File.createTempFile("jaxrstest1", ".txt");

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/base/TestGeneric.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/base/TestGeneric.java
@@ -32,7 +32,7 @@ import org.apache.servicecomb.it.schema.Generic;
 import org.apache.servicecomb.it.schema.User;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpStatus;
 

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestJAXRSObjectParamType.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestJAXRSObjectParamType.java
@@ -41,7 +41,7 @@ import org.apache.servicecomb.it.schema.objectparams.MultiLayerObjectParam;
 import org.apache.servicecomb.it.schema.objectparams.MultiLayerObjectParam2;
 import org.apache.servicecomb.it.schema.objectparams.ObjectParamTypeSchema;
 import org.apache.servicecomb.it.schema.objectparams.RecursiveObjectParam;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestRPCObjectParamType.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestRPCObjectParamType.java
@@ -35,7 +35,7 @@ import org.apache.servicecomb.it.schema.objectparams.MultiLayerObjectParam;
 import org.apache.servicecomb.it.schema.objectparams.MultiLayerObjectParam2;
 import org.apache.servicecomb.it.schema.objectparams.ObjectParamTypeSchema;
 import org.apache.servicecomb.it.schema.objectparams.RecursiveObjectParam;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestSpringMVCObjectParamType.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestSpringMVCObjectParamType.java
@@ -37,7 +37,7 @@ import org.apache.servicecomb.it.schema.objectparams.ObjectParamTypeSchema;
 import org.apache.servicecomb.it.schema.objectparams.QueryObjectModel;
 import org.apache.servicecomb.it.schema.objectparams.RecursiveObjectParam;
 import org.apache.servicecomb.it.schema.objectparams.TestNullFieldAndDefaultValueParam;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestSpringMVCObjectParamTypeRestOnly.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/objectparams/TestSpringMVCObjectParamTypeRestOnly.java
@@ -22,7 +22,7 @@ import java.util.LinkedHashMap;
 import org.apache.servicecomb.it.Consumers;
 import org.apache.servicecomb.it.schema.objectparams.ObjectParamTypeSchema;
 import org.apache.servicecomb.it.schema.objectparams.TestNullFieldAndDefaultValueParam;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.ResponseEntity;
 

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/publicHeaders/TestPublicHeadersEdge.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/publicHeaders/TestPublicHeadersEdge.java
@@ -18,7 +18,7 @@
 package org.apache.servicecomb.it.testcase.publicHeaders;
 
 import org.apache.servicecomb.it.extend.engine.GateRestTemplate;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/thirdparty/Test3rdPartyInvocation.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/thirdparty/Test3rdPartyInvocation.java
@@ -43,8 +43,8 @@ import org.apache.servicecomb.registry.RegistrationManager;
 import org.apache.servicecomb.registry.api.registry.MicroserviceInstance;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
@@ -66,7 +66,7 @@ public class Test3rdPartyInvocation {
 
   private static DataTypeJaxrsSchemaAsyncIntf dataTypeJaxrsSchemaAsync;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeClass() {
     String endpoint =
         ((ITSCBRestTemplate) consumersJaxrs.getSCBRestTemplate()).getAddress(Const.RESTFUL);

--- a/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/weak/consumer/TestSpringmvcBasic.java
+++ b/integration-tests/it-consumer/src/main/java/org/apache/servicecomb/it/testcase/weak/consumer/TestSpringmvcBasic.java
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.servicecomb.it.Consumers;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;

--- a/integration-tests/it-consumer/src/test/java/org/apache/servicecomb/it/TestMain.java
+++ b/integration-tests/it-consumer/src/test/java/org/apache/servicecomb/it/TestMain.java
@@ -17,7 +17,7 @@
 package org.apache.servicecomb.it;
 
 import org.apache.servicecomb.it.junit.ITJUnitUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 public class TestMain {

--- a/integration-tests/jaxrs-tests/src/test/java/org/apache/servicecomb/demo/jaxrs/tests/JaxrsIntegrationTestBase.java
+++ b/integration-tests/jaxrs-tests/src/test/java/org/apache/servicecomb/demo/jaxrs/tests/JaxrsIntegrationTestBase.java
@@ -36,8 +36,8 @@ import java.util.Map;
 import org.apache.servicecomb.common.rest.codec.RestObjectMapperFactory;
 import org.apache.servicecomb.demo.compute.Person;
 import org.apache.servicecomb.demo.server.User;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
@@ -48,7 +48,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-@Ignore
+@Disabled
 public class JaxrsIntegrationTestBase {
 
   private final String baseUrl = "http://127.0.0.1:8080/";

--- a/integration-tests/jaxrs-tests/src/test/java/org/apache/servicecomb/demo/jaxrs/tests/RawJaxrsIntegrationTest.java
+++ b/integration-tests/jaxrs-tests/src/test/java/org/apache/servicecomb/demo/jaxrs/tests/RawJaxrsIntegrationTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.servicecomb.demo.jaxrs.tests;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class RawJaxrsIntegrationTest extends JaxrsIntegrationTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     JaxrsTestMain.main(new String[0]);
   }

--- a/integration-tests/pojo-test/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoIntegrationTestBase.java
+++ b/integration-tests/pojo-test/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoIntegrationTestBase.java
@@ -38,11 +38,11 @@ import org.apache.servicecomb.demo.smartcare.Response;
 import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
-@Ignore
+@Disabled
 public class PojoIntegrationTestBase {
 
   @Test

--- a/integration-tests/pojo-test/src/test/java/org/apache/servicecomb/demo/pojo/test/RawPojoIntegrationTest.java
+++ b/integration-tests/pojo-test/src/test/java/org/apache/servicecomb/demo/pojo/test/RawPojoIntegrationTest.java
@@ -17,11 +17,11 @@
 
 package org.apache.servicecomb.demo.pojo.test;
 
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 
 public class RawPojoIntegrationTest extends PojoIntegrationTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     PojoTestMain.main(new String[0]);
   }

--- a/integration-tests/spring-jaxrs-tests/src/test/java/org/apache/servicecomb/demo/jaxrs/tests/JaxrsSpringIntegrationTest.java
+++ b/integration-tests/spring-jaxrs-tests/src/test/java/org/apache/servicecomb/demo/jaxrs/tests/JaxrsSpringIntegrationTest.java
@@ -17,25 +17,25 @@
 
 package org.apache.servicecomb.demo.jaxrs.tests;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.netflix.config.DynamicProperty;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = JaxrsSpringMain.class)
 public class JaxrsSpringIntegrationTest extends JaxrsIntegrationTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     System.setProperty("property.test5", "from_system_property");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     System.clearProperty("property.test5");
   }

--- a/integration-tests/spring-pojo-connection-limit-test/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoSpringConnectionLimitIntegrationTest.java
+++ b/integration-tests/spring-pojo-connection-limit-test/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoSpringConnectionLimitIntegrationTest.java
@@ -17,15 +17,15 @@
 
 package org.apache.servicecomb.demo.pojo.test;
 
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class PojoSpringConnectionLimitIntegrationTest {
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     PojoTestMain.main(null);
   }

--- a/integration-tests/spring-pojo-tests/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoSpringIntegrationTest.java
+++ b/integration-tests/spring-pojo-tests/src/test/java/org/apache/servicecomb/demo/pojo/test/PojoSpringIntegrationTest.java
@@ -18,20 +18,20 @@
 package org.apache.servicecomb.demo.pojo.test;
 
 import org.apache.servicecomb.core.SCBEngine;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class PojoSpringIntegrationTest extends PojoIntegrationTestBase {
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     PojoTestMain.main(null);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardownClass() {
     SCBEngine.getInstance().destroy();
   }

--- a/integration-tests/springmvc-tests/common/src/test/java/org/apache/servicecomb/demo/springmvc/tests/SpringMvcIntegrationTestBase.java
+++ b/integration-tests/springmvc-tests/common/src/test/java/org/apache/servicecomb/demo/springmvc/tests/SpringMvcIntegrationTestBase.java
@@ -29,17 +29,19 @@ import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VAL
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.servicecomb.common.rest.codec.RestObjectMapperFactory;
 import org.apache.servicecomb.demo.compute.Person;
 import org.apache.servicecomb.demo.server.User;
@@ -47,11 +49,10 @@ import org.apache.servicecomb.provider.springmvc.reference.RestTemplateBuilder;
 import org.apache.servicecomb.provider.springmvc.reference.async.CseAsyncRestTemplate;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.ClassRule;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.http.HttpEntity;
@@ -69,12 +70,12 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
-@Ignore
+@Disabled
 @SuppressWarnings("deprecation")
 // TODO : upgrade to spring 5 will having warning's , we'll fix it later
 public class SpringMvcIntegrationTestBase {
-  @ClassRule
-  public static final TemporaryFolder folder = new TemporaryFolder();
+  @TempDir
+  public static Path folder;
 
   private final String baseUrl = "http://127.0.0.1:8080/";
 
@@ -690,10 +691,9 @@ public class SpringMvcIntegrationTestBase {
   }
 
   private File newFile(String fileContent) throws IOException {
-    File file = folder.newFile();
-    try (FileOutputStream output = new FileOutputStream(file)) {
-      IOUtils.write(fileContent, output, StandardCharsets.UTF_8);
-    }
-    return file;
+    Path file = folder;
+    Path tempFile = Files.createFile(file.resolve("scb-" + UUID.randomUUID()));
+    Files.write(tempFile, fileContent.getBytes(StandardCharsets.UTF_8), StandardOpenOption.WRITE);
+    return tempFile.toFile();
   }
 }

--- a/integration-tests/springmvc-tests/connection-limit/src/test/java/org/apache/servicecomb/demo/springmvc/tests/RawSpringMvcIntegrationTest.java
+++ b/integration-tests/springmvc-tests/connection-limit/src/test/java/org/apache/servicecomb/demo/springmvc/tests/RawSpringMvcIntegrationTest.java
@@ -19,9 +19,9 @@ package org.apache.servicecomb.demo.springmvc.tests;
 
 import org.apache.servicecomb.core.SCBEngine;
 import org.apache.servicecomb.provider.springmvc.reference.RestTemplateBuilder;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 import org.springframework.web.client.RestTemplate;
 
@@ -33,7 +33,7 @@ public class RawSpringMvcIntegrationTest {
 
   private final String controllerUrl = baseUrl + "springmvc/controller/";
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     System.setProperty("servicecomb.uploads.directory", "/tmp");
     SpringMvcTestMain.main(new String[0]);
@@ -49,7 +49,7 @@ public class RawSpringMvcIntegrationTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     SCBEngine.getInstance().destroy();
   }

--- a/integration-tests/springmvc-tests/general-with-springboot/src/test/java/org/apache/servicecomb/demo/springmvc/tests/SpringMvcSpringIntegrationTest.java
+++ b/integration-tests/springmvc-tests/general-with-springboot/src/test/java/org/apache/servicecomb/demo/springmvc/tests/SpringMvcSpringIntegrationTest.java
@@ -18,21 +18,21 @@
 package org.apache.servicecomb.demo.springmvc.tests;
 
 import org.apache.servicecomb.core.SCBEngine;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.SpringApplication;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class SpringMvcSpringIntegrationTest extends SpringMvcIntegrationTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     System.setProperty("servicecomb.uploads.directory", "/tmp");
     SpringApplication.run(SpringMvcSpringMain.class);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     SCBEngine.getInstance().destroy();
   }

--- a/integration-tests/springmvc-tests/general/src/test/java/org/apache/servicecomb/demo/springmvc/tests/RawSpringMvcIntegrationTest.java
+++ b/integration-tests/springmvc-tests/general/src/test/java/org/apache/servicecomb/demo/springmvc/tests/RawSpringMvcIntegrationTest.java
@@ -18,17 +18,17 @@
 package org.apache.servicecomb.demo.springmvc.tests;
 
 import org.apache.servicecomb.core.SCBEngine;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class RawSpringMvcIntegrationTest extends SpringMvcIntegrationTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     System.setProperty("servicecomb.uploads.directory", "target");
     SpringMvcTestMain.main(new String[0]);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     SCBEngine.getInstance().destroy();
   }

--- a/integration-tests/springmvc-tests/simplified-mapping-with-springboot/src/test/java/org/apache/servicecomb/demo/springmvc/tests/SimplifiedMappingAnnotationIntegrationTest.java
+++ b/integration-tests/springmvc-tests/simplified-mapping-with-springboot/src/test/java/org/apache/servicecomb/demo/springmvc/tests/SimplifiedMappingAnnotationIntegrationTest.java
@@ -18,22 +18,22 @@
 package org.apache.servicecomb.demo.springmvc.tests;
 
 import org.apache.servicecomb.core.SCBEngine;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.SpringApplication;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class SimplifiedMappingAnnotationIntegrationTest extends SpringMvcIntegrationTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void init() {
     System.setProperty("spring.profiles.active", "SimplifiedMapping");
     System.setProperty("servicecomb.uploads.directory", "/tmp");
     SpringApplication.run(SpringMvcSpringMain.class);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     SCBEngine.getInstance().destroy();
   }

--- a/integration-tests/springmvc-tests/simplified-mapping/src/test/java/org/apache/servicecomb/demo/springmvc/tests/RawSpringMvcSimplifiedMappingAnnotationIntegrationTest.java
+++ b/integration-tests/springmvc-tests/simplified-mapping/src/test/java/org/apache/servicecomb/demo/springmvc/tests/RawSpringMvcSimplifiedMappingAnnotationIntegrationTest.java
@@ -18,18 +18,18 @@
 package org.apache.servicecomb.demo.springmvc.tests;
 
 import org.apache.servicecomb.core.SCBEngine;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class RawSpringMvcSimplifiedMappingAnnotationIntegrationTest extends SpringMvcIntegrationTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     System.setProperty("spring.profiles.active", "SimplifiedMapping");
     System.setProperty("servicecomb.uploads.directory", "/tmp");
     SpringMvcTestMain.main(new String[0]);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     SCBEngine.getInstance().destroy();
   }

--- a/integration-tests/test-common/src/test/java/org/apache/servicecomb/tests/tracing/TracingTestBase.java
+++ b/integration-tests/test-common/src/test/java/org/apache/servicecomb/tests/tracing/TracingTestBase.java
@@ -31,7 +31,7 @@ import org.apache.servicecomb.tests.EmbeddedAppender;
 import org.apache.servicecomb.tests.Log4jConfig;
 import org.awaitility.Awaitility;
 import org.hamcrest.MatcherAssert;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +51,7 @@ public class TracingTestBase {
 
   final RestTemplate restTemplate = new RestTemplate();
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws Exception {
     System.setProperty(CONFIG_TRACING_COLLECTOR_ADDRESS, zipkin.httpUrl());
 

--- a/integration-tests/tracing-tests/src/test/java/org/apache/servicecomb/tests/tracing/ZipkinTracingIntegrationTest.java
+++ b/integration-tests/tracing-tests/src/test/java/org/apache/servicecomb/tests/tracing/ZipkinTracingIntegrationTest.java
@@ -24,12 +24,12 @@ import static org.springframework.http.HttpStatus.OK;
 import java.util.Collection;
 
 import org.hamcrest.MatcherAssert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
 
 public class ZipkinTracingIntegrationTest extends TracingTestBase {
-  @Before
+  @BeforeEach
   public void setUp() {
     TracingTestMain.main(new String[0]);
   }


### PR DESCRIPTION
1. rewrite `static initialization block` and `run` method of class `ITJUnitUtils` to adapt to junit5
2. add `junit-platform-launcher` to module `it-consumer`
3. migrate annotations from `junit4` to `junit5`