### PR TITLE
[#4806] Fix the bug that the SC address is configured for automatic discovery but cannot be automatically refreshed

### DIFF
--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/registry/sc/SCAddressManager.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/registry/sc/SCAddressManager.java
@@ -63,7 +63,7 @@ public class SCAddressManager {
     this.configurationProperties = configurationProperties;
     this.serviceCenterClient = serviceCenterClient;
     this.scRegistration = scRegistration;
-    EventManager.getEventBus().register(this);
+    scRegistration.getEventBus().register(this);
   }
 
   @Subscribe

--- a/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/registry/sc/SCRegistration.java
+++ b/service-registry/registry-service-center/src/main/java/org/apache/servicecomb/registry/sc/SCRegistration.java
@@ -194,4 +194,8 @@ public class SCRegistration implements Registration<SCRegistrationInstance> {
   public MicroserviceInstance getBackendMicroserviceInstance() {
     return microserviceInstance;
   }
+
+  EventBus getEventBus() {
+    return eventBus;
+  }
 }


### PR DESCRIPTION
Subscribing to the `HeartBeatEvent` and publishing the `HeartBeatEvent` are handled by two different event buses. Therefore, the `SCAddressManager` will never receive the `HeartBeatEvent`. As a result, even if `servicecomb.registry.sc.autodiscovery: true` is configured, the system will not automatically refresh the SC address.

Fixes #4806 

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
