### PR TITLE
[SCB-2587] change servicecomb.monitor.client.enabled default value to…

### DIFF
--- a/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/data/MonitorConstant.java
+++ b/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/data/MonitorConstant.java
@@ -105,7 +105,7 @@ public class MonitorConstant {
 
   public static boolean isMonitorEnabled() {
     DynamicBooleanProperty property = DynamicPropertyFactory.getInstance().
-        getBooleanProperty("servicecomb.monitor.client.enabled", true);
+        getBooleanProperty("servicecomb.monitor.client.enabled", false);
     return property.getValue();
   }
 


### PR DESCRIPTION
… false

**for this reasion:** </br>
if servicecomb.monitor.client.enabled default value is true, when the monitor serverUrl configuration is not performed, the service cannot be started normally
