### PR TITLE
[#4993] Change TestMeasurementGroupConfig.addGroup to deterministic implementation

### DIFF
--- a/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/spectator/TestMeasurementGroupConfig.java
+++ b/foundations/foundation-metrics/src/test/java/org/apache/servicecomb/foundation/metrics/publish/spectator/TestMeasurementGroupConfig.java
@@ -53,7 +53,7 @@ public class TestMeasurementGroupConfig {
     config.addGroup("id1", "tag1.1", "tag1.2");
     config.addGroup("id2", "tag2.1", "tag2.2");
 
-    MatcherAssert.assertThat(groups.keySet(), Matchers.contains("id2", "id1"));
+    MatcherAssert.assertThat(groups.keySet(), Matchers.containsInAnyOrder("id2", "id1"));
     MatcherAssert.assertThat(groups.get("id1").stream().map(TagFinder::getTagKey).toArray(), Matchers.arrayContaining("tag1.1", "tag1.2"));
     MatcherAssert.assertThat(groups.get("id2").stream().map(TagFinder::getTagKey).toArray(), Matchers.arrayContaining("tag2.1", "tag2.2"));
   }


### PR DESCRIPTION
**Issue**: See #4993. To summarize, since the `groups` HashMap is unordered, using `Matchers.contains`, which does strict order checking, can result in a test failure since the key iteration order isn't guaranteed.

**Fix:** I simply replace `Matchers.contains` with [`Matchers.containsInAnyOrder`](https://hamcrest.org/JavaHamcrest/javadoc/1.3/org/hamcrest/Matchers.html#containsInAnyOrder(T...)), since it doesn't do strict order checking. 

**PR Checklist:**
 - [x] Github Issue: https://github.com/apache/servicecomb-java-chassis/issues/4993
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
