### PR TITLE
fix OOM problem when receive big response of SSE interface from backend

### DIFF
--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   checkstyle:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up jdk

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -29,7 +29,7 @@ jobs:
   build:
 
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/rat_check.yml
+++ b/.github/workflows/rat_check.yml
@@ -29,7 +29,7 @@ on:
 jobs:
   rat_check:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up jdk

--- a/.github/workflows/spotbugs.yml
+++ b/.github/workflows/spotbugs.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   spotbugs:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up jdk

--- a/.github/workflows/unit-test-jdk17.yml
+++ b/.github/workflows/unit-test-jdk17.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   unit-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up jdk

--- a/.github/workflows/unit-test-jdk21.yml
+++ b/.github/workflows/unit-test-jdk21.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   unit-tests:
     timeout-minutes: 60
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up jdk

--- a/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceEventStreamProcessor.java
+++ b/common/common-rest/src/main/java/org/apache/servicecomb/common/rest/codec/produce/ProduceEventStreamProcessor.java
@@ -325,6 +325,7 @@ public class ProduceEventStreamProcessor implements ProduceProcessor {
 
   private byte[] readALineOfBytesFromBuffer(ByteBuf buffer) {
     matchingDelimiterIndex = 0;
+    int newLineStartPos = buffer.readerIndex();
     try (final ByteArrayOutputStream bos = new ByteArrayOutputStream(buffer.readableBytes())) {
       while (buffer.readableBytes() > 0 && matchingDelimiterIndex < lineDelimiterBytes.length) {
         final byte b = buffer.readByte();
@@ -336,7 +337,7 @@ public class ProduceEventStreamProcessor implements ProduceProcessor {
       if (matchingDelimiterIndex < lineDelimiterBytes.length) {
         // The newline character was not matched, so this part of the buffer does not constitute a complete line of
         // content and needs to remain in the buffer, waiting for the next segment to arrive for processing.
-        buffer.writeBytes(bos.toByteArray());
+        buffer.readerIndex(newLineStartPos);
         return null;
       }
       matchingDelimiterIndex = 0;


### PR DESCRIPTION
已在github仓提issue，#5147

这个解决办法比较简单，也比较有效，我本地实测，这个buffer不会膨胀了，体积也不会那么容易超过region大小的一半，基本都分配在eden区了，可以通过younggc快速回收。

Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/SCB) filed for the change (usually before you start working on it).  Trivial changes like typos do not require a JIRA issue.  Your pull request should address just this issue, without pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [ ] Format the pull request title like `[SCB-XXX] Fixes bug in ApproximateQuantiles`, where you replace `SCB-XXX` with the appropriate JIRA issue.
 - [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [ ] Run `mvn clean install -Pit` to make sure basic checks pass. A more thorough check will be performed on your pull request automatically.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

---
