### PR TITLE
Skip JSON serialization for String data in SSE event stream

### DIFF
--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceEventStreamProcessor.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceEventStreamProcessor.java
@@ -379,8 +379,10 @@ public class ProduceEventStreamProcessor implements ProduceProcessor {
       throw new Exception("sse response data is null!");
     }
     for (Object data : datas) {
+      String value = data instanceof String ? (String) data
+          : RestObjectMapperFactory.getRestObjectMapper().writeValueAsString(data);
       eventBuilder.append("data: ")
-          .append(RestObjectMapperFactory.getRestObjectMapper().writeValueAsString(data))
+          .append(value)
           .append("\n");
     }
   }


### PR DESCRIPTION
When SSE response data is already a String, avoid redundant JSON serialization that would wrap it in extra quotes.
