### PR TITLE
[#4717]Bump vertx from 4.5.12 to 4.5.13

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -88,7 +88,7 @@
     <snakeyaml.version>2.3</snakeyaml.version>
     <spring.version>6.1.10</spring.version>
     <swagger.version>2.2.28</swagger.version>
-    <vertx.version>4.5.12</vertx.version>
+    <vertx.version>4.5.13</vertx.version>
     <zipkin.version>3.4.4</zipkin.version>
     <zipkin-reporter.version>3.4.0</zipkin-reporter.version>
     <jetcd-core.version>0.8.4</jetcd-core.version>


### PR DESCRIPTION
- 将 vertx 版本从 4.5.12 升级到4.5.13
- 此次升级可能包含安全性更新和 bug 修复
