### PR TITLE
Fix excldue typo in apache-rat exclude patterns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,9 +236,9 @@
             <exclude>DISCLAIMER</exclude>
             <exclude>.travis.yml</exclude>
             <exclude>**/*.md</exclude>
-            <excldue>**/*.MD</excldue>
-            <excldue>**/*.iml</excldue>
-            <excldue>.github/**</excldue>
+            <exclude>**/*.MD</exclude>
+            <exclude>**/*.iml</exclude>
+            <exclude>.github/**</exclude>
             <!-- Skip the code style configuration file -->
             <exclude>**/etc/eclipse-java-google-style.xml</exclude>
             <exclude>**/etc/intellij-java-google-style.xml</exclude>


### PR DESCRIPTION
## What
Fixed `<excldue>` → `<exclude>` in the apache-rat plugin config.

Maven silently ignores unknown tags, so `**/*.MD` (and any other patterns under the misspelled tag) were never excluded from license checks.

## Why
Same class of bug as apache/shenyu#7028 / related rat typo reports. Small, safe pom-only fix.

## Test
Diff-only change to POM exclude tags; no runtime behavior change.