### PR TITLE
[Backport 2.8.x][#3850] Fix the problem when setting content-type by ResponseEntity.header() does not take effect

### DIFF
--- a/demo/demo-springmvc/springmvc-client/src/main/java/org/apache/servicecomb/demo/springmvc/client/TestDownloadSchema.java
+++ b/demo/demo-springmvc/springmvc-client/src/main/java/org/apache/servicecomb/demo/springmvc/client/TestDownloadSchema.java
@@ -21,8 +21,12 @@ import org.apache.servicecomb.demo.CategorizedTestCase;
 import org.apache.servicecomb.demo.TestMgr;
 import org.apache.servicecomb.foundation.vertx.http.ReadStreamPart;
 import org.apache.servicecomb.provider.springmvc.reference.RestTemplateBuilder;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
 
 @Component
 public class TestDownloadSchema implements CategorizedTestCase {
@@ -31,6 +35,7 @@ public class TestDownloadSchema implements CategorizedTestCase {
     testDownloadFileAndDeleted();
     testDownloadFileNotDeleted();
     testDownloadFileWithNull();
+    testSetContentTypeByResponseEntity();
   }
 
   private void testDownloadFileAndDeleted() throws Exception {
@@ -68,5 +73,15 @@ public class TestDownloadSchema implements CategorizedTestCase {
     boolean exists = restTemplate
         .getForObject("servicecomb://springmvc/download/assertLastFileDeleted", boolean.class);
     TestMgr.check(exists, true);
+  }
+
+  private void testSetContentTypeByResponseEntity() throws Exception {
+    RestTemplate restTemplate = RestTemplateBuilder.create();
+    ResponseEntity<ReadStreamPart> responseEntity = restTemplate
+            .getForEntity("servicecomb://springmvc/download/setContentTypeByResponseEntity?content=hello&contentType=customType",
+                    ReadStreamPart.class);
+    String hello = responseEntity.getBody().saveAsString().get();
+    TestMgr.check(responseEntity.getHeaders().get(HttpHeaders.CONTENT_TYPE), Collections.singletonList("customType"));
+    TestMgr.check(hello, "hello");
   }
 }

--- a/demo/demo-springmvc/springmvc-server/src/main/java/org/apache/servicecomb/demo/springmvc/server/DownloadSchema.java
+++ b/demo/demo-springmvc/springmvc-server/src/main/java/org/apache/servicecomb/demo/springmvc/server/DownloadSchema.java
@@ -92,6 +92,17 @@ public class DownloadSchema {
         .body(new FilePart(null, file));
   }
 
+  @GetMapping(path = "/setContentTypeByResponseEntity")
+  public ResponseEntity<Part> setContentTypeByResponseEntity(@RequestParam("content") String content, @RequestParam("contentType") String contentType) throws IOException {
+    File file = createTempFile(content);
+
+    return ResponseEntity
+            .ok()
+            .header(HttpHeaders.CONTENT_TYPE, contentType)
+            .header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=tempFileEntity.txt")
+            .body(new FilePart(null, file));
+  }
+
   @GetMapping(path = "/assertLastFileDeleted")
   public boolean assertLastFileDeleted() {
     return lastFile.exists();

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/DownloadUtils.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/DownloadUtils.java
@@ -44,7 +44,11 @@ public final class DownloadUtils {
       return;
     }
     if (responseEx.getHeader(HttpHeaders.CONTENT_TYPE.toString()) == null) {
-      responseEx.setHeader(HttpHeaders.CONTENT_TYPE.toString(), part.getContentType());
+      if (responseEx.getContentType() != null) {
+        responseEx.setHeader(HttpHeaders.CONTENT_TYPE.toString(), responseEx.getContentType());
+      } else {
+        responseEx.setHeader(HttpHeaders.CONTENT_TYPE.toString(), part.getContentType());
+      }
     }
 
     if (responseEx.getHeader(javax.ws.rs.core.HttpHeaders.CONTENT_DISPOSITION) == null) {


### PR DESCRIPTION
(cherry picked from commit c57f5cf4e19fb1b6573feed48e78da80b8165799)

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
