### PR TITLE
[#5106] Bump org.springframework.boot:spring-boot-dependencies from 3.4.5 to 3.4.13, io.vertx:vertx-dependencies from 4.5.15 to 4.5.24

### DIFF
--- a/dependencies/default/pom.xml
+++ b/dependencies/default/pom.xml
@@ -86,7 +86,7 @@
     <slf4j.version>1.7.36</slf4j.version>
     <snakeyaml.version>2.4</snakeyaml.version>
     <swagger.version>2.2.32</swagger.version>
-    <vertx.version>4.5.15</vertx.version>
+    <vertx.version>4.5.24</vertx.version>
     <zipkin.version>3.5.1</zipkin.version>
     <zipkin-reporter.version>3.4.0</zipkin-reporter.version>
     <jetcd-core.version>0.8.5</jetcd-core.version>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <site-maven-plugin.version>3.21.0</site-maven-plugin.version>
     <source-maven-plugin.version>3.3.0</source-maven-plugin.version>
     <spotbug-maven-plugin.version>4.9.3.0</spotbug-maven-plugin.version>
-    <spring-boot.version>3.4.5</spring-boot.version>
+    <spring-boot.version>3.4.13</spring-boot.version>
     <surefire-maven-plugin.version>3.5.3</surefire-maven-plugin.version>
     <!-- plugin version end -->
   </properties>


### PR DESCRIPTION
Bump org.springframework.boot:spring-boot-dependencies from 3.4.5 to 3.4.13
Fixes https://github.com/apache/servicecomb-java-chassis/issues/5106

bump io.vertx:vertx-dependencies from 4.5.15 to 4.5.24