### PR TITLE
[#4970] Change MessageTest unit tests to deterministic implementation

### DIFF
--- a/service-registry/registry-lightweight/src/test/java/org/apache/servicecomb/registry/lightweight/MessageTest.java
+++ b/service-registry/registry-lightweight/src/test/java/org/apache/servicecomb/registry/lightweight/MessageTest.java
@@ -18,10 +18,12 @@
 package org.apache.servicecomb.registry.lightweight;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.Json;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 class MessageTest {
   private String toLinuxPrettyJson(Object value) {
@@ -33,7 +35,8 @@ class MessageTest {
   void should_encode_register_type() {
     Message<RegisterRequest> msg = Message.of(MessageType.REGISTER, new RegisterRequest());
 
-    assertThat(toLinuxPrettyJson(msg)).isEqualTo(""
+    try {
+      JSONAssert.assertEquals(toLinuxPrettyJson(msg), ""
         + "{\n"
         + "  \"type\" : \"REGISTER\",\n"
         + "  \"body\" : {\n"
@@ -45,7 +48,11 @@ class MessageTest {
         + "    \"status\" : null,\n"
         + "    \"endpoints\" : null\n"
         + "  }\n"
-        + "}");
+        + "}", false);
+    } catch (Exception e) {
+      fail("Failed to compare JSONs: " + e.getMessage(), e);
+    }
+
   }
 
   @Test
@@ -60,14 +67,18 @@ class MessageTest {
   void should_encode_unregister_type() {
     Message<UnregisterRequest> msg = Message.of(MessageType.UNREGISTER, new UnregisterRequest());
 
-    assertThat(toLinuxPrettyJson(msg)).isEqualTo(""
+    try {
+      JSONAssert.assertEquals(toLinuxPrettyJson(msg), ""
         + "{\n"
         + "  \"type\" : \"UNREGISTER\",\n"
         + "  \"body\" : {\n"
         + "    \"serviceId\" : null,\n"
         + "    \"instanceId\" : null\n"
         + "  }\n"
-        + "}");
+        + "}", false);
+    } catch (Exception e) {
+      fail("Failed to compare JSONs: " + e.getMessage(), e);
+    }
   }
 
   @Test


### PR DESCRIPTION
**Issue:** This is the same issue as #4946 involving JSON comparisons. Here it's happening in both the `should_encode_register_type` and `should_encode_unregister_type` unit tests. In summary, since JSONs are unordered, after converting them to strings, the parameter ordering is not guaranteed, which can lead to the tests failing occasionally. For another example of this issue being addressed, see this [previous merged PR](https://github.com/apache/servicecomb-java-chassis/pull/4633).

These two tests were flagged via the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool, which detects potentially unreliable tests due to underlying Java API assumptions. To see the Nondex output for the test class `MessageTest`, you can run:

```
mvn -pl service-registry/registry-lightweight edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest="org.apache.servicecomb.registry.lightweight.MessageTest"
```

**Fix:** The fix here is also similar to the one I detailed in this PR for the other issue: #4947. I use [JSONAssert's](https://jsonassert.skyscreamer.org/apidocs/org/skyscreamer/jsonassert/JSONAssert.html) `assertEquals()` method, using non-strict checking (which ignores parameter ordering). This compares the JSON strings without enforcing parameter ordering, which removes the potentially unreliable nature of these tests. **This library is already included within the spring-boot dependency, which is already used in the project, so there's no need to update the pom file.** Rerunning Nondex shows a passing result.

Since `JSONAssert.assertEquals` can throw a `JsonException`, I wrap the code blocks in a try-catch, then using `Assertions.fail()` to fail the unit test if an exception occurs. I'm catching the generic `Exception` to handle all possible exceptions, but let me know if I should change this. I'm also using AssertJ for this since the existing assertions in the class use AssertJ, but I can switch to jUnit as well if that's better.

**PR Checklist:**
 - [x] Github Issue: #4970 
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
