### PR TITLE
[#4722] Fix bug in `ProviderAuthFilter` where `requestPath` not absolute problem

### DIFF
--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/RestOperationMeta.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/definition/RestOperationMeta.java
@@ -102,7 +102,7 @@ public class RestOperationMeta {
       }
     }
 
-    setAbsolutePath(concatPath(SwaggerUtils.getBasePath(swagger), operationMeta.getOperationPath()));
+    setAbsolutePath(SwaggerUtils.concatAbsolutePath(swagger, operationMeta.getOperationPath()));
   }
 
   private void addRestParamByName(OperationMeta operationMeta, String name, Operation operation) {
@@ -166,21 +166,6 @@ public class RestOperationMeta {
 
   public void setOperationMeta(OperationMeta operationMeta) {
     this.operationMeta = operationMeta;
-  }
-
-  /**
-   * Concat the two paths to an absolute path, end of '/' added.
-   *
-   * e.g. "/" + "/ope" = /ope/
-   * e.g. "/prefix" + "/ope" = /prefix/ope/
-   */
-  private String concatPath(String basePath, String operationPath) {
-    return ("/" + nonNullify(basePath) + "/" + nonNullify(operationPath))
-        .replaceAll("/{2,}", "/");
-  }
-
-  private String nonNullify(String path) {
-    return path == null ? "" : path;
   }
 
   public String getAbsolutePath() {

--- a/core/src/main/java/org/apache/servicecomb/core/governance/MatchType.java
+++ b/core/src/main/java/org/apache/servicecomb/core/governance/MatchType.java
@@ -36,7 +36,7 @@ public final class MatchType {
     public String apiPath() {
       if (MatchType.REST.equalsIgnoreCase(invocation.getOperationMeta().getConfig().getGovernanceMatchType())) {
         if (!invocation.isProducer()) {
-          return concatAbsolutePath(SwaggerUtils.getBasePath(invocation.getSchemaMeta().getSwagger()),
+          return SwaggerUtils.concatAbsolutePath(invocation.getSchemaMeta().getSwagger(),
               invocation.getOperationMeta().getOperationPath());
         }
         // not highway
@@ -113,20 +113,5 @@ public final class MatchType {
 
   public static GovernanceRequestExtractor createGovHttpRequest(Invocation invocation) {
     return new GovernanceRequestExtractorImpl(invocation);
-  }
-
-  /**
-   * Concat the two paths to an absolute path, without end of '/'.
-   *
-   * e.g. "/" + "/ope" = /ope
-   * e.g. "/prefix" + "/ope" = /prefix/ope
-   */
-  private static String concatAbsolutePath(String basePath, String operationPath) {
-    return ("/" + nonNullify(basePath) + "/" + nonNullify(operationPath))
-        .replaceAll("/{2,}", "/");
-  }
-
-  private static String nonNullify(String path) {
-    return path == null ? "" : path;
   }
 }

--- a/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/provider/ProviderAuthFilter.java
+++ b/handlers/handler-publickey-auth/src/main/java/org/apache/servicecomb/authentication/provider/ProviderAuthFilter.java
@@ -24,6 +24,7 @@ import org.apache.servicecomb.core.filter.AbstractFilter;
 import org.apache.servicecomb.core.filter.Filter;
 import org.apache.servicecomb.core.filter.FilterNode;
 import org.apache.servicecomb.core.filter.ProviderFilter;
+import org.apache.servicecomb.swagger.SwaggerUtils;
 import org.apache.servicecomb.swagger.invocation.Response;
 import org.apache.servicecomb.swagger.invocation.exception.InvocationException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,7 +55,9 @@ public class ProviderAuthFilter extends AbstractFilter implements ProviderFilter
 
   @Override
   public CompletableFuture<Response> onFilter(Invocation invocation, FilterNode nextNode) {
-    if (PathCheckUtils.isNotRequiredAuth(invocation.getOperationMeta().getOperationPath(), env)) {
+    String requestFullPath = SwaggerUtils.concatAbsolutePath(invocation.getSchemaMeta().getSwagger(),
+            invocation.getOperationMeta().getOperationPath());
+    if (PathCheckUtils.isNotRequiredAuth(requestFullPath, env)) {
       return nextNode.onFilter(invocation);
     }
     String token = invocation.getContext(CoreConst.AUTH_TOKEN);

--- a/handlers/handler-publickey-auth/src/test/java/org/apache/servicecomb/authentication/provider/TestPathCheckUtils.java
+++ b/handlers/handler-publickey-auth/src/test/java/org/apache/servicecomb/authentication/provider/TestPathCheckUtils.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.servicecomb.authentication.provider;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.when;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.servers.Server;
+import org.apache.servicecomb.swagger.SwaggerUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.core.env.Environment;
+
+import java.util.ArrayList;
+
+public class TestPathCheckUtils {
+  private Environment environment;
+
+  private OpenAPI swagger;
+
+  @BeforeEach
+  public void setUp() {
+    environment = Mockito.mock(Environment.class);
+    swagger = new OpenAPI();
+    swagger.setServers(new ArrayList<>());
+    swagger.getServers().add(new Server().url("/api/v1"));
+  }
+
+  @Test
+  public void testExcludePathWithBasePathAndExactMatch() {
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("/api/v1/public");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment), 
+        "Should not require auth for excluded path with exact match");
+  }
+
+  @Test
+  public void testExcludePathWithBasePathAndWildcard() {
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("/api/v1/public/*");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public/test");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth for excluded path with wildcard");
+
+    fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public/nested/path");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth for excluded nested path with wildcard");
+  }
+
+  @Test
+  public void testIncludePathWithBasePath() {
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("");
+    when(environment.getProperty("servicecomb.publicKey.accessControl.includePathPatterns", ""))
+        .thenReturn("/api/v1/private/*");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/private/resource");
+    assertFalse(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should require auth for included path");
+
+    fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public/resource");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth for non-included path");
+  }
+
+  @Test
+  public void testExcludeOverrideIncludePath() {
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("/api/v1/resource");
+    when(environment.getProperty("servicecomb.publicKey.accessControl.includePathPatterns", ""))
+        .thenReturn("/api/v1/*");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/resource");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Exclude patterns should override include patterns");
+  }
+
+  @Test
+  public void testMultipleExcludePaths() {
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("/api/v1/public,/api/v1/health,/api/v1/metrics/*");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth for first exclude path");
+
+    fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/health");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth for second exclude path");
+
+    fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/metrics/jvm");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth for wildcard exclude path");
+  }
+
+  @Test
+  public void testDifferentBasePath() {
+    swagger.getServers().clear();
+    swagger.getServers().add(new Server().url("/different/base"));
+
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("/different/base/public");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth with different base path");
+
+    fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/private");
+    assertFalse(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should require auth for non-excluded path with different base path");
+  }
+
+  @Test
+  public void testNoBasePath() {
+    swagger.setServers(null);
+
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("/public");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public");
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should not require auth when no base path is set");
+  }
+
+  @Test
+  public void testEmptyConfiguration() {
+    when(environment.getProperty("servicecomb.publicKey.accessControl.excludePathPatterns", ""))
+        .thenReturn("");
+    when(environment.getProperty("servicecomb.publicKey.accessControl.includePathPatterns", ""))
+        .thenReturn("");
+
+    String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/any/path");
+    assertFalse(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
+        "Should require auth by default when no patterns are configured");
+  }
+}

--- a/handlers/handler-publickey-auth/src/test/java/org/apache/servicecomb/authentication/provider/TestPathCheckUtils.java
+++ b/handlers/handler-publickey-auth/src/test/java/org/apache/servicecomb/authentication/provider/TestPathCheckUtils.java
@@ -49,7 +49,7 @@ public class TestPathCheckUtils {
         .thenReturn("/api/v1/public");
 
     String fullPath = SwaggerUtils.concatAbsolutePath(swagger, "/public");
-    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment), 
+    assertTrue(PathCheckUtils.isNotRequiredAuth(fullPath, environment),
         "Should not require auth for excluded path with exact match");
   }
 

--- a/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/SwaggerUtils.java
+++ b/swagger/swagger-generator/generator-core/src/main/java/org/apache/servicecomb/swagger/SwaggerUtils.java
@@ -445,4 +445,24 @@ public final class SwaggerUtils {
       default -> false;
     };
   }
+
+  public static String concatAbsolutePath(OpenAPI swagger, String operationPath) {
+    String basePath = getBasePath(swagger);
+    return concatPath(basePath, operationPath);
+  }
+
+  /**
+   * Concat the two paths to an absolute path, without end of '/'.
+   * <p>
+   * e.g. "/" + "/ope" = /ope
+   * e.g. "/prefix" + "/ope" = /prefix/ope
+   */
+  public static String concatPath(String basePath, String operationPath) {
+    return ("/" + nonNullify(basePath) + "/" + nonNullify(operationPath))
+            .replaceAll("/{2,}", "/");
+  }
+
+  private static String nonNullify(String path) {
+    return path == null ? "" : path;
+  }
 }


### PR DESCRIPTION
1. Fix problem that `ProviderAuthFilter` not use absolute path.
2. Same logic has come up twice, move it to `SwaggerUtils`.
3. Add tests for `excludePathPatterns`/`includePathPatterns` feature in`handler-publickey-auth`

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [X] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [X] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
