### PR TITLE
Fix Flaky Test `CommonExceptionDataTest#should_include_code_in_json_when_code_is_not_null`

### DIFF
--- a/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/exception/CommonExceptionDataTest.java
+++ b/swagger/swagger-invocation/invocation-core/src/test/java/org/apache/servicecomb/swagger/invocation/exception/CommonExceptionDataTest.java
@@ -20,6 +20,8 @@ package org.apache.servicecomb.swagger.invocation.exception;
 import static com.google.common.collect.ImmutableMap.of;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 
 import io.vertx.core.json.Json;
@@ -36,7 +38,11 @@ class CommonExceptionDataTest {
   void should_include_code_in_json_when_code_is_not_null() {
     CommonExceptionData data = new CommonExceptionData("code", "msg");
 
-    assertThat(Json.encode(data)).isEqualTo("{\"code\":\"code\",\"message\":\"msg\"}");
+    String json = Json.encode(data);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> obj = Json.decodeValue(json, Map.class);
+
+    assertThat(obj).containsEntry("code", "code").containsEntry("message", "msg").hasSize(2);
   }
 
   @Test


### PR DESCRIPTION
### Issue
Test `CommonExceptionDataTest#should_include_code_in_json_when_code_is_not_null` is flaky. See #4991 

### Fix
This fix decodes the JSON and asserts the key–value pairs on a map, so the test checks semantic content instead of exact string formatting or key order. It keeps the original goal of verifying that both "code" and "message" fields have the correct values, while removing flakiness caused by unpredictable key ordering during JSON serialization.

### Checklist
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

