### PR TITLE
Change TestThreadPoolPublishModelFactory to deterministic implementation

### DIFF
--- a/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestThreadPoolPublishModelFactory.java
+++ b/metrics/metrics-core/src/test/java/org/apache/servicecomb/metrics/core/publish/TestThreadPoolPublishModelFactory.java
@@ -24,7 +24,6 @@ import org.apache.servicecomb.foundation.common.utils.JsonUtils;
 import org.apache.servicecomb.foundation.metrics.MetricsBootstrapConfig;
 import org.apache.servicecomb.metrics.core.ThreadPoolMetersInitializer;
 import org.apache.servicecomb.metrics.core.publish.model.DefaultPublishModel;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -35,6 +34,8 @@ import org.mockito.Mockito;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.skyscreamer.jsonassert.JSONAssert;
 
 @ExtendWith(MockitoExtension.class)
 @TestMethodOrder(MethodOrderer.MethodName.class)
@@ -61,9 +62,9 @@ public class TestThreadPoolPublishModelFactory {
     PublishModelFactory factory = new PublishModelFactory(registry.getMeters());
     DefaultPublishModel model = factory.createDefaultPublishModel();
 
-    Assertions.assertEquals(
+    JSONAssert.assertEquals(
         """
             {"test":{"avgTaskCount":0.0,"avgCompletedTaskCount":0.0,"currentThreadsBusy":0,"maxThreads":0,"poolSize":0,"corePoolSize":0,"queueSize":10,"rejected":0.0}}""",
-        JsonUtils.writeValueAsString(model.getThreadPools()));
+        JsonUtils.writeValueAsString(model.getThreadPools()), false);
   }
 }


### PR DESCRIPTION
**Issue:** This is the same issue as #4946 for a different class, since there is also a JSON string comparison here. In summary, since JSONs are unordered, after converting them to strings, the parameter ordering is not guaranteed. For another example of this issue being addressed, see this [previous merged PR](https://github.com/apache/servicecomb-java-chassis/pull/4633).

This test was flagged via the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which detects potentially unreliable tests due to underlying Java API assumptions. To see the Nondex output for this test, you can run:

```
mvn -pl metrics/metrics-core edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="org.apache.servicecomb.metrics.core.publish.TestThreadPoolPublishModelFactory#createDefaultPublishModel"
```

**Fix:** The fix here is also similar to the one I detailed in this PR for the other issue: #4947. I use [JSONAssert's](https://jsonassert.skyscreamer.org/apidocs/org/skyscreamer/jsonassert/JSONAssert.html) `assertEquals()` method, using non-strict checking (which ignores parameter ordering). This compares the JSON strings without enforcing parameter ordering, which removes the potentially unreliable nature of these tests. **This library is already included within the spring-boot dependency, which is already used in the project, so there's no need to update the pom file.** Rerunning Nondex shows a passing result.

**PR Checklist:**
 - [ ] Github Issue: #4968 
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.

---
