### PR TITLE
update spell's error

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -27,6 +27,7 @@
 ignore = [
     "**/cobertura.ser"
 ]
+
 [words]
 allow = [
     "Verticle",

--- a/.typos.toml
+++ b/.typos.toml
@@ -27,3 +27,7 @@
 ignore = [
     "**/cobertura.ser"
 ]
+[words]
+allow = [
+    "Verticle",
+]

--- a/.typos.toml
+++ b/.typos.toml
@@ -22,3 +22,8 @@
 "VERTX" = "VERTX"
 "Vertx" = "Vertx"
 "vertx" = "vertx"
+
+[files]
+ignore = [
+    "**/cobertura.ser"
+]

--- a/dynamic-config/config-cc/src/main/java/org/apache/servicecomb/config/cc/TransportUtils.java
+++ b/dynamic-config/config-cc/src/main/java/org/apache/servicecomb/config/cc/TransportUtils.java
@@ -61,10 +61,10 @@ public class TransportUtils {
         DEFAULT_OPTION.getCiphers(),
         "ssl." + tag + ".checkCN.white.file",
         "ssl.checkCN.white.file"));
-    option.setAllowRenegociate(getBooleanProperty(environment,
-        DEFAULT_OPTION.isAllowRenegociate(),
-        "ssl." + tag + ".allowRenegociate",
-        "ssl.allowRenegociate"));
+    option.setAllowRenegotiate(getBooleanProperty(environment,
+        DEFAULT_OPTION.isAllowRenegotiate(),
+        "ssl." + tag + ".allowRenegotiate",
+        "ssl.allowRenegotiate"));
     option.setStorePath(
         getStringProperty(environment,
             DEFAULT_OPTION.getStorePath(),

--- a/dynamic-config/config-kie/src/main/java/org/apache/servicecomb/config/kie/TransportUtils.java
+++ b/dynamic-config/config-kie/src/main/java/org/apache/servicecomb/config/kie/TransportUtils.java
@@ -61,10 +61,10 @@ public class TransportUtils {
         DEFAULT_OPTION.getCiphers(),
         "ssl." + tag + ".checkCN.white.file",
         "ssl.checkCN.white.file"));
-    option.setAllowRenegociate(getBooleanProperty(environment,
-        DEFAULT_OPTION.isAllowRenegociate(),
-        "ssl." + tag + ".allowRenegociate",
-        "ssl.allowRenegociate"));
+    option.setAllowRenegotiate(getBooleanProperty(environment,
+        DEFAULT_OPTION.isAllowRenegotiate(),
+        "ssl." + tag + ".allowRenegotiate",
+        "ssl.allowRenegotiate"));
     option.setStorePath(
         getStringProperty(environment,
             DEFAULT_OPTION.getStorePath(),

--- a/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLOption.java
+++ b/foundations/foundation-ssl/src/main/java/org/apache/servicecomb/foundation/ssl/SSLOption.java
@@ -47,7 +47,7 @@ public final class SSLOption {
     DEFAULT_OPTION.setCheckCNHost(false);
     DEFAULT_OPTION.setCheckCNWhite(false);
     DEFAULT_OPTION.setCheckCNWhiteFile("white.list");
-    DEFAULT_OPTION.setAllowRenegociate(true);
+    DEFAULT_OPTION.setAllowRenegotiate(true);
     DEFAULT_OPTION.setStorePath("internal");
     DEFAULT_OPTION.setTrustStore("trust.jks");
     DEFAULT_OPTION.setTrustStoreType("JKS");
@@ -72,7 +72,7 @@ public final class SSLOption {
 
   private String checkCNWhiteFile;
 
-  private boolean allowRenegociate;
+  private boolean allowRenegotiate;
 
   private String clientAuth;
 
@@ -126,8 +126,8 @@ public final class SSLOption {
     this.checkCNWhiteFile = checkCNWhiteFile;
   }
 
-  public void setAllowRenegociate(boolean allowRenegociate) {
-    this.allowRenegociate = allowRenegociate;
+  public void setAllowRenegotiate(boolean allowRenegotiate) {
+    this.allowRenegotiate = allowRenegotiate;
   }
 
   public void setStorePath(String storePath) {
@@ -186,8 +186,8 @@ public final class SSLOption {
     return checkCNWhiteFile;
   }
 
-  public boolean isAllowRenegociate() {
-    return allowRenegociate;
+  public boolean isAllowRenegotiate() {
+    return allowRenegotiate;
   }
 
   public String getStorePath() {
@@ -314,10 +314,10 @@ public final class SSLOption {
         DEFAULT_OPTION.getCiphers(),
         "ssl." + tag + ".checkCN.white.file",
         "ssl.checkCN.white.file");
-    option.allowRenegociate = getBooleanProperty(environment,
-        DEFAULT_OPTION.isAllowRenegociate(),
-        "ssl." + tag + ".allowRenegociate",
-        "ssl.allowRenegociate");
+    option.allowRenegotiate = getBooleanProperty(environment,
+        DEFAULT_OPTION.isAllowRenegotiate(),
+        "ssl." + tag + ".allowRenegotiate",
+        "ssl.allowRenegotiate");
     option.storePath =
         getStringProperty(environment,
             DEFAULT_OPTION.getStorePath(),
@@ -365,7 +365,7 @@ public final class SSLOption {
     this.checkCNHost = propBoolean(props, "ssl.checkCN.host");
     this.checkCNWhite = propBoolean(props, "ssl.checkCN.white");
     this.checkCNWhiteFile = propString(props, "ssl.checkCN.white.file");
-    this.allowRenegociate = propBoolean(props, "ssl.allowRenegociate");
+    this.allowRenegotiate = propBoolean(props, "ssl.allowRenegotiate");
     this.storePath = propString(props, "ssl.storePath");
     this.clientAuth = propString(props, "ssl.clientAuth", false);
     this.trustStore = propString(props, "ssl.trustStore");

--- a/foundations/foundation-ssl/src/test/java/org/apache/servicecomb/foundation/ssl/SSLOptionTest.java
+++ b/foundations/foundation-ssl/src/test/java/org/apache/servicecomb/foundation/ssl/SSLOptionTest.java
@@ -47,7 +47,7 @@ public class SSLOptionTest {
     Mockito.when(environment.getProperty("ssl.checkCN.host")).thenReturn("true");
     Mockito.when(environment.getProperty("ssl.checkCN.white")).thenReturn("true");
     Mockito.when(environment.getProperty("ssl.checkCN.white.file")).thenReturn("white.list");
-    Mockito.when(environment.getProperty("ssl.allowRenegociate")).thenReturn("false");
+    Mockito.when(environment.getProperty("ssl.allowRenegotiate")).thenReturn("false");
     Mockito.when(environment.getProperty("ssl.storePath")).thenReturn("internal");
     Mockito.when(environment.getProperty("ssl.trustStore")).thenReturn("trust.jks");
     Mockito.when(environment.getProperty("ssl.trustStoreType")).thenReturn("JKS");
@@ -91,9 +91,9 @@ public class SSLOptionTest {
     option.setCheckCNWhiteFile(checkCNWhiteFile);
     Assertions.assertEquals("white.list", checkCNWhiteFile);
 
-    boolean allowRenegociate = option.isAllowRenegociate();
-    option.setAllowRenegociate(allowRenegociate);
-    Assertions.assertFalse(allowRenegociate);
+    boolean allowRenegotiate = option.isAllowRenegotiate();
+    option.setAllowRenegotiate(allowRenegotiate);
+    Assertions.assertFalse(allowRenegotiate);
 
     String storePath = option.getStorePath();
     option.setStorePath(storePath);
@@ -158,9 +158,9 @@ public class SSLOptionTest {
     option.setCheckCNWhiteFile(checkCNWhiteFile);
     Assertions.assertEquals("white.list", checkCNWhiteFile);
 
-    boolean allowRenegociate = option.isAllowRenegociate();
-    option.setAllowRenegociate(allowRenegociate);
-    Assertions.assertFalse(allowRenegociate);
+    boolean allowRenegotiate = option.isAllowRenegotiate();
+    option.setAllowRenegotiate(allowRenegotiate);
+    Assertions.assertFalse(allowRenegotiate);
 
     String storePath = option.getStorePath();
     option.setStorePath(storePath);
@@ -264,9 +264,9 @@ public class SSLOptionTest {
     option.setCheckCNWhiteFile(checkCNWhiteFile);
     Assertions.assertEquals("white.list", checkCNWhiteFile);
 
-    boolean allowRenegociate = option.isAllowRenegociate();
-    option.setAllowRenegociate(allowRenegociate);
-    Assertions.assertFalse(allowRenegociate);
+    boolean allowRenegotiate = option.isAllowRenegotiate();
+    option.setAllowRenegotiate(allowRenegotiate);
+    Assertions.assertFalse(allowRenegotiate);
 
     String storePath = option.getStorePath();
     option.setStorePath(storePath);

--- a/foundations/foundation-ssl/src/test/resources/client.ssl.properties
+++ b/foundations/foundation-ssl/src/test/resources/client.ssl.properties
@@ -23,7 +23,7 @@ ssl.authPeer=true
 ssl.checkCN.host=false
 ssl.checkCN.white=true
 ssl.checkCN.white.file=white.list
-ssl.allowRenegociate=false
+ssl.allowRenegotiate=false
 
 #########certificates config
 ssl.storePath=internal

--- a/foundations/foundation-ssl/src/test/resources/microservice.yaml
+++ b/foundations/foundation-ssl/src/test/resources/microservice.yaml
@@ -23,7 +23,7 @@ ssl:
   checkCN.host: true
   checkCN.white: true
   checkCN.white.file: white.list
-  allowRenegociate: false
+  allowRenegotiate: false
   storePath: internal
   trustStore: trust.jks
   trustStoreType: JKS

--- a/foundations/foundation-ssl/src/test/resources/server.ssl.properties
+++ b/foundations/foundation-ssl/src/test/resources/server.ssl.properties
@@ -22,7 +22,7 @@ ssl.authPeer=true
 ssl.checkCN.host=true
 ssl.checkCN.white=true
 ssl.checkCN.white.file=white.list
-ssl.allowRenegociate=false
+ssl.allowRenegotiate=false
 
 #########certificates config
 ssl.storePath=internal

--- a/foundations/foundation-ssl/src/test/resources/server.ssl.resource.properties
+++ b/foundations/foundation-ssl/src/test/resources/server.ssl.resource.properties
@@ -22,7 +22,7 @@ ssl.authPeer=true
 ssl.checkCN.host=true
 ssl.checkCN.white=true
 ssl.checkCN.white.file=white.list
-ssl.allowRenegociate=false
+ssl.allowRenegotiate=false
 
 #########certificates config
 ssl.storePath=internal

--- a/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultInjectionUtil.java
+++ b/handlers/handler-fault-injection/src/main/java/org/apache/servicecomb/faultinjection/FaultInjectionUtil.java
@@ -39,7 +39,7 @@ public class FaultInjectionUtil {
   private FaultInjectionUtil() {
   }
 
-  // key is config paramter
+  // key is config parameter
   private static final Map<String, AtomicInteger> configCenterValue = new ConcurrentHashMapEx<>();
 
   /**

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/Configuration.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/Configuration.java
@@ -38,7 +38,7 @@ public final class Configuration {
   // 2.0 configuration items
   public static final String ROOT_20 = "ribbon.";
 
-  // SessionStickinessRule configruation
+  // SessionStickinessRule configuration
   public static final String SESSION_TIMEOUT_IN_SECONDS = "SessionStickinessRule.sessionTimeoutInSeconds";
 
   public static final String SUCCESSIVE_FAILED_TIMES = "SessionStickinessRule.successiveFailedTimes";

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/LoadBalanceConfiguration.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/LoadBalanceConfiguration.java
@@ -43,8 +43,8 @@ public class LoadBalanceConfiguration {
   }
 
   @Bean
-  public RuleNameExtentionsFactory scbRuleNameExtentionsFactory() {
-    return new RuleNameExtentionsFactory();
+  public RuleNameExtensionsFactory scbRuleNameExtensionsFactory() {
+    return new RuleNameExtensionsFactory();
   }
 
   @Bean

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RuleNameExtensionsFactory.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RuleNameExtensionsFactory.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 
 import com.google.common.collect.Lists;
 
-public class RuleNameExtentionsFactory implements ExtensionsFactory {
+public class RuleNameExtensionsFactory implements ExtensionsFactory {
   private static final Collection<String> ACCEPT_KEYS = Lists.newArrayList(
       Configuration.RULE_STRATEGY_NAME);
 

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestExtensionsManager.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestExtensionsManager.java
@@ -42,7 +42,7 @@ public class TestExtensionsManager {
   @Test
   public void testRuleName() {
     List<ExtensionsFactory> extensionsFactories = new ArrayList<>();
-    extensionsFactories.add(new RuleNameExtentionsFactory());
+    extensionsFactories.add(new RuleNameExtensionsFactory());
     ExtensionsManager extensionsManager = new ExtensionsManager(extensionsFactories);
 
     Assertions.assertEquals(RoundRobinRuleExt.class.getName(),

--- a/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalanceFilter.java
+++ b/handlers/handler-loadbalance/src/test/java/org/apache/servicecomb/loadbalance/TestLoadBalanceFilter.java
@@ -114,7 +114,7 @@ public class TestLoadBalanceFilter {
     };
 
     List<ExtensionsFactory> extensionsFactories = new ArrayList<>();
-    extensionsFactories.add(new RuleNameExtentionsFactory());
+    extensionsFactories.add(new RuleNameExtensionsFactory());
     ExtensionsManager extensionsManager = new ExtensionsManager(extensionsFactories);
 
     DiscoveryTree discoveryTree = new DiscoveryTree(

--- a/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/TransportUtils.java
+++ b/huawei-cloud/dashboard/src/main/java/org/apache/servicecomb/huaweicloud/dashboard/monitor/TransportUtils.java
@@ -61,10 +61,10 @@ public class TransportUtils {
         DEFAULT_OPTION.getCiphers(),
         "ssl." + tag + ".checkCN.white.file",
         "ssl.checkCN.white.file"));
-    option.setAllowRenegociate(getBooleanProperty(environment,
-        DEFAULT_OPTION.isAllowRenegociate(),
-        "ssl." + tag + ".allowRenegociate",
-        "ssl.allowRenegociate"));
+    option.setAllowRenegotiate(getBooleanProperty(environment,
+        DEFAULT_OPTION.isAllowRenegotiate(),
+        "ssl." + tag + ".allowRenegotiate",
+        "ssl.allowRenegotiate"));
     option.setStorePath(
         getStringProperty(environment,
             DEFAULT_OPTION.getStorePath(),

--- a/huawei-cloud/servicestage/src/main/java/org/apache/servicecomb/huaweicloud/servicestage/RBACBootStrapService.java
+++ b/huawei-cloud/servicestage/src/main/java/org/apache/servicecomb/huaweicloud/servicestage/RBACBootStrapService.java
@@ -163,10 +163,10 @@ public class RBACBootStrapService implements BootStrapService {
         DEFAULT_OPTION.getCiphers(),
         "ssl." + SSL_TAG + ".checkCN.white.file",
         "ssl.checkCN.white.file"));
-    option.setAllowRenegociate(getBooleanProperty(environment,
-        DEFAULT_OPTION.isAllowRenegociate(),
-        "ssl." + SSL_TAG + ".allowRenegociate",
-        "ssl.allowRenegociate"));
+    option.setAllowRenegotiate(getBooleanProperty(environment,
+        DEFAULT_OPTION.isAllowRenegotiate(),
+        "ssl." + SSL_TAG + ".allowRenegotiate",
+        "ssl.allowRenegotiate"));
     option.setStorePath(
         getStringProperty(environment,
             DEFAULT_OPTION.getStorePath(),

--- a/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/AbstractArgumentsMapperCreator.java
+++ b/swagger/swagger-invocation/invocation-core/src/main/java/org/apache/servicecomb/swagger/invocation/arguments/AbstractArgumentsMapperCreator.java
@@ -57,7 +57,7 @@ import io.swagger.v3.oas.models.parameters.RequestBody;
  *         int add(int x, int y)
  *       swagger parameters:
  *         x, y
- *    2) swagger only one POJO paramter, extract all field to method parameters (POJO dev mode)
+ *    2) swagger only one POJO parameter, extract all field to method parameters (POJO dev mode)
  *      interface method:
  *        int add(int x, int y)
  *      swagger parameters:


### PR DESCRIPTION
refactor(loadbalance): Modify load balancing configuration and naming

- Fix typos in Configuration file
-Rename RuleNameExtentionsFactory to RuleNameExtensionsFactory
- Update references in relevant test files
- Added Verticle as an allowed word in .typos.toml
- Fixed typo in AbstractArgumentsMapperCreator file
- Fixed typo in FaultInjectionUtil file