### PR TITLE
[#4946] Change TestInvocationPublishModelFactory to deterministic implementation

### DIFF
--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestInvocationPublishModelFactory.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestInvocationPublishModelFactory.java
@@ -30,7 +30,6 @@ import org.apache.servicecomb.metrics.core.InvocationMetersInitializer;
 import org.apache.servicecomb.metrics.core.publish.model.DefaultPublishModel;
 import org.apache.servicecomb.swagger.invocation.InvocationType;
 import org.apache.servicecomb.swagger.invocation.Response;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.core.env.Environment;
@@ -40,6 +39,8 @@ import com.google.common.eventbus.EventBus;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.vertx.core.json.Json;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 public class TestInvocationPublishModelFactory {
   EventBus eventBus = new EventBus();
@@ -60,7 +61,7 @@ public class TestInvocationPublishModelFactory {
   Environment environment = Mockito.mock(Environment.class);
 
   @Test
-  public void createDefaultPublishModel() {
+  public void createDefaultPublishModel() throws Exception {
     Mockito.when(environment.getProperty(METRICS_WINDOW_TIME, int.class, DEFAULT_METRICS_WINDOW_TIME))
         .thenReturn(DEFAULT_METRICS_WINDOW_TIME);
     Mockito.when(environment.getProperty(
@@ -170,8 +171,8 @@ public class TestInvocationPublishModelFactory {
             }
           }
         """;
-    Assertions.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
-        Json.encodePrettily(model.getConsumer()));
+    JSONAssert.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
+        Json.encodePrettily(model.getConsumer()), false);
 
     expect = """
         {
@@ -269,8 +270,8 @@ public class TestInvocationPublishModelFactory {
           }
         }
         """;
-    Assertions.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
-        Json.encodePrettily(model.getProducer()));
+    JSONAssert.assertEquals(Json.encodePrettily(Json.decodeValue(expect, Object.class)),
+        Json.encodePrettily(model.getProducer()), false);
   }
 
   protected void prepareInvocation() {


### PR DESCRIPTION
**Issue:** The method `createDefaultPublishModel()` in `TestInvocationPublishModelFactory` compares JSONs to verify that the default object is properly created. However, since JSONs are unordered collections, when converted to strings the parameter order may not be preserved. This test uses a hard-coded JSON string as the expected correct value, but the test could fail if the parameters from the test object are stringified in a different order than the expected string. For another example of this issue being addressed, see this [previous merged PR](https://github.com/apache/servicecomb-java-chassis/pull/4633).

This test was flagged via the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which detects potentially unreliable tests due to underlying Java API assumptions. To see the Nondex output for this test, you can run:

```
mvn -pl metrics/metrics-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="org.apache.servicecomb.metrics.core.publish.TestInvocationPublishModelFactory#createDefaultPublishModel"
```

**Fix:** The fix I implemented uses [JSONAssert's](https://jsonassert.skyscreamer.org/apidocs/org/skyscreamer/jsonassert/JSONAssert.html) `assertEquals()` method, using non-strict checking (which ignores parameter ordering). This compares the JSON strings without enforcing parameter ordering, which removes the potentially unreliable nature of these tests. **This library is already included within the spring-boot dependency, which is already used in the project, so there's no need to update the pom file.** Rerunning Nondex shows a passing result.

I believe this is the simplest fix, but it seems someone else has already fixed a similar test in a different way: https://github.com/apache/servicecomb-java-chassis/pull/4633 using JsonNode trees. If it's better to keep code consistency, I can also implement the same methodology here.

One additional change I had to make was to add the `throws Exception` clause onto the test method signature since `JSONAssert.assertEquals()` can throw a `JSONException`. Please let me know if this is an issue; this clause already exists in the same method in `TestThreadPoolPublishModelFactory` within the same module metrics/metrics-core, and the integration tests from `mvn clean install -Pit` pass.

**PR Checklist:**
 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes. (I created a Github Issue instead since I noticed that the JIRA seems to be inactive)
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.

---
