### PR TITLE
[SCB-2895]The findServices method returns data errors

### DIFF
--- a/service-registry/registry-consul/src/main/java/org/apache/servicecomb/registry/consul/ConsulDiscovery.java
+++ b/service-registry/registry-consul/src/main/java/org/apache/servicecomb/registry/consul/ConsulDiscovery.java
@@ -84,8 +84,11 @@ public class ConsulDiscovery implements Discovery<ConsulDiscoveryInstance> {
   @Override
   public List<String> findServices(String application) {
     LOGGER.info("ConsulDiscovery findServices(application={})", application);
-    Map<String, Service> services = consulClient.agentClient().getServices();
-    return Lists.newArrayList(services.keySet());
+    Map<String, List<String>> response = consulClient.catalogClient().getServices().getResponse();
+    if (!CollectionUtils.isEmpty(response)) {
+      return Lists.newArrayList(response.keySet());
+    }
+    return Lists.newArrayList();
   }
 
   @Override


### PR DESCRIPTION
The findServices should return a list of service names, but it actually returns a list of service IDs
