### PR TITLE
build: upgrade Protobuf to version 4.28.3

### DIFF
--- a/demo/demo-etcd/consumer/pom.xml
+++ b/demo/demo-etcd/consumer/pom.xml
@@ -35,12 +35,6 @@
       <artifactId>java-chassis-spring-boot-starter-standalone</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>registry-etcd</artifactId>
     </dependency>

--- a/demo/demo-etcd/gateway/pom.xml
+++ b/demo/demo-etcd/gateway/pom.xml
@@ -39,12 +39,6 @@
       <artifactId>edge-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>registry-etcd</artifactId>
     </dependency>

--- a/demo/demo-etcd/provider/pom.xml
+++ b/demo/demo-etcd/provider/pom.xml
@@ -38,12 +38,12 @@
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>java-chassis-spring-boot-starter-standalone</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
-      <scope>runtime</scope>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>com.google.protobuf</groupId>-->
+<!--      <artifactId>protobuf-java</artifactId>-->
+<!--      <version>3.25.5</version>-->
+<!--      <scope>runtime</scope>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>registry-etcd</artifactId>

--- a/demo/demo-etcd/test-client/pom.xml
+++ b/demo/demo-etcd/test-client/pom.xml
@@ -50,12 +50,6 @@
       <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.25.5</version>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 
   <profiles>

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -74,7 +74,7 @@
     <netty.version>4.1.113.Final</netty.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <protobuf.version>4.28.3</protobuf.version>
+    <protobuf.version>4.27.5</protobuf.version>
     <protostuff.version>1.8.0</protostuff.version>
     <protostuff-parser.version>3.1.40</protostuff-parser.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -74,7 +74,7 @@
     <netty.version>4.1.113.Final</netty.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <protobuf.version>4.27.5</protobuf.version>
+    <protobuf.version>4.28.3</protobuf.version>
     <protostuff.version>1.8.0</protostuff.version>
     <protostuff-parser.version>3.1.40</protostuff-parser.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>

--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -74,9 +74,9 @@
     <netty.version>4.1.113.Final</netty.version>
     <okhttp3.version>4.12.0</okhttp3.version>
     <prometheus.version>0.16.0</prometheus.version>
-    <protobuf.version>3.23.4</protobuf.version>
+    <protobuf.version>4.28.3</protobuf.version>
     <protostuff.version>1.8.0</protostuff.version>
-    <protostuff-parser.version>2.2.27</protostuff-parser.version>
+    <protostuff-parser.version>3.1.40</protostuff-parser.version>
     <reactive-streams.version>1.0.4</reactive-streams.version>
     <resilience4j.versioin>1.7.0</resilience4j.versioin>
     <ribbon.version>2.7.18</ribbon.version>
@@ -190,7 +190,12 @@
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${protobuf.version}</version>
-        <scope>test</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java-util</artifactId>
+        <version>${protobuf.version}</version>
       </dependency>
 
       <dependency>

--- a/dynamic-config/config-etcd/pom.xml
+++ b/dynamic-config/config-etcd/pom.xml
@@ -39,6 +39,16 @@
     <dependency>
       <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>protobuf-java</artifactId>
+          <groupId>com.google.protobuf</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <maven-remote-resources-plugin.version>3.2.0</maven-remote-resources-plugin.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-    <protoc3-maven-plugin.version>4.28.3</protoc3-maven-plugin.version>
+    <protoc3-maven-plugin.version>4.27.5</protoc3-maven-plugin.version>
     <protoc-gen-grpc-java-plugin.version>1.47.0</protoc-gen-grpc-java-plugin.version>
     <puppycrawl-checkstyle.version>10.20.0</puppycrawl-checkstyle.version>
     <release-maven-plugin.version>3.1.1</release-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <maven-remote-resources-plugin.version>3.2.0</maven-remote-resources-plugin.version>
     <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
     <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
-    <protoc3-maven-plugin.version>3.19.2</protoc3-maven-plugin.version>
+    <protoc3-maven-plugin.version>4.28.3</protoc3-maven-plugin.version>
     <protoc-gen-grpc-java-plugin.version>1.47.0</protoc-gen-grpc-java-plugin.version>
     <puppycrawl-checkstyle.version>10.20.0</puppycrawl-checkstyle.version>
     <release-maven-plugin.version>3.1.1</release-maven-plugin.version>

--- a/service-registry/registry-etcd/pom.xml
+++ b/service-registry/registry-etcd/pom.xml
@@ -34,6 +34,12 @@
     <dependency>
       <groupId>io.etcd</groupId>
       <artifactId>jetcd-core</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>protobuf-java</artifactId>
+          <groupId>com.google.protobuf</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.servicecomb</groupId>
@@ -46,6 +52,10 @@
     <dependency>
       <groupId>org.apache.servicecomb</groupId>
       <artifactId>java-chassis-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
- Upgraded protobuf.version from 3.23.4 to 4.28.3
- Update protostuff-parser.version from 2.2.27 to 3.1.40 - Remove com.google.protobuf dependencies in multiple modules
- Add protobuf-java-util dependency to default dependencies
- Update protoc3-maven-plugin version to 4.28.3
- Remove protobuf-java from jetcd-core dependency

