### PR TITLE
Change unit test in HighwayServerCodecFilterTest to deterministic implementation

### DIFF
--- a/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/HighwayServerCodecFilterTest.java
+++ b/transports/transport-highway/src/test/java/org/apache/servicecomb/transport/highway/HighwayServerCodecFilterTest.java
@@ -45,6 +45,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.springframework.core.env.Environment;
 
 import io.vertx.core.MultiMap;
@@ -146,9 +147,10 @@ public class HighwayServerCodecFilterTest {
     Response response = codecFilter.onFilter(invocation, nextNode).get();
 
     assertThat(response.getStatus()).isEqualTo(INTERNAL_SERVER_ERROR);
-    assertThat(Json.encode(((InvocationException) response.getResult()).getErrorData()))
-        .isEqualTo("{\"code\":\"SCB.50000000\",\"message\":\"Unexpected "
-            + "exception when processing null. encode request failed\"}");
+
+    JSONAssert.assertEquals(Json.encode(((InvocationException) response.getResult()).getErrorData()),
+        "{\"code\":\"SCB.50000000\",\"message\":\"Unexpected "
+            + "exception when processing null. encode request failed\"}", false);
   }
 
   private void success_invocation() throws InterruptedException, ExecutionException {


### PR DESCRIPTION
**Issue:** See #4987.

**Fix:** The fix here is the same as previously merged PRs such as #4969 and #4971. I use [JSONAssert's](https://jsonassert.skyscreamer.org/apidocs/org/skyscreamer/jsonassert/JSONAssert.html) assertEquals() method, using non-strict checking (which ignores parameter ordering). This compares the JSON strings without enforcing parameter ordering, which removes the potentially unreliable nature of these tests. **This library is already included within in the project, so there's no need to update the pom file.** Rerunning Nondex shows a passing result.

**PR Checklist:**
 - [x] Github Issue: https://github.com/apache/servicecomb-java-chassis/issues/4987
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.

---

