### PR TITLE
[SCB-2625] use clazz.getDeclaredConstructor().newInstance() instead o…

### DIFF
--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceProcessorManager.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceProcessorManager.java
@@ -68,7 +68,7 @@ public final class ProduceProcessorManager extends RegisterManager<String, Map<S
       Map<String, ProduceProcessor> produceViewMap) {
     ProduceProcessor newInstance;
     try {
-      newInstance = produceViewMap.get(DEFAULT_SERIAL_CLASS).getClass().newInstance();
+      newInstance = produceViewMap.get(DEFAULT_SERIAL_CLASS).getClass().getDeclaredConstructor().newInstance();
       newInstance.setSerializationView(serialViewClass);
       return newInstance;
     } catch (Throwable e) {

--- a/core/src/main/java/org/apache/servicecomb/core/handler/AbstractHandlerManager.java
+++ b/core/src/main/java/org/apache/servicecomb/core/handler/AbstractHandlerManager.java
@@ -93,7 +93,7 @@ public abstract class AbstractHandlerManager extends AbstractObjectManager<Strin
     List<Handler> handlerList = new ArrayList<>();
     for (Class<Handler> cls : chainClasses) {
       try {
-        handlerList.add(cls.newInstance());
+        handlerList.add(cls.getDeclaredConstructor().newInstance());
       } catch (Exception e) {
         // 在启动阶段直接抛异常出来
         throw new Error(e);

--- a/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/spring/PaasNamespaceHandler.java
+++ b/foundations/foundation-common/src/main/java/org/apache/servicecomb/foundation/common/spring/PaasNamespaceHandler.java
@@ -50,10 +50,10 @@ public class PaasNamespaceHandler extends NamespaceHandlerSupport {
       String className = entry.getValue().toString();
       try {
         Class<?> clazz = Class.forName(className);
-        Object instance = clazz.newInstance();
+        Object instance = clazz.getDeclaredConstructor().newInstance();
         registerBeanDefinitionParser(entry.getKey().toString(),
             (BeanDefinitionParser) instance);
-      } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+      } catch (ReflectiveOperationException e) {
         // 类找不到，说明没部署相应的jar包，这不一定是错误
         // 可能是业务就选择不部署相应的jar包
         // 所以只是打印个info日志

--- a/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/priority/ConfigObjectFactory.java
+++ b/foundations/foundation-config/src/main/java/org/apache/servicecomb/config/priority/ConfigObjectFactory.java
@@ -56,7 +56,7 @@ public class ConfigObjectFactory {
 
   public <T> ConfigObject<T> create(Class<T> cls, Map<String, Object> parameters) {
     try {
-      return create(cls.newInstance(), parameters);
+      return create(cls.getDeclaredConstructor().newInstance(), parameters);
     } catch (Throwable e) {
       throw new IllegalStateException("create config object failed, class=" + cls.getName(), e);
     }

--- a/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/config/AbstractPropertiesLoader.java
+++ b/foundations/foundation-registry/src/main/java/org/apache/servicecomb/registry/config/AbstractPropertiesLoader.java
@@ -65,12 +65,12 @@ public abstract class AbstractPropertiesLoader {
         throw new Error(errMsg);
       }
 
-      PropertyExtended instance = (PropertyExtended) classExternalProperty.newInstance();
+      PropertyExtended instance = (PropertyExtended) classExternalProperty.getDeclaredConstructor().newInstance();
       Map<String, String> extendedPropertiesMap = instance.getExtendedProperties();
       if (extendedPropertiesMap != null && !extendedPropertiesMap.isEmpty()) {
         propertiesMap.putAll(extendedPropertiesMap);
       }
-    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+    } catch (ReflectiveOperationException e) {
       String errMsg = "Fail to create instance of class: " + extendedPropertyClass;
       LOGGER.error(errMsg);
       throw new Error(errMsg, e);

--- a/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLCustom.java
+++ b/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLCustom.java
@@ -45,9 +45,9 @@ public abstract class SSLCustom {
   public static SSLCustom createSSLCustom(String name) {
     try {
       if (name != null && !name.isEmpty()) {
-        return (SSLCustom) Class.forName(name).newInstance();
+        return (SSLCustom) Class.forName(name).getDeclaredConstructor().newInstance();
       }
-    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+    } catch (ReflectiveOperationException e) {
       LOG.warn("init SSLCustom class failed, name is " + name);
     }
     return defaultSSLCustom();

--- a/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLOptionFactory.java
+++ b/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLOptionFactory.java
@@ -31,8 +31,8 @@ public interface SSLOptionFactory {
   static SSLOptionFactory createSSLOptionFactory(String className) {
     if (className != null && !className.isEmpty()) {
       try {
-        return (SSLOptionFactory) Class.forName(className).newInstance();
-      } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+        return (SSLOptionFactory) Class.forName(className).getDeclaredConstructor().newInstance();
+      } catch (ReflectiveOperationException e) {
         throw new IllegalStateException("Failed to create SSLOptionFactory.", e);
       }
     }

--- a/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/instance/PojoInstanceFactory.java
+++ b/providers/provider-pojo/src/main/java/org/apache/servicecomb/provider/pojo/instance/PojoInstanceFactory.java
@@ -30,7 +30,7 @@ public class PojoInstanceFactory implements InstanceFactory {
   public Object create(String className) {
     try {
       Class<?> clazz = Class.forName(className);
-      return clazz.newInstance();
+      return clazz.getDeclaredConstructor().newInstance();
     } catch (Exception e) {
       throw new Error("Fail to create instance of class:" + className, e);
     }

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/ConverterMgr.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/converter/ConverterMgr.java
@@ -90,7 +90,7 @@ public final class ConverterMgr {
   private static void initTypeFormatMap() {
     try {
       for (Entry<Class<? extends Property>, JavaType> entry : PROPERTY_MAP.entrySet()) {
-        Property property = entry.getKey().newInstance();
+        Property property = entry.getKey().getDeclaredConstructor().newInstance();
         String key = genTypeFormatKey(property.getType(), property.getFormat());
         TYPE_FORMAT_MAP.put(key, entry.getValue());
       }

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerBeanParamMapper.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/producer/ProducerBeanParamMapper.java
@@ -55,7 +55,7 @@ public class ProducerBeanParamMapper extends ProducerArgumentMapper {
   public void swaggerArgumentToInvocationArguments(SwaggerInvocation invocation,
       Map<String, Object> swaggerArguments, Map<String, Object> invocationArguments) {
     try {
-      Object paramInstance = producerParamType.newInstance();
+      Object paramInstance = producerParamType.getDeclaredConstructor().newInstance();
       invocationArguments.put(invocationArgumentName, paramInstance);
 
       for (FieldMeta fieldMeta : fields) {

--- a/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/RestTransportClientManager.java
+++ b/transports/transport-rest/transport-rest-client/src/main/java/org/apache/servicecomb/transport/rest/client/RestTransportClientManager.java
@@ -31,7 +31,7 @@ public final class RestTransportClientManager {
 
   private RestTransportClientManager() {
     try {
-      restClient = TransportClientConfig.getRestTransportClientCls().newInstance();
+      restClient = TransportClientConfig.getRestTransportClientCls().getDeclaredConstructor().newInstance();
       restClient.init(transportVertx);
     } catch (Exception e) {
       throw new IllegalStateException("Failed to init RestTransportClient.", e);


### PR DESCRIPTION
…f clazz.newInstance()

### the reason for change: 

clazz.newInstance() is deprecated after jdk9
