### PR TITLE
[#4479]Bump io.reactivex.rxnetty from 0.5.1 to 0.4.20

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -87,7 +87,7 @@
     <resilience4j.versioin>1.7.0</resilience4j.versioin>
     <ribbon.version>2.7.18</ribbon.version>
     <rxjava.version>1.3.8</rxjava.version>
-    <rxnetty.version>0.5.1</rxnetty.version>
+    <rxnetty.version>0.4.20</rxnetty.version>
     <seanyinx.version>1.0.0</seanyinx.version>
     <servo.version>0.13.2</servo.version>
     <servlet-api.version>4.0.4</servlet-api.version>


### PR DESCRIPTION
The 0.5.1 version is unintentionally released to the Maven repository version. The corresponding tag cannot be found in the community.

For [issue4479](https://github.com/apache/servicecomb-java-chassis/issues/4479)

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
