### PR TITLE
[SCB-2739] fix flaky tests in clients

### DIFF
--- a/clients/service-center-client/src/test/java/org/apache/servicecomb/service/center/client/ServiceCenterClientTest.java
+++ b/clients/service-center-client/src/test/java/org/apache/servicecomb/service/center/client/ServiceCenterClientTest.java
@@ -36,6 +36,7 @@ import org.apache.servicecomb.service.center.client.model.SchemaInfo;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.mockito.ArgumentMatchers;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -116,7 +117,8 @@ public class ServiceCenterClientTest {
     objectMapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
 
     Mockito.when(serviceCenterRawClient
-        .postHttpRequest("/registry/microservices", null, objectMapper.writeValueAsString(microservice)))
+        .postHttpRequest(ArgumentMatchers.eq("/registry/microservices"), ArgumentMatchers.eq(null),
+        Mockito.anyString()))
         .thenReturn(httpResponse);
 
     ServiceCenterClient serviceCenterClient = new ServiceCenterClient(serviceCenterRawClient);
@@ -250,8 +252,9 @@ public class ServiceCenterClientTest {
     ObjectMapper mapper = new ObjectMapper();
     mapper.configure(SerializationFeature.WRAP_ROOT_VALUE, true);
 
-    Mockito.when(serviceCenterRawClient.postHttpRequest("/registry/microservices/222222/instances", null,
-        mapper.writeValueAsString(instance)))
+    Mockito.when(serviceCenterRawClient.postHttpRequest(ArgumentMatchers.eq("/registry/microservices/222222/instances"),
+        ArgumentMatchers.eq(null),
+        Mockito.anyString()))
         .thenReturn(httpResponse);
 
     ServiceCenterClient serviceCenterClient = new ServiceCenterClient(serviceCenterRawClient);
@@ -387,7 +390,8 @@ public class ServiceCenterClientTest {
         .when(serviceCenterRawClient.putHttpRequest("/registry/microservices/111/instances/222/heartbeat", null, null))
         .thenReturn(httpResponse);
     Mockito.when(serviceCenterRawClient
-        .putHttpRequest("/registry/heartbeats", null, mapper.writeValueAsString(heartbeatsRequest)))
+        .putHttpRequest(ArgumentMatchers.eq("/registry/heartbeats"), ArgumentMatchers.eq(null),
+        Mockito.anyString()))
         .thenReturn(httpResponse);
 
     ServiceCenterClient serviceCenterClient = new ServiceCenterClient(serviceCenterRawClient);


### PR DESCRIPTION
### Summary
The function `writeValueAsString` returns the order of elements in no fix order and can hamper the functionality of `mock` function. 
For the test `#TestSendHeartBeats` , these are 2 values I received from the function `writeValueAsString`
![ServiceComb-1](https://user-images.githubusercontent.com/20678029/203647954-ef5c91e6-5b6b-4684-9008-5645f75512c0.PNG)
![ServiceComb-2](https://user-images.githubusercontent.com/20678029/203647980-0bdc82eb-1123-4430-a4ae-bc9d54d7a000.PNG)

We are only changing the code to take any string value for the 3rd parameter and the first 2 parameter will be checked.
Similar code is present in other test functions - `TestGetServiceInstanceMessage`, `TestDeleteServiceInstance` , where all the parameters are mocked for any value.

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
