### PR TITLE
[#5017] Fix `swagger/swagger-generator/generator-core` OD tests

### DIFF
--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestApiResponse.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestApiResponse.java
@@ -19,10 +19,11 @@ package org.apache.servicecomb.swagger.generator.core;
 
 import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperation;
 import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperations;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -31,15 +32,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.ws.rs.core.MediaType;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestApiResponse {
+
   SwaggerOperations swaggerOperations;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() {
     swaggerOperations = SwaggerOperations.generate(ApiResponseAnnotation.class);
   }
 
-  @AfterEach
+  @AfterAll
   public void tearDown() {
     swaggerOperations = null;
   }

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestOperationGenerator.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/TestOperationGenerator.java
@@ -25,10 +25,11 @@ import java.util.List;
 import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperation;
 import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperations;
 import org.hamcrest.MatcherAssert;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.Operation;
@@ -40,15 +41,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class TestOperationGenerator {
   SwaggerOperations swaggerOperations;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() {
     swaggerOperations = SwaggerOperations.generate(TestClass.class);
   }
 
-  @AfterEach
+  @AfterAll
   public void tearDown() {
     swaggerOperations = null;
   }

--- a/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/processor/annotation/OperationMethodAnnotationProcessorTest.java
+++ b/swagger/swagger-generator/generator-core/src/test/java/org/apache/servicecomb/swagger/generator/core/processor/annotation/OperationMethodAnnotationProcessorTest.java
@@ -26,10 +26,11 @@ import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperation;
 import org.apache.servicecomb.swagger.generator.core.model.SwaggerOperations;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -42,15 +43,16 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.ws.rs.core.MediaType;
 
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class OperationMethodAnnotationProcessorTest {
   SwaggerOperations swaggerOperations;
 
-  @BeforeEach
+  @BeforeAll
   public void setUp() {
     swaggerOperations = SwaggerOperations.generate(TestClass.class);
   }
 
-  @AfterEach
+  @AfterAll
   public void tearDown() {
     swaggerOperations = null;
   }


### PR DESCRIPTION
### Issue
Several tests (`TestApiResponse`, `TestOperationGenerator`, and `OperationMethodAnnotationProcessorTest`) were identified as order-dependent (OD) flaky tests. See #5017 

### Fix
This PR transitions the test class to the JUnit 5 `@TestInstance(Lifecycle.PER_CLASS)` lifecycle, replacing the shared static field with an instance-scoped variable initialized in `@BeforeAll`. This resolves order-dependent flakiness by eliminating global state pollution, while ensuring that the resource-intensive Swagger generation runs only once per class. This approach balances test isolation with the performance efficiency required to hopefully prevent resource exhaustion and timeouts in the CI environment.


### Checklist
 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---

