### PR TITLE
[#4716]Fix load balance rule may not properly handle integer overflow

### DIFF
--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RandomRuleExt.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RandomRuleExt.java
@@ -28,7 +28,7 @@ import org.apache.servicecomb.core.Invocation;
 public class RandomRuleExt implements RuleExt {
   @Override
   public ServiceCombServer choose(List<ServiceCombServer> servers, Invocation invocation) {
-    if (servers == null || servers.isEmpty()) {
+    if (servers.isEmpty()) {
       return null;
     }
     int index = ThreadLocalRandom.current().nextInt(servers.size());

--- a/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RandomRuleExt.java
+++ b/handlers/handler-loadbalance/src/main/java/org/apache/servicecomb/loadbalance/RandomRuleExt.java
@@ -28,10 +28,10 @@ import org.apache.servicecomb.core.Invocation;
 public class RandomRuleExt implements RuleExt {
   @Override
   public ServiceCombServer choose(List<ServiceCombServer> servers, Invocation invocation) {
-    if (servers.isEmpty()) {
+    if (servers == null || servers.isEmpty()) {
       return null;
     }
-    int index = Math.abs(ThreadLocalRandom.current().nextInt()) % servers.size();
+    int index = ThreadLocalRandom.current().nextInt(servers.size());
     return servers.get(index);
   }
 }


### PR DESCRIPTION
-增加对 servers 列表的空值检查，避免空指针异常
- 使用 ThreadLocalRandom.current().nextInt(servers.size()) 替代 Math.abs(ThreadLocalRandom.current().nextInt()) % servers.size() 生成随机索引，提高性能
