### PR TITLE
[#4985] upgrade org.apache.tomcat.embed:tomcat-embed-core to 9.0.108

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -101,6 +101,7 @@
     <vertx.version>4.5.21</vertx.version>
     <zipkin.version>2.24.0</zipkin.version>
     <zipkin-reporter.version>2.16.3</zipkin-reporter.version>
+    <tomcat.version>9.0.108</tomcat.version>
     <!-- Base dir of main -->
     <main.basedir>${basedir}/../..</main.basedir>
   </properties>
@@ -772,6 +773,22 @@
         <groupId>org.java-websocket</groupId>
         <artifactId>Java-WebSocket</artifactId>
         <version>${java-websocket.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-core</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-el</artifactId>
+        <version>${tomcat.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat.embed</groupId>
+        <artifactId>tomcat-embed-websocket</artifactId>
+        <version>${tomcat.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Due to JDK version constraints, Spring Boot cannot be upgraded further. Therefore, tomcat-embed-core can only be upgraded to 9.0.108 to address the CVE-2025-48989 vulnerability.
Fixes: https://github.com/apache/servicecomb-java-chassis/issues/4985
Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
