### PR TITLE
[SCB-2890]Bump jakarta.servlet:jakarta.servlet-api from 6.0.0 to 6.1.0

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -83,7 +83,7 @@
     <rxjava.version>3.1.8</rxjava.version>
     <seanyinx.version>1.0.0</seanyinx.version>
     <servo.version>0.13.2</servo.version>
-    <servlet-api.version>6.0.0</servlet-api.version>
+    <servlet-api.version>6.1.0</servlet-api.version>
     <slf4j.version>1.7.36</slf4j.version>
     <snakeyaml.version>2.3</snakeyaml.version>
     <spring.version>6.1.10</spring.version>

--- a/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/AbstractHttpServletResponse.java
+++ b/foundations/foundation-vertx/src/main/java/org/apache/servicecomb/foundation/vertx/http/AbstractHttpServletResponse.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 import io.vertx.core.buffer.Buffer;
 import jakarta.servlet.ServletOutputStream;
@@ -231,6 +232,31 @@ public abstract class AbstractHttpServletResponse extends BodyBufferSupportImpl 
 
   @Override
   public CompletableFuture<Void> sendBuffer(Buffer buffer) {
+    throw new Error("not supported method");
+  }
+
+  @Override
+  public void sendRedirect(String location, boolean clearBuffer) throws IOException {
+    throw new Error("not supported method");
+  }
+
+  @Override
+  public void sendRedirect(String location, int statusCode) throws IOException {
+    throw new Error("not supported method");
+  }
+
+  @Override
+  public void sendRedirect(String location, int statusCode, boolean clearBuffer) throws IOException {
+    throw new Error("not supported method");
+  }
+
+  @Override
+  public void setTrailerFields(Supplier<Map<String, String>> supplier) {
+    throw new Error("not supported method");
+  }
+
+  @Override
+  public Supplier<Map<String, String>> getTrailerFields() {
     throw new Error("not supported method");
   }
 }

--- a/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestAbstractHttpServletResponse.java
+++ b/foundations/foundation-vertx/src/test/java/org/apache/servicecomb/foundation/vertx/http/TestAbstractHttpServletResponse.java
@@ -17,6 +17,7 @@
 
 package org.apache.servicecomb.foundation.vertx.http;
 
+import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -247,6 +248,36 @@ public class TestAbstractHttpServletResponse {
   @Test
   public void sendPart() {
     Error error = Assertions.assertThrows(Error.class, () -> response.sendPart(null));
+    checkError(error);
+  }
+
+  @Test
+  public void testSendRedirectWithStatusCode() {
+    Error error = Assertions.assertThrows(Error.class, () -> response.sendRedirect("", HttpServletResponse.SC_ACCEPTED));
+    checkError(error);
+  }
+
+  @Test
+  public void testSendRedirectWithClearBuffer() {
+    Error error = Assertions.assertThrows(Error.class, () -> response.sendRedirect("", true));
+    checkError(error);
+  }
+
+  @Test
+  public void testSendRedirectWithStatusCodeAndClearBuffer() {
+    Error error = Assertions.assertThrows(Error.class, () -> response.sendRedirect("", HttpServletResponse.SC_ACCEPTED, true));
+    checkError(error);
+  }
+
+  @Test
+  public void testSetTrailerFields() {
+    Error error = Assertions.assertThrows(Error.class, () -> response.setTrailerFields(null));
+    checkError(error);
+  }
+
+  @Test
+  public void testGetTrailerFields() {
+    Error error = Assertions.assertThrows(Error.class, () -> response.getTrailerFields());
     checkError(error);
   }
 }


### PR DESCRIPTION
solution was discussed in https://github.com/apache/servicecomb-java-chassis/issues/4467.