### PR TITLE
Fixed flaky tests in ExceptionsTest.java with ObjectMapper

### DIFF
--- a/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java
+++ b/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java
@@ -20,6 +20,7 @@ package org.apache.servicecomb.core.exception;
 import static jakarta.ws.rs.core.Response.Status.BAD_REQUEST;
 import static jakarta.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static org.assertj.core.api.Assertions.assertThat;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Collections;
 
@@ -51,8 +52,15 @@ class ExceptionsTest {
     assertThat(invocationException).hasCause(exception);
     assertThat(invocationException.getStatus()).isEqualTo(BAD_REQUEST);
     assertThat(invocationException.getErrorData()).isInstanceOf(CommonExceptionData.class);
-    assertThat(Json.encode(invocationException.getErrorData()))
-        .isEqualTo("{\"code\":\"SCB.00000000\",\"message\":\"Unexpected exception when processing none. msg\"}");
+    
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    try {
+      assertThat(objectMapper.readTree(Json.encode(invocationException.getErrorData())))
+          .isEqualTo(objectMapper.readTree("{\"code\":\"SCB.00000000\",\"message\":\"Unexpected exception when processing none. msg\"}"));
+    } catch (Exception e) {
+      throw new AssertionError("Error during JSON comparison: " + e.getMessage(), e);
+    }
   }
 
   @Test
@@ -64,8 +72,15 @@ class ExceptionsTest {
     assertThat(invocationException).hasCause(exception);
     assertThat(invocationException.getStatus()).isEqualTo(INTERNAL_SERVER_ERROR);
     assertThat(invocationException.getErrorData()).isInstanceOf(CommonExceptionData.class);
-    assertThat(Json.encode(invocationException.getErrorData()))
-        .isEqualTo("{\"code\":\"SCB.50000000\",\"message\":\"Unexpected exception when processing none. msg\"}");
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    try {
+      assertThat(objectMapper.readTree(Json.encode(invocationException.getErrorData())))
+          .isEqualTo(objectMapper.readTree("{\"code\":\"SCB.50000000\",\"message\":\"Unexpected exception when processing none. msg\"}"));
+    } catch (Exception e) {
+      throw new AssertionError("Error during JSON comparison: " + e.getMessage(), e);
+    }
   }
 
   static class ThrowExceptionWhenConvert implements ExceptionConverter<Throwable> {

--- a/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java
+++ b/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java
@@ -52,7 +52,7 @@ class ExceptionsTest {
     assertThat(invocationException).hasCause(exception);
     assertThat(invocationException.getStatus()).isEqualTo(BAD_REQUEST);
     assertThat(invocationException.getErrorData()).isInstanceOf(CommonExceptionData.class);
-    
+
     ObjectMapper objectMapper = new ObjectMapper();
 
     try {

--- a/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java
+++ b/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java
@@ -35,6 +35,9 @@ import io.vertx.core.json.Json;
 import jakarta.ws.rs.core.Response.StatusType;
 
 class ExceptionsTest {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
   @Test
   void should_not_convert_invocation_exception() {
     InvocationException exception = Exceptions.genericConsumer("msg");
@@ -53,8 +56,6 @@ class ExceptionsTest {
     assertThat(invocationException.getStatus()).isEqualTo(BAD_REQUEST);
     assertThat(invocationException.getErrorData()).isInstanceOf(CommonExceptionData.class);
 
-    ObjectMapper objectMapper = new ObjectMapper();
-
     try {
       assertThat(objectMapper.readTree(Json.encode(invocationException.getErrorData())))
           .isEqualTo(objectMapper.readTree("{\"code\":\"SCB.00000000\",\"message\":\"Unexpected exception when processing none. msg\"}"));
@@ -72,8 +73,6 @@ class ExceptionsTest {
     assertThat(invocationException).hasCause(exception);
     assertThat(invocationException.getStatus()).isEqualTo(INTERNAL_SERVER_ERROR);
     assertThat(invocationException.getErrorData()).isInstanceOf(CommonExceptionData.class);
-
-    ObjectMapper objectMapper = new ObjectMapper();
 
     try {
       assertThat(objectMapper.readTree(Json.encode(invocationException.getErrorData())))


### PR DESCRIPTION
Hello, I apologize for not creating and linking a JIRA issue for this PR yet, though I did request for a JIRA account on the self-serve page if needed. This PR is fairly trivial though and does not change much code. 

### Purpose of this PR
This PR fixes the flaky tests:
* [`org.apache.servicecomb.core.exception.ExceptionsTest.should_convert_unknown_client_exception_to_invocation_exception`](https://github.com/apache/servicecomb-java-chassis/blob/fc7c01668fbb992e015458a86bc4366a00dc5878/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java#L46)
* [`org.apache.servicecomb.core.exception.ExceptionsTest.should_convert_unknown_server_exception_to_invocation_exception`](https://github.com/apache/servicecomb-java-chassis/blob/fc7c01668fbb992e015458a86bc4366a00dc5878/core/src/test/java/org/apache/servicecomb/core/exception/ExceptionsTest.java#L59)

The mentioned tests may non-deterministically pass or fail without changes made to the source code when it is run in different JVMs due to the inherent unordered nature of JSON properties in the JSON strings during comparison. The tests expect: 

* `"{\"code\":\"SCB.00000000\",\"message\":\"Unexpected exception when processing none. msg\"}"`
* `"{\"code\":\"SCB.50000000\",\"message\":\"Unexpected exception when processing none. msg\"}"`

But `Json.encode(invocationException.getErrorData())` will sometimes return: 

* `"{\"message\":\"Unexpected exception when processing none. msg\",\"code\":\"SCB.00000000\"}"`
* `"{\"message\":\"Unexpected exception when processing none. msg\",\"code\":\"SCB.50000000\"}"`

### Steps to Reproduce

This change was confirmed by running the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which explores and reports errors in different behaviors of under-determined Java APIs.
```
# Compile the module in project directory
mvn clean install -pl core -am -DskipTests

# Run the unit tests using NonDex
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl core -Dtest=org.apache.servicecomb.core.exception.ExceptionsTest#should_convert_unknown_client_exception_to_invocation_exception \
mvn edu.illinois:nondex-maven-plugin:2.1.7:nondex -pl core -Dtest=org.apache.servicecomb.core.exception.ExceptionsTest#should_convert_unknown_server_exception_to_invocation_exception
```
* Following the above steps for the mentioned tests will produce the following results for those runs, respectively:
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ExceptionsTest.should_convert_unknown_client_exception_to_invocation_exception:55 
expected: "{"code":"SCB.00000000","message":"Unexpected exception when processing none. msg"}"
 but was: "{"message":"Unexpected exception when processing none. msg","code":"SCB.00000000"}"
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```
```
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   ExceptionsTest.should_convert_unknown_server_exception_to_invocation_exception:68 
expected: "{"code":"SCB.50000000","message":"Unexpected exception when processing none. msg"}"
 but was: "{"message":"Unexpected exception when processing none. msg","code":"SCB.50000000"}"
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```

### Fix
* I propose to use an ObjectMapper to convert the JSON strings into JsonNode trees which can be compared for equality regardless of the order. 
* After the fix, I was able to get both test cases to pass on NonDex: 

![image](https://github.com/user-attachments/assets/ebda66c0-7fa4-4bbe-bae5-267e34d26978)


Please let me know if there are any changes you would like me to make. 




