### PR TITLE
Remove unused stale profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <java.version>17</java.version>
     <argLine>-Dfile.encoding=UTF-8</argLine>
     <skip-remote-resource>true</skip-remote-resource>
-    <werror.properties>-Werror</werror.properties>
+    <werror.properties></werror.properties>
     <test.additional.args>
       -Djdk.attach.allowAttachSelf
       --add-opens java.base/java.io=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -42,28 +42,6 @@
     <argLine>-Dfile.encoding=UTF-8</argLine>
     <skip-remote-resource>true</skip-remote-resource>
     <werror.properties></werror.properties>
-    <test.additional.args>
-      -Djdk.attach.allowAttachSelf
-      --add-opens java.base/java.io=ALL-UNNAMED
-      --add-opens java.base/java.lang=ALL-UNNAMED
-      --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-      --add-opens java.base/java.net=ALL-UNNAMED
-      --add-opens java.base/java.nio=ALL-UNNAMED
-      --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
-      --add-opens java.base/java.nio.file=ALL-UNNAMED
-      --add-opens java.base/java.util=ALL-UNNAMED
-      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-      --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
-      --add-opens java.base/java.util.jar=ALL-UNNAMED
-      --add-opens java.base/java.util.stream=ALL-UNNAMED
-      --add-opens java.base/java.time=ALL-UNNAMED
-      --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
-      --add-opens java.base/sun.net.dns=ALL-UNNAMED
-      --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-      --add-opens java.base/sun.security.jca=ALL-UNNAMED
-      --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
-      --add-reads java.base=java.desktop
-    </test.additional.args>
     <!-- plugin version start -->
     <!-- sort by alpha -->
     <checkstyle-maven-plugin.version>3.2.1</checkstyle-maven-plugin.version>
@@ -304,7 +282,28 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${surefire-maven-plugin.version}</version>
         <configuration>
-          <argLine>${test.additional.args}</argLine>
+          <argLine>
+            -Djdk.attach.allowAttachSelf
+            --add-opens java.base/java.io=ALL-UNNAMED
+            --add-opens java.base/java.lang=ALL-UNNAMED
+            --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens java.base/java.net=ALL-UNNAMED
+            --add-opens java.base/java.nio=ALL-UNNAMED
+            --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
+            --add-opens java.base/java.nio.file=ALL-UNNAMED
+            --add-opens java.base/java.util=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+            --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
+            --add-opens java.base/java.util.jar=ALL-UNNAMED
+            --add-opens java.base/java.util.stream=ALL-UNNAMED
+            --add-opens java.base/java.time=ALL-UNNAMED
+            --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+            --add-opens java.base/sun.net.dns=ALL-UNNAMED
+            --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+            --add-opens java.base/sun.security.jca=ALL-UNNAMED
+            --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+            --add-reads java.base=java.desktop
+          </argLine>
           <skip>${maven.test.skip}</skip>
           <testFailureIgnore>${maven.test.failure.ignore}</testFailureIgnore>
           <excludes>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,28 @@
     <argLine>-Dfile.encoding=UTF-8</argLine>
     <skip-remote-resource>true</skip-remote-resource>
     <werror.properties>-Werror</werror.properties>
-    <test.additional.args/>
+    <test.additional.args>
+      -Djdk.attach.allowAttachSelf
+      --add-opens java.base/java.io=ALL-UNNAMED
+      --add-opens java.base/java.lang=ALL-UNNAMED
+      --add-opens java.base/java.lang.reflect=ALL-UNNAMED
+      --add-opens java.base/java.net=ALL-UNNAMED
+      --add-opens java.base/java.nio=ALL-UNNAMED
+      --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
+      --add-opens java.base/java.nio.file=ALL-UNNAMED
+      --add-opens java.base/java.util=ALL-UNNAMED
+      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
+      --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
+      --add-opens java.base/java.util.jar=ALL-UNNAMED
+      --add-opens java.base/java.util.stream=ALL-UNNAMED
+      --add-opens java.base/java.time=ALL-UNNAMED
+      --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
+      --add-opens java.base/sun.net.dns=ALL-UNNAMED
+      --add-opens java.base/sun.nio.ch=ALL-UNNAMED
+      --add-opens java.base/sun.security.jca=ALL-UNNAMED
+      --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
+      --add-reads java.base=java.desktop
+    </test.additional.args>
     <!-- plugin version start -->
     <!-- sort by alpha -->
     <checkstyle-maven-plugin.version>3.2.1</checkstyle-maven-plugin.version>
@@ -642,51 +663,6 @@
           </plugin>
         </plugins>
       </reporting>
-    </profile>
-    <profile>
-      <id>jdk11</id>
-      <activation>
-        <jdk>[11,17)</jdk>
-      </activation>
-      <properties>
-        <werror.properties/>
-        <test.additional.args>
-          -Djdk.attach.allowAttachSelf
-          --add-opens java.base/java.lang=ALL-UNNAMED
-          --add-reads java.base=java.desktop
-        </test.additional.args>
-      </properties>
-    </profile>
-    <profile>
-      <id>jdk17</id>
-      <activation>
-        <jdk>[17,)</jdk>
-      </activation>
-      <properties>
-        <werror.properties/>
-        <test.additional.args>
-          -Djdk.attach.allowAttachSelf
-          --add-opens java.base/java.io=ALL-UNNAMED
-          --add-opens java.base/java.lang=ALL-UNNAMED
-          --add-opens java.base/java.lang.reflect=ALL-UNNAMED
-          --add-opens java.base/java.net=ALL-UNNAMED
-          --add-opens java.base/java.nio=ALL-UNNAMED
-          --add-opens java.base/java.nio.channels.spi=ALL-UNNAMED
-          --add-opens java.base/java.nio.file=ALL-UNNAMED
-          --add-opens java.base/java.util=ALL-UNNAMED
-          --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-          --add-opens java.base/java.util.concurrent.atomic=ALL-UNNAMED
-          --add-opens java.base/java.util.jar=ALL-UNNAMED
-          --add-opens java.base/java.util.stream=ALL-UNNAMED
-          --add-opens java.base/java.time=ALL-UNNAMED
-          --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
-          --add-opens java.base/sun.net.dns=ALL-UNNAMED
-          --add-opens java.base/sun.nio.ch=ALL-UNNAMED
-          --add-opens java.base/sun.security.jca=ALL-UNNAMED
-          --add-opens java.xml/jdk.xml.internal=ALL-UNNAMED
-          --add-reads java.base=java.desktop
-        </test.additional.args>
-      </properties>
     </profile>
   </profiles>
 


### PR DESCRIPTION
Since we will only support jdk17 in master branch, it's time to delete the stable profile.
There are still some compile warning to be fixed. Let's fix it in other PR.