### PR TITLE
[SCB-2611]Replace jmokit Deencapsulation.invoke to invoke directly

### DIFF
--- a/clients/http-client-common/src/test/java/org/apache/servicecomb/http/client/common/AbstractAddressManagerTest.java
+++ b/clients/http-client-common/src/test/java/org/apache/servicecomb/http/client/common/AbstractAddressManagerTest.java
@@ -121,7 +121,7 @@ public class AbstractAddressManagerTest {
     new Expectations(addressManager) {
       {
         Deencapsulation.setField(addressManager, "cacheAddress", cache);
-        Deencapsulation.invoke(addressManager, "telnetTest", "http://127.0.0.3:30100");
+        addressManager.telnetTest("http://127.0.0.3:30100");
         result = true;
       }
     };

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/AbstractRestInvocation.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/AbstractRestInvocation.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response.Status;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.servicecomb.common.rest.codec.produce.ProduceProcessor;
 import org.apache.servicecomb.common.rest.codec.produce.ProduceProcessorManager;
@@ -98,7 +99,8 @@ public abstract class AbstractRestInvocation {
     }
   }
 
-  protected void setContext() throws Exception {
+  @VisibleForTesting
+  public void setContext() throws Exception {
     String strCseContext = requestEx.getHeader(Const.CSE_CONTEXT);
     if (StringUtils.isEmpty(strCseContext)) {
       return;

--- a/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/VertxRestInvocationTest.java
+++ b/common/common-rest/src/test/java/org/apache/servicecomb/common/rest/VertxRestInvocationTest.java
@@ -50,7 +50,7 @@ public class VertxRestInvocationTest {
         vertxRestInvocation, "invocation", invocation);
     Mockito.when(requestEx.getContext()).thenReturn(routingContext);
 
-    Deencapsulation.invoke(vertxRestInvocation, "createInvocation");
+    vertxRestInvocation.createInvocation();
 
     Mockito.verify(routingContext, Mockito.times(1)).put(RestConst.REST_INVOCATION_CONTEXT, invocation);
   }

--- a/dynamic-config/config-apollo/src/test/java/org/apache/servicecomb/config/client/ApolloClientTest.java
+++ b/dynamic-config/config-apollo/src/test/java/org/apache/servicecomb/config/client/ApolloClientTest.java
@@ -80,7 +80,7 @@ public class ApolloClientTest {
     ConfigRefresh cr = apolloClient.new ConfigRefresh("");
 
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }
@@ -88,7 +88,7 @@ public class ApolloClientTest {
 
     before.put("test", "testValue");
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }
@@ -96,14 +96,14 @@ public class ApolloClientTest {
 
     after.put("test", "testValue2");
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }
     Assertions.assertTrue(status);
 
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }

--- a/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/nacos/client/NacosClientTest.java
+++ b/dynamic-config/config-nacos/src/test/java/org/apache/servicecomb/config/nacos/client/NacosClientTest.java
@@ -61,7 +61,7 @@ public class NacosClientTest {
     NacosClient.ConfigRefresh cr = nacosClient.new ConfigRefresh();
 
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }
@@ -70,7 +70,7 @@ public class NacosClientTest {
     status = true;
     before.put("test", "testValue");
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }
@@ -79,7 +79,7 @@ public class NacosClientTest {
     status = true;
     after.put("test", "testValue2");
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }
@@ -87,7 +87,7 @@ public class NacosClientTest {
 
     status = true;
     try {
-      Deencapsulation.invoke(cr, "compareChangedConfig", before, after);
+      cr.compareChangedConfig(before, after);
     } catch (Exception e) {
       status = false;
     }

--- a/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/EdgeInvocation.java
+++ b/edge/edge-core/src/main/java/org/apache/servicecomb/edge/core/EdgeInvocation.java
@@ -119,7 +119,7 @@ public class EdgeInvocation extends AbstractRestInvocation {
   }
 
   @Override
-  protected void setContext() throws Exception {
+  public void setContext() throws Exception {
     // do not read InvocationContext from HTTP header, for security reason
   }
 }

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpClientConnection.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/client/tcp/TcpClientConnection.java
@@ -208,7 +208,8 @@ public class TcpClientConnection extends TcpConnection {
     tryLogin();
   }
 
-  private void onClosed(Void v) {
+  @VisibleForTesting
+  void onClosed(Void v) {
     onDisconnected(new IOException("socket closed"));
   }
 

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/client/tcp/TestTcpClientConnection.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/client/tcp/TestTcpClientConnection.java
@@ -234,7 +234,7 @@ public class TestTcpClientConnection {
     }));
     tcpClientConnection.initNetSocket(netSocket);
 
-    Deencapsulation.invoke(tcpClientConnection, "onClosed", new Class<?>[] {Void.class}, new Object[] {null});
+    tcpClientConnection.onClosed(null);
     Assertions.assertEquals(Status.DISCONNECTED, Deencapsulation.getField(tcpClientConnection, "status"));
     Assertions.assertEquals(0, requestMap.size());
   }

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/LoadbalanceHandler.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/LoadbalanceHandler.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 
 import javax.ws.rs.core.Response.Status;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.servicecomb.core.Endpoint;
 import org.apache.servicecomb.core.Handler;
@@ -180,7 +181,8 @@ public class LoadbalanceHandler implements Handler {
     loadBalancerMap.clear();
   }
 
-  private void send(Invocation invocation, AsyncResponse asyncResp, LoadBalancer chosenLB) throws Exception {
+  @VisibleForTesting
+  void send(Invocation invocation, AsyncResponse asyncResp, LoadBalancer chosenLB) throws Exception {
     long time = System.currentTimeMillis();
     ServiceCombServer server = chooseServer(invocation, chosenLB);
     if (null == server) {

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/ServiceCombLoadBalancerStats.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/ServiceCombLoadBalancerStats.java
@@ -122,7 +122,8 @@ public class ServiceCombLoadBalancerStats {
     return this.pingView;
   }
 
-  void init() {
+  @VisibleForTesting
+  public void init() {
     // for testing
     if (timer != null) {
       timer.cancel();

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/SessionStickinessRule.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/SessionStickinessRule.java
@@ -19,6 +19,7 @@ package org.apache.servicecomb.loadbalance;
 
 import java.util.List;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.servicecomb.core.Invocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -75,7 +76,8 @@ public class SessionStickinessRule implements RuleExt {
     return lastServer;
   }
 
-  private ServiceCombServer chooseServerWhenTimeout(List<ServiceCombServer> servers, Invocation invocation) {
+  @VisibleForTesting
+  ServiceCombServer chooseServerWhenTimeout(List<ServiceCombServer> servers, Invocation invocation) {
     synchronized (lock) {
       if (isTimeOut()) {
         chooseNextServer(servers, invocation);

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadbalanceHandler.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadbalanceHandler.java
@@ -130,7 +130,7 @@ public class TestLoadbalanceHandler {
   }
 
   @Test
-  public void send_noEndPoint(@Injectable LoadBalancer loadBalancer) {
+  public void send_noEndPoint(@Injectable LoadBalancer loadBalancer) throws Exception {
     new Expectations(loadBalancer) {
       {
         loadBalancer.chooseServer(invocation);
@@ -139,16 +139,14 @@ public class TestLoadbalanceHandler {
     };
 
     Holder<Throwable> result = new Holder<>();
-    Deencapsulation.invoke(handler, "send", invocation, (AsyncResponse) resp -> {
-      result.value = (Throwable) resp.getResult();
-    }, loadBalancer);
+    handler.send(invocation, resp -> result.value = resp.getResult(), loadBalancer);
 
     Assertions.assertEquals("InvocationException: code=500;msg=CommonExceptionData [message=No available address found.]",
         result.value.getMessage());
   }
 
   @Test
-  public void send_failed2(@Injectable LoadBalancer loadBalancer) {
+  public void send_failed2(@Injectable LoadBalancer loadBalancer) throws Exception {
     MicroserviceInstance instance1 = new MicroserviceInstance();
     instance1.setInstanceId("1234");
     CacheEndpoint cacheEndpoint = new CacheEndpoint("rest://localhost:8080", instance1);
@@ -165,10 +163,7 @@ public class TestLoadbalanceHandler {
     sendResponse = Response.create(Status.BAD_REQUEST, "send failed");
 
     Holder<Throwable> result = new Holder<>();
-    Deencapsulation.invoke(handler, "send", invocation, (AsyncResponse) resp -> {
-      result.value = resp.getResult();
-    }, loadBalancer);
-
+    handler.send(invocation, resp -> result.value = resp.getResult(), loadBalancer);
     // InvocationException is not taken as a failure
     Assertions.assertEquals(0,
         loadBalancer.getLoadBalancerStats().getSingleServerStat(server).getSuccessiveConnectionFailureCount());
@@ -177,7 +172,7 @@ public class TestLoadbalanceHandler {
   }
 
   @Test
-  public void send_failed(@Injectable LoadBalancer loadBalancer) {
+  public void send_failed(@Injectable LoadBalancer loadBalancer) throws Exception {
     MicroserviceInstance instance1 = new MicroserviceInstance();
     instance1.setInstanceId("1234");
     CacheEndpoint cacheEndpoint = new CacheEndpoint("rest://localhost:8080", instance1);
@@ -194,9 +189,7 @@ public class TestLoadbalanceHandler {
     sendResponse = Response.consumerFailResp(new SocketException());
 
     Holder<Throwable> result = new Holder<>();
-    Deencapsulation.invoke(handler, "send", invocation, (AsyncResponse) resp -> {
-      result.value = (Throwable) resp.getResult();
-    }, loadBalancer);
+    handler.send(invocation, resp -> result.value = resp.getResult(), loadBalancer);
 
     Assertions.assertEquals(1,
         loadBalancer.getLoadBalancerStats().getSingleServerStat(server).getSuccessiveConnectionFailureCount());
@@ -206,7 +199,7 @@ public class TestLoadbalanceHandler {
   }
 
   @Test
-  public void send_success(@Injectable LoadBalancer loadBalancer) {
+  public void send_success(@Injectable LoadBalancer loadBalancer) throws Exception {
     MicroserviceInstance instance1 = new MicroserviceInstance();
     instance1.setInstanceId("1234");
     CacheEndpoint cacheEndpoint = new CacheEndpoint("rest://localhost:8080", instance1);
@@ -223,9 +216,7 @@ public class TestLoadbalanceHandler {
     sendResponse = Response.ok("success");
 
     Holder<String> result = new Holder<>();
-    Deencapsulation.invoke(handler, "send", invocation, (AsyncResponse) resp -> {
-      result.value = resp.getResult();
-    }, loadBalancer);
+    handler.send(invocation, resp -> result.value = resp.getResult(), loadBalancer);
 
     Assertions.assertEquals(1,
         loadBalancer.getLoadBalancerStats().getSingleServerStat(server).getActiveRequestsCount());

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestSessionSticknessRule.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestSessionSticknessRule.java
@@ -54,7 +54,7 @@ public class TestSessionSticknessRule {
     Invocation invocation = mock(Invocation.class);
     LoadBalancerStats stats = mock(LoadBalancerStats.class);
     Mockito.when(mockedLb.getLoadBalancerStats()).thenReturn(stats);
-    Deencapsulation.invoke(rule, "chooseServerWhenTimeout", Arrays.asList(mockedServer), invocation);
+    rule.chooseServerWhenTimeout(Arrays.asList(mockedServer), invocation);
     mockedServer.setAlive(true);
     mockedServer.setReadyToServe(true);
     List<ServiceCombServer> allServers = Arrays.asList(mockedServer);

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/filter/IsolationDiscoveryFilterTest.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/filter/IsolationDiscoveryFilterTest.java
@@ -90,7 +90,7 @@ public class IsolationDiscoveryFilterTest {
 
   @AfterEach
   public void after() {
-    Deencapsulation.invoke(ServiceCombLoadBalancerStats.INSTANCE, "init");
+    ServiceCombLoadBalancerStats.INSTANCE.init();
     TestServiceCombServerStats.releaseTryingChance();
   }
 

--- a/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseClientHttpRequest.java
+++ b/providers/provider-springmvc/src/main/java/org/apache/servicecomb/provider/springmvc/reference/CseClientHttpRequest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.Part;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.servicecomb.common.rest.RestConst;
 import org.apache.servicecomb.common.rest.codec.RestCodec;
 import org.apache.servicecomb.common.rest.definition.RestOperationMeta;
@@ -226,7 +227,8 @@ public class CseClientHttpRequest implements ClientHttpRequest {
     return invocation;
   }
 
-  private CseClientHttpResponse invoke(Map<String, Object> swaggerArguments) {
+  @VisibleForTesting
+  CseClientHttpResponse invoke(Map<String, Object> swaggerArguments) {
     Invocation invocation = prepareInvocation(swaggerArguments);
     Response response = doInvoke(invocation);
 

--- a/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/TestUrlWithProviderPrefixClientHttpRequestFactory.java
+++ b/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/TestUrlWithProviderPrefixClientHttpRequestFactory.java
@@ -76,7 +76,7 @@ public class TestUrlWithProviderPrefixClientHttpRequestFactory {
     Deencapsulation.setField(request, "requestMeta", requestMeta);
     Deencapsulation.setField(request, "path", request.findUriPath(uri));
 
-    Deencapsulation.invoke(request, "invoke", new HashMap<>());
+    request.invoke(new HashMap<>());
 
     Assertions.assertEquals("/v1/path", handlerContext.get(RestConst.REST_CLIENT_REQUEST_PATH));
   }

--- a/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/TestUrlWithServiceNameClientHttpRequestFactory.java
+++ b/providers/provider-springmvc/src/test/java/org/apache/servicecomb/provider/springmvc/reference/TestUrlWithServiceNameClientHttpRequestFactory.java
@@ -75,7 +75,7 @@ public class TestUrlWithServiceNameClientHttpRequestFactory {
     Deencapsulation.setField(request, "requestMeta", requestMeta);
     Deencapsulation.setField(request, "path", request.findUriPath(uri));
 
-    Deencapsulation.invoke(request, "invoke", new HashMap<>());
+    request.invoke(new HashMap<>());
 
     Assertions.assertEquals("/ms/v1/path", handlerContext.get(RestConst.REST_CLIENT_REQUEST_PATH));
   }

--- a/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
+++ b/service-registry/registry-service-center/src/test/java/org/apache/servicecomb/serviceregistry/client/http/TestServiceRegistryClientImpl.java
@@ -62,7 +62,6 @@ import com.google.common.cache.LoadingCache;
 
 import io.vertx.core.Handler;
 import io.vertx.core.buffer.Buffer;
-import io.vertx.core.http.HttpClientOptions;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.Json;
 import mockit.Deencapsulation;
@@ -100,25 +99,6 @@ public class TestServiceRegistryClientImpl {
   public void tearDown() throws Exception {
     oClient = null;
     HttpClients.destroy();
-  }
-
-  @Test
-  public void testPrivateMethodCreateHttpClientOptions() {
-    ArchaiusUtils.setProperty(BootStrapProperties.CONFIG_SERVICE_APPLICATION, "app");
-    ArchaiusUtils.setProperty(BootStrapProperties.CONFIG_SERVICE_NAME, "ms");
-    MicroserviceFactory microserviceFactory = new MicroserviceFactory();
-    Microservice microservice = microserviceFactory.create();
-    oClient.registerMicroservice(microservice);
-    oClient.registerMicroserviceInstance(microservice.getInstance());
-    try {
-      oClient.init();
-      HttpClientOptions httpClientOptions = Deencapsulation.invoke(oClient, "createHttpClientOptions");
-      Assertions.assertNotNull(httpClientOptions);
-      Assertions.assertEquals(80, httpClientOptions.getDefaultPort());
-    } catch (Exception e) {
-      Assertions.assertNotNull(e);
-    }
-    ArchaiusUtils.resetConfig();
   }
 
   @Test

--- a/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayClient.java
+++ b/transports/transport-highway/src/main/java/org/apache/servicecomb/transport/highway/HighwayClient.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeoutException;
 
 import javax.ws.rs.core.Response.Status;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.servicecomb.codec.protobuf.definition.OperationProtobuf;
 import org.apache.servicecomb.codec.protobuf.definition.ProtobufManager;
 import org.apache.servicecomb.core.Invocation;
@@ -65,7 +66,8 @@ public class HighwayClient {
     VertxUtils.blockDeploy(vertx, ClientVerticle.class, deployOptions);
   }
 
-  private TcpClientConfig createTcpClientConfig() {
+  @VisibleForTesting
+  TcpClientConfig createTcpClientConfig() {
     TcpClientConfig tcpClientConfig = new TcpClientConfig();
     // global request timeout to be login timeout
     tcpClientConfig.setMsLoginTimeout(DynamicPropertyFactory.getInstance()

--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayClient.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/TestHighwayClient.java
@@ -89,7 +89,7 @@ public class TestHighwayClient {
 
   @Test
   public void testLoginTimeout(@Mocked Vertx vertx) {
-    TcpClientConfig tcpClientConfig = Deencapsulation.invoke(client, "createTcpClientConfig");
+    TcpClientConfig tcpClientConfig = client.createTcpClientConfig();
     Assertions.assertEquals(2000, tcpClientConfig.getMsLoginTimeout());
   }
 

--- a/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestRestClientInvocation.java
+++ b/transports/transport-rest/transport-rest-client/src/test/java/org/apache/servicecomb/transport/rest/client/http/TestRestClientInvocation.java
@@ -279,7 +279,7 @@ public class TestRestClientInvocation {
   }
 
   @Test
-  public void testSetCseContext_enable_unicode() {
+  public void testSetCseContext_enable_unicode() throws Exception {
     Map<String, String> contextMap = new HashMap<>();
     contextMap.put("key", "测试");
     contextMap.put("encodedKey", StringEscapeUtils.escapeJson("测试"));
@@ -302,7 +302,7 @@ public class TestRestClientInvocation {
     Deencapsulation.setField(vertxRestInvocation, "requestEx", requestEx);
     Deencapsulation.setField(vertxRestInvocation, "invocation", invocation);
 
-    Deencapsulation.invoke(vertxRestInvocation, "setContext");
+    vertxRestInvocation.setContext();
 
     Assertions.assertEquals("测试", invocation.getContext().get("key"));
     Assertions.assertEquals(StringEscapeUtils.escapeJson("测试"), invocation.getContext().get("encodedKey"));
@@ -310,7 +310,7 @@ public class TestRestClientInvocation {
 
 
   @Test
-  public void testSetCseContext_disable_unicode() throws JsonProcessingException {
+  public void testSetCseContext_disable_unicode() throws Exception {
     Map<String, String> contextMap = new HashMap<>();
     contextMap.put("key", "测试");
     contextMap.put("encodedKey", StringEscapeUtils.escapeJson("测试"));
@@ -340,8 +340,7 @@ public class TestRestClientInvocation {
     Deencapsulation.setField(vertxRestInvocation, "requestEx", requestEx);
     Deencapsulation.setField(vertxRestInvocation, "invocation", invocation);
 
-    Deencapsulation.invoke(vertxRestInvocation, "setContext");
-
+    vertxRestInvocation.setContext();
     Assertions.assertEquals("测试", invocation.getContext().get("key"));
     Assertions.assertEquals(StringEscapeUtils.escapeJson("测试"), invocation.getContext().get("encodedKey"));
   }

--- a/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/RestServerVerticle.java
+++ b/transports/transport-rest/transport-rest-vertx/src/main/java/org/apache/servicecomb/transport/rest/vertx/RestServerVerticle.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.servicecomb.common.accessLog.AccessLogConfig;
 import org.apache.servicecomb.common.accessLog.core.element.impl.LocalHostAccessItem;
 import org.apache.servicecomb.common.rest.codec.RestObjectMapperFactory;
@@ -127,7 +128,8 @@ public class RestServerVerticle extends AbstractVerticle {
     }
   }
 
-  private void mountGlobalRestFailureHandler(Router mainRouter) {
+  @VisibleForTesting
+  void mountGlobalRestFailureHandler(Router mainRouter) {
     GlobalRestFailureHandler globalRestFailureHandler =
         SPIServiceUtils.getPriorityHighestService(GlobalRestFailureHandler.class);
     Handler<RoutingContext> failureHandler = null == globalRestFailureHandler ?

--- a/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestRestServerVerticle.java
+++ b/transports/transport-rest/transport-rest-vertx/src/test/java/org/apache/servicecomb/transport/rest/vertx/TestRestServerVerticle.java
@@ -49,7 +49,6 @@ import io.vertx.ext.web.Route;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.CorsHandler;
-import mockit.Deencapsulation;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -251,7 +250,7 @@ public class TestRestServerVerticle {
 
     RestServerVerticle server = new RestServerVerticle();
 
-    Deencapsulation.invoke(server, "mountCorsHandler", router);
+    server.mountCorsHandler(router);
     Assertions.assertEquals(7, counter.get());
   }
 
@@ -278,7 +277,7 @@ public class TestRestServerVerticle {
 
     RestServerVerticle restServerVerticle = new RestServerVerticle();
 
-    Deencapsulation.invoke(restServerVerticle, "mountGlobalRestFailureHandler", mainRouter);
+    restServerVerticle.mountGlobalRestFailureHandler(mainRouter);
     Assertions.assertNotNull(handlerHolder.value);
 
     RoutingContext routingContext = Mockito.mock(RoutingContext.class);


### PR DESCRIPTION
We are doing a job that's upgrade jmockit to newest version, and this's method in jmockit `mockit.Deencapsulation#invoke` has bean Deprecated. So replace it to invoke directly