### PR TITLE
[#5106] Bump org.springframework.boot:spring-boot-dependencies from 3.4.5 to 3.4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <site-maven-plugin.version>3.21.0</site-maven-plugin.version>
     <source-maven-plugin.version>3.3.0</source-maven-plugin.version>
     <spotbug-maven-plugin.version>4.9.3.0</spotbug-maven-plugin.version>
-    <spring-boot.version>3.4.5</spring-boot.version>
+    <spring-boot.version>3.4.9</spring-boot.version>
     <surefire-maven-plugin.version>3.5.3</surefire-maven-plugin.version>
     <!-- plugin version end -->
   </properties>


### PR DESCRIPTION
Bump org.springframework.boot:spring-boot-dependencies from 3.4.5 to 3.4.9
Fixes https://github.com/apache/servicecomb-java-chassis/issues/5106
